### PR TITLE
fix: pin docs build to python 3.10

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         cp CHANGELOG.md docs/docs/changelog.md
         cp CONTRIBUTING.md docs/docs/contributing.md
-        uv run --no-default-groups --group docs mkdocs build -f docs/mkdocs.yml
+        uv run --python 3.10 --no-default-groups --group docs mkdocs build -f docs/mkdocs.yml
 
     - name: Save site site as artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The uv docs build defaulted to the runner's Python 3.12, where the locked `numba`/`llvmlite` chain (pulled in via `shap`, which the API docs import) has no wheel and fails to build. Pinning the docs build to 3.10 (matching `run_tests.yml` and the currently-supported version) fixes it.

Follow-up: the upcoming test-matrix PR will need `numba`/`llvmlite` versions that support 3.11–3.13.