### PR TITLE
fix: correct mkdocstrings option typo

### DIFF
--- a/docs/docs/api_docs/api_extras.md
+++ b/docs/docs/api_docs/api_extras.md
@@ -1,11 +1,11 @@
 ## Models
 ### ::: effector.models
       options:
-        show_rooting_heading: True
+        show_root_heading: True
         show_symbol_type_toc: True
 
 ## Datasets
 ### ::: effector.datasets
       options:
-        show_rooting_heading: True
+        show_root_heading: True
         show_symbol_type_toc: True


### PR DESCRIPTION
The docs build broke on `main` with:

```
Invalid options: PythonOptions.__init__() got an unexpected keyword argument 'show_rooting_heading'
```

`api_extras.md` used `show_rooting_heading` (a typo) where every other API page uses `show_root_heading`. It only surfaced now because the docs workflow installs mkdocs deps unpinned — the last release pulled an older mkdocstrings-python that ignored the bad option; the current latter rejects it.

Verified by rebuilding locally against the **latest** mkdocstrings (1.18.2): build passes, no other errors.

Follow-up (separate PR): pin the docs dependencies so upstream changes can't silently break releases.