### PR TITLE
ci: deploy docs via ssh key

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -57,9 +57,8 @@ jobs:
       with:
           repository: xai-effector/xai-effector.github.io
           ref: gh-pages
-          token: ${{ secrets.EFFECTOR_GITHUB_API_KEY }}
+          ssh-key: ${{ secrets.EFFECTOR_DOCS_DEPLOY_KEY }}
           path: xai-effector.github.io
-          persist-credentials: false
 
     - name: rm old site and copy new site
       run: |
@@ -76,5 +75,5 @@ jobs:
               echo "No changes to commit"
               exit 0
           fi
-          git commit -m "Update site from ntipakos/effector"
-          git push --force https://x-access-token:${{ secrets.EFFECTOR_GITHUB_API_KEY }}@github.com/xai-effector/xai-effector.github.io.git gh-pages
+          git commit -m "Update site from givasile/effector"
+          git push --force origin gh-pages


### PR DESCRIPTION
Replaces the expired `EFFECTOR_GITHUB_API_KEY` PAT with a dedicated, non-expiring **SSH deploy key** for pushing the built site to `xai-effector/xai-effector.github.io`.

- Checkout uses `ssh-key: secrets.EFFECTOR_DOCS_DEPLOY_KEY` (persisted); push targets the SSH `origin`.
- Deploy key verified: authenticates as the repo, with read **and** write access.
- No token expiry to babysit going forward.

Merging this triggers a docs publish from `main` that should now fully succeed (build fixed in #9, deploy fixed here).