### PR TITLE
ci: publish docs on main push

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -2,8 +2,9 @@ name: Publish documentation
 
 on:
   push:
-    tags:
-      - "v*.*"
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build-documentation:


### PR DESCRIPTION
Docs currently rebuild only on `v*.*` release tags, so changes merged to `main` (like the new CONTRIBUTING page) stay invisible on the site until the next release.

This switches the trigger to **push on `main`** (+ manual `workflow_dispatch`), so docs go live as soon as they merge. Merging this PR will itself trigger a rebuild that publishes the CONTRIBUTING page.

Verified locally: `mkdocs build` succeeds and generates the Contributing page in the nav.