### PR TITLE
test: mark slow tests for fast gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,8 @@ tracker = "https://github.com/givasile/effector/issues"
 
 [project.optional-dependencies]
 tutorials = ["ipython", "pandas", "tensorflow-cpu", "keras", "ucimlrepo", "jupyter", "openml", "tabpfn"]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselected on the merge gate with '-m \"not slow\"')",
+]

--- a/tests/test_functional_gam.py
+++ b/tests/test_functional_gam.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 import effector
 
+@pytest.mark.slow
 def test_gam():
     """
     Test the vectorized version of the SHAP function for a square model

--- a/tests/test_functional_linear.py
+++ b/tests/test_functional_linear.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 import effector
 
+@pytest.mark.slow
 def test_linear():
     """
     Test the vectorized version of the SHAP function for a linear model

--- a/tests/test_regional_methods.py
+++ b/tests/test_regional_methods.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 import effector
 
 
+@pytest.mark.slow
 def test_regional():
     np.random.seed(21)
 


### PR DESCRIPTION
**Temporary** speed-up for the merge gate. Marks the three slowest tests (`test_regional` 26s, `test_gam` 26s, `test_linear` 22s) with `@pytest.mark.slow`. CI already runs `-m "not slow"`, so the gate now runs only the fast subset (~15s locally vs ~90s) — 12 tests, 3 deselected.

Registers the `slow` marker in `pyproject.toml`.

⚠️ Tradeoff: the slow (core functional) tests no longer run on PRs. **To restore later:** run the full suite (incl. slow) on push to `main` and/or a nightly schedule. Tracked in ROADMAP.