### PR TITLE
CI: modernize GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     name: Ruff lint & format check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ruff:
     name: Ruff lint & format check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    name: Ruff lint & format check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Run ruff check
+        run: uv run --python 3.10 --no-default-groups --group dev ruff check effector tests
+
+      - name: Run ruff format check
+        run: uv run --python 3.10 --no-default-groups --group dev ruff format --check effector tests

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -36,6 +37,7 @@ jobs:
 
   push-site:
     name: Copy site to effector.github.io
+    if: github.event_name != 'pull_request'
     needs:
     - build-documentation
 

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -19,18 +19,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
-
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
+          enable-cache: true
 
       - name: Build package
-        run: python -m build
+        run: uv build --python 3.10
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -75,3 +75,40 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract changelog section for this tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            BEGIN { found=0 }
+            /^#+ \[/ {
+              if (found) exit
+              if ($0 ~ "\\[" ver "\\]") { found=1; next }
+              next
+            }
+            found { print }
+          ' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "::error::No CHANGELOG.md section found for version $VERSION"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes-file release_notes.md

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -6,8 +6,44 @@ on:
       - "v*.*"
 
 jobs:
+  verify-tag-on-main:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tagged commit is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on main"
+            exit 1
+          fi
+
+  test:
+    name: Run tests
+    needs: verify-tag-on-main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Run tests
+        run: uv run --python 3.10 --no-default-groups --group test pytest tests -m "not slow"
+
   publish:
     name: Build & Publish to PyPI
+    needs: test
     runs-on: ubuntu-latest
 
     environment: pypi
@@ -26,6 +62,12 @@ jobs:
 
       - name: Build package
         run: uv build --python 3.10
+
+      - name: Smoke test built wheel
+        run: |
+          uv venv /tmp/smoke-env --python 3.10
+          uv pip install --python /tmp/smoke-env/bin/python dist/*.whl
+          /tmp/smoke-env/bin/python -c "import effector"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*"
 
+permissions:
+  contents: read
+
 jobs:
   verify-tag-on-main:
     name: Verify tag is on main
@@ -49,6 +52,7 @@ jobs:
     environment: pypi
 
     permissions:
+      contents: read
       id-token: write  # Needed for OpenID Connect authentication
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,6 +2,9 @@ name: Execute all tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests (Python ${{ matrix.python-version }})

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,8 +4,13 @@ on: [push, pull_request]
 
 jobs:
   run-tests:
-    name: Run tests
+    name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -16,9 +21,15 @@ jobs:
           enable-cache: true
 
       - name: Run tests with coverage
-        run: uv run --python 3.10 --no-default-groups --group test pytest --cov=effector --cov-report=xml tests -m "not slow"
+        if: matrix.python-version == '3.10'
+        run: uv run --python ${{ matrix.python-version }} --no-default-groups --group test pytest --cov=effector --cov-report=xml tests -m "not slow"
+
+      - name: Run tests
+        if: matrix.python-version != '3.10'
+        run: uv run --python ${{ matrix.python-version }} --no-default-groups --group test pytest tests -m "not slow"
 
       - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.10'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,6 +5,10 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: Run tests (Python ${{ matrix.python-version }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,8 @@ We use [uv](https://docs.astral.sh/uv/) to manage the environment. Install it on
 uv sync          # create .venv and install all dev dependencies
 make test        # run the fast test suite (the merge gate)
 make test-all    # run the full suite, including slow tests
-make format      # format the code (black)
+make format      # format the code (ruff)
+make lint        # lint the code (ruff)
 make docs-serve  # preview the docs locally
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ test-all:  ## run the full test suite, including slow tests
 
 # Code style ----------------------------------------------------------------
 .PHONY: format
-format:  ## format the source code with black
-	uv run --group dev black $(PROJECT_NAME)
+format:  ## format the source code with ruff
+	uv run --no-default-groups --group dev ruff format $(PROJECT_NAME) tests
+
+.PHONY: lint
+lint:  ## lint the source code with ruff
+	uv run --no-default-groups --group dev ruff check $(PROJECT_NAME) tests
 
 # Documentation -------------------------------------------------------------
 .PHONY: docs-serve

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![codecov](https://codecov.io/gh/givasile/effector/branch/main/graph/badge.svg)](https://codecov.io/gh/givasile/effector)
 ![Publish Documentation](https://github.com/givasile/effector/actions/workflows/publish_documentation.yml/badge.svg)
 [![PyPI Downloads](https://static.pepy.tech/badge/effector)](https://pepy.tech/projects/effector)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230.svg)](https://github.com/astral-sh/ruff)
 
 ---
 

--- a/effector/__init__.py
+++ b/effector/__init__.py
@@ -1,13 +1,7 @@
+from effector import axis_partitioning, datasets, models, space_partitioning
 from effector.global_effect_ale import ALE, RHALE
 from effector.global_effect_pdp import PDP, DerPDP
 from effector.global_effect_shap import ShapDP
-
 from effector.regional_effect_ale import RegionalALE, RegionalRHALE
-from effector.regional_effect_pdp import RegionalPDP, RegionalDerPDP
+from effector.regional_effect_pdp import RegionalDerPDP, RegionalPDP
 from effector.regional_effect_shap import RegionalShapDP
-
-from effector import axis_partitioning
-from effector import space_partitioning
-
-from effector import models
-from effector import datasets

--- a/effector/axis_partitioning.py
+++ b/effector/axis_partitioning.py
@@ -1,9 +1,10 @@
 import typing
 
-import numpy as np
-import effector.utils as utils
-import effector.helpers as helpers
 import matplotlib.pyplot as plt
+import numpy as np
+
+import effector.helpers as helpers
+import effector.utils as utils
 
 
 class Base:
@@ -189,15 +190,16 @@ class Greedy(Base):
         }
         super(Greedy, self).__init__("greedy", method_args)
 
-
-    def find_limits(self, data, data_effect, axis_limits) -> typing.Union[np.ndarray, bool]:
+    def find_limits(
+        self, data, data_effect, axis_limits
+    ) -> typing.Union[np.ndarray, bool]:
 
         self._preprocess_find(data, data_effect, axis_limits)
         xs_min = self.xs_min
         xs_max = self.xs_max
         init_nof_bins = self.method_args["init_nof_bins"]
         discount = self.method_args["discount"]
-        cat_limit = self.method_args["cat_limit"]
+        _cat_limit = self.method_args["cat_limit"]
 
         if self._none_valid_binning():
             self.limits = False
@@ -263,8 +265,13 @@ class Greedy(Base):
 
 
 class DynamicProgramming(Base):
-
-    def __init__(self, max_nof_bins: int = 20, min_points_per_bin: int = 2., discount: float = 0.3, cat_limit: int = 10):
+    def __init__(
+        self,
+        max_nof_bins: int = 20,
+        min_points_per_bin: int = 2.0,
+        discount: float = 0.3,
+        cat_limit: int = 10,
+    ):
         assert min_points_per_bin >= 2, "min_points_per_bin should be at least 2"
         method_args = {
             "max_nof_bins": max_nof_bins,
@@ -298,9 +305,9 @@ class DynamicProgramming(Base):
         return cost
 
     def _argmatrix_to_limits(self, K):
-        assert (
-            "argmatrix" in self.method_outputs
-        ), "argmatrix not found in method_outputs"
+        assert "argmatrix" in self.method_outputs, (
+            "argmatrix not found in method_outputs"
+        )
         argmatrix = self.method_outputs["argmatrix"]
         dx = (self.xs_max - self.xs_min) / K
 
@@ -332,7 +339,7 @@ class DynamicProgramming(Base):
         max_nof_bins = self.method_args["max_nof_bins"]
         min_points = self.method_args["min_points"]
         discount = self.method_args["discount"]
-        cat_limit = self.method_args["cat_limit"]
+        _cat_limit = self.method_args["cat_limit"]
 
         self.min_points = min_points
         big_M = self.big_M
@@ -386,7 +393,7 @@ class DynamicProgramming(Base):
 
 
 class Fixed(Base):
-    def __init__(self, nof_bins: int = 20, min_points_per_bin=0., cat_limit: int = 10):
+    def __init__(self, nof_bins: int = 20, min_points_per_bin=0.0, cat_limit: int = 10):
         method_args = {
             "nof_bins": nof_bins,
             "min_points": min_points_per_bin,
@@ -398,7 +405,7 @@ class Fixed(Base):
         self._preprocess_find(data, data_effect, axis_limits)
         nof_bins = self.method_args["nof_bins"]
         min_points = self.method_args["min_points"]
-        cat_limit = self.method_args["cat_limit"]
+        _cat_limit = self.method_args["cat_limit"]
 
         if self._none_valid_binning():
             self.limits = False

--- a/effector/datasets.py
+++ b/effector/datasets.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from effector import helpers
+
 
 class Base:
     def __init__(self, name: str, dim: int, axis_limits: np.array):
@@ -23,10 +25,9 @@ class Base:
 
 
 class IndependentUniform(Base):
-    def __init__(self, dim: int =2, low: float = 0, high: float = 1):
+    def __init__(self, dim: int = 2, low: float = 0, high: float = 1):
         axis_limits = np.array([[low, high] for _ in range(dim)]).T
         super().__init__(name=self.__class__.__name__, dim=dim, axis_limits=axis_limits)
-
 
     def generate_data(self, n: int, seed: int = 21) -> np.array:
         """Generate N samples
@@ -43,7 +44,9 @@ class IndependentUniform(Base):
 
         """
         np.random.seed(seed)
-        x = np.random.uniform(self.axis_limits[0, :], self.axis_limits[1, :], (n, self.dim))
+        x = np.random.uniform(
+            self.axis_limits[0, :], self.axis_limits[1, :], (n, self.dim)
+        )
         np.random.shuffle(x)
         return x
 
@@ -77,16 +80,20 @@ class RealDatasetBase:
         self.fetch_and_preprocess()
 
         self.x_train, self.x_test, self.y_train, self.y_test = self.split(
-            self.dataset[:, :-1], self.dataset[:, -1], pcg_train)
+            self.dataset[:, :-1], self.dataset[:, -1], pcg_train
+        )
 
         if standardize:
-            self.x_train, self.x_train_mu, self.x_train_std = self.standarize(self.x_train)
+            self.x_train, self.x_train_mu, self.x_train_std = self.standarize(
+                self.x_train
+            )
             self.x_test, self.x_test_mu, self.x_test_std = self.standarize(self.x_test)
-            self.y_train, self.y_train_mu, self.y_train_std = self.standarize(self.y_train)
+            self.y_train, self.y_train_mu, self.y_train_std = self.standarize(
+                self.y_train
+            )
             self.y_test, self.y_test_mu, self.y_test_std = self.standarize(self.y_test)
 
         self.postprocess()
-
 
     def fetch_and_preprocess(self):
         # self.dataset = ...
@@ -94,7 +101,6 @@ class RealDatasetBase:
 
     def postprocess(self):
         raise NotImplementedError
-
 
     @staticmethod
     def standarize(x):
@@ -123,10 +129,13 @@ class RealDatasetBase:
 
 class BikeSharing(RealDatasetBase):
     def __init__(self, pcg_train=0.8, standardize=True):
-        super().__init__(name="BikeSharing", pcg_train=pcg_train, standardize=standardize)
+        super().__init__(
+            name="BikeSharing", pcg_train=pcg_train, standardize=standardize
+        )
 
     def fetch_and_preprocess(self):
         from ucimlrepo import fetch_ucirepo
+
         bike_sharing_dataset = fetch_ucirepo(id=275)
 
         # bike_sharing_dataset.feature_names
@@ -134,7 +143,6 @@ class BikeSharing(RealDatasetBase):
         X = X.drop(["dteday", "atemp"], axis=1)
         self.feature_names = X.columns.to_list()
         X = X.to_numpy()
-
 
         y = bike_sharing_dataset.data.targets
         self.target_name = y.columns.item()
@@ -147,11 +155,8 @@ class BikeSharing(RealDatasetBase):
         self.x_test_mu[8] += 8
         self.x_test_std[8] *= 47
 
-
         self.x_train_std[9] *= 100
         self.x_test_std[9] *= 100
 
         self.x_train_std[10] *= 67
         self.x_test_std[10] *= 67
-
-

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -1,7 +1,9 @@
-import numpy as np
-from typing import Callable, List, Optional, Union, Tuple
-from effector import helpers
 from abc import ABC, abstractmethod
+from typing import Callable, List, Optional, Tuple, Union
+
+import numpy as np
+
+from effector import helpers
 
 
 class GlobalEffectBase(ABC):
@@ -40,13 +42,17 @@ class GlobalEffectBase(ABC):
             # drop points outside of limits
             accept_indices = helpers.indices_within_limits(data, axis_limits)
             data = data[accept_indices, :]
-            data_effect = data_effect[accept_indices, :] if data_effect is not None else None
+            data_effect = (
+                data_effect[accept_indices, :] if data_effect is not None else None
+            )
         else:
             axis_limits = helpers.axis_limits_from_data(data)
         self.axis_limits: np.ndarray = axis_limits
 
         # data preprocessing (ii): select nof_instances from the remaining data
-        self.nof_instances, self.indices = helpers.prep_nof_instances(nof_instances, data.shape[0])
+        self.nof_instances, self.indices = helpers.prep_nof_instances(
+            nof_instances, data.shape[0]
+        )
         data = data[self.indices, :]
         data_effect = data_effect[self.indices, :] if data_effect is not None else None
 
@@ -76,10 +82,10 @@ class GlobalEffectBase(ABC):
 
     @abstractmethod
     def fit(
-            self,
-            features: Union[int, str, list] = "all",
-            centering: Union[bool, str] = False,
-            **kwargs
+        self,
+        features: Union[int, str, list] = "all",
+        centering: Union[bool, str] = False,
+        **kwargs,
     ) -> None:
         """Fit, i.e., compute the quantities that are necessary for evaluating and plotting the feature effect, for the given features.
 
@@ -95,11 +101,11 @@ class GlobalEffectBase(ABC):
 
     @abstractmethod
     def plot(
-            self,
-            feature: int,
-            heterogeneity: Union[bool, str] = False,
-            centering: Union[bool, str] = False,
-            **kwargs
+        self,
+        feature: int,
+        heterogeneity: Union[bool, str] = False,
+        centering: Union[bool, str] = False,
+        **kwargs,
     ) -> None:
         """
 

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -1,17 +1,18 @@
 import typing
-from typing import List, Optional, Union, Tuple
-import effector.utils as utils
-import effector.visualization as vis
-import effector.helpers as helpers
-import effector.utils_integrate as utils_integrate
-from effector.global_effect import GlobalEffectBase
-import effector.axis_partitioning as ap
-import numpy as np
 from abc import abstractmethod
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+
+import effector.axis_partitioning as ap
+import effector.helpers as helpers
+import effector.utils as utils
+import effector.utils_integrate as utils_integrate
+import effector.visualization as vis
+from effector.global_effect import GlobalEffectBase
 
 
 class ALEBase(GlobalEffectBase):
-
     def __init__(
         self,
         data: np.ndarray,
@@ -81,12 +82,14 @@ class ALEBase(GlobalEffectBase):
             # append the "norm_const" to the feature effect if centering is not False
             if centering is not False:
                 self.feature_effect["feature_" + str(s)]["norm_const"] = (
-                    self._compute_norm_const(s, method=centering, nof_points=points_for_centering)
+                    self._compute_norm_const(
+                        s, method=centering, nof_points=points_for_centering
+                    )
                 )
             else:
-                self.feature_effect["feature_" + str(s)][
-                    "norm_const"
-                ] = self.empty_symbol
+                self.feature_effect["feature_" + str(s)]["norm_const"] = (
+                    self.empty_symbol
+                )
 
             self.is_fitted[s] = True
             self.fit_args["feature_" + str(s)] = {
@@ -99,7 +102,9 @@ class ALEBase(GlobalEffectBase):
             x, limits=params["limits"], bin_effect=params["bin_effect"], dx=params["dx"]
         )
         if heterogeneity:
-            var = utils.apply_bin_value(x=x, bin_limits=params["limits"], bin_value=params["bin_variance"])
+            var = utils.apply_bin_value(
+                x=x, bin_limits=params["limits"], bin_value=params["bin_variance"]
+            )
             return y, var
         else:
             return y
@@ -110,7 +115,7 @@ class ALEBase(GlobalEffectBase):
         xs: np.ndarray,
         heterogeneity: bool = False,
         centering: typing.Union[bool, str] = True,
-        **kwargs
+        **kwargs,
     ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """Evalueate the (RH)ALE feature effect of feature `feature` at points `xs`.
 
@@ -226,7 +231,11 @@ class ALEBase(GlobalEffectBase):
         else:
             avg_output = None
 
-        title = "Accumulated Local Effects (ALE)" if self.method_name == "ale" else "Robust and Heterogeneity-Aware ALE (RHALE)"
+        title = (
+            "Accumulated Local Effects (ALE)"
+            if self.method_name == "ale"
+            else "Robust and Heterogeneity-Aware ALE (RHALE)"
+        )
         ret = vis.ale_plot(
             self.feature_effect["feature_" + str(feature)],
             self.eval,
@@ -250,8 +259,6 @@ class ALEBase(GlobalEffectBase):
             return fig, ax
 
 
-
-
 class ALE(ALEBase):
     def __init__(
         self,
@@ -262,7 +269,7 @@ class ALE(ALEBase):
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
     ):
-        """
+        r"""
         Constructor for the ALE plot.
 
         Definition:
@@ -331,11 +338,15 @@ class ALE(ALEBase):
 
         data = self.data
         # assertion
-        assert binning_method == "fixed" or isinstance(binning_method, ap.Fixed), "ALE can work only with the fixed binning method!"
+        assert binning_method == "fixed" or isinstance(binning_method, ap.Fixed), (
+            "ALE can work only with the fixed binning method!"
+        )
 
         if isinstance(binning_method, str):
             binning_method = ap.Fixed()
-        limits = binning_method.find_limits(data[:, feature], None, self.axis_limits[:, feature])
+        limits = binning_method.find_limits(
+            data[:, feature], None, self.axis_limits[:, feature]
+        )
 
         # assert bins can be computed else raise error
         assert limits is not False, (
@@ -348,16 +359,12 @@ class ALE(ALEBase):
         )
 
         # compute data effect on bin limits
-        data_effect = utils.compute_local_effects(
-            data, self.model, limits, feature
-        )
+        data_effect = utils.compute_local_effects(data, self.model, limits, feature)
         self.data_effect_ale["feature_" + str(feature)] = data_effect
         self.bin_limits["feature_" + str(feature)] = limits
 
         # compute the bin effect
-        dale_params = utils.compute_ale_params(
-            data[:, feature], data_effect, limits
-        )
+        dale_params = utils.compute_ale_params(data[:, feature], data_effect, limits)
         dale_params["alg_params"] = "fixed"
         return dale_params
 
@@ -366,7 +373,7 @@ class ALE(ALEBase):
         features: typing.Union[int, str, list] = "all",
         binning_method: typing.Union[str, ap.Fixed] = "fixed",
         centering: typing.Union[bool, str] = True,
-        points_for_centering: int = 30
+        points_for_centering: int = 30,
     ) -> None:
         """Fit the ALE plot.
 
@@ -390,9 +397,9 @@ class ALE(ALEBase):
 
             points_for_centering: the number of points to use for centering the plot. Default is 100.
         """
-        assert binning_method == "fixed" or isinstance(
-            binning_method, ap.Fixed
-        ), "ALE can work only with the fixed binning method!"
+        assert binning_method == "fixed" or isinstance(binning_method, ap.Fixed), (
+            "ALE can work only with the fixed binning method!"
+        )
 
         self._fit_loop(features, binning_method, centering, points_for_centering)
 
@@ -409,7 +416,7 @@ class RHALE(ALEBase):
         feature_names: typing.Optional[list] = None,
         target_name: typing.Optional[str] = None,
     ):
-        """
+        r"""
         Constructor for RHALE.
 
         Definition:
@@ -481,7 +488,6 @@ class RHALE(ALEBase):
             "RHALE",
         )
 
-
     def compile(self):
         """Prepare everything for fitting, i.e., compute the gradients on data points."""
         if self.data_effect is None and self.model_jac is not None:
@@ -489,7 +495,13 @@ class RHALE(ALEBase):
         elif self.data_effect is None and self.model_jac is None:
             self.data_effect = utils.compute_jacobian_numerically(self.model, self.data)
 
-    def _fit_feature(self, feature: int, binning_method: Union[str, ap.DynamicProgramming, ap.Greedy, ap.Fixed] = "greedy") -> typing.Dict:
+    def _fit_feature(
+        self,
+        feature: int,
+        binning_method: Union[
+            str, ap.DynamicProgramming, ap.Greedy, ap.Fixed
+        ] = "greedy",
+    ) -> typing.Dict:
         if self.data_effect is None:
             self.compile()
 
@@ -498,7 +510,9 @@ class RHALE(ALEBase):
 
         if isinstance(binning_method, str):
             binning_method = ap.return_default(binning_method)
-        limits = binning_method.find_limits(data[:, feature], self.data_effect[:, feature], self.axis_limits[:, feature])
+        limits = binning_method.find_limits(
+            data[:, feature], self.data_effect[:, feature], self.axis_limits[:, feature]
+        )
 
         # assert bins can be computed else raise error
         assert limits is not False, (
@@ -525,7 +539,7 @@ class RHALE(ALEBase):
             str, ap.DynamicProgramming, ap.Greedy, ap.Fixed
         ] = "greedy",
         centering: typing.Union[bool, str] = True,
-        points_for_centering: int = 30
+        points_for_centering: int = 30,
     ) -> None:
         """Fit the model.
 

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -1,9 +1,11 @@
+import copy
 import typing
 from typing import Callable, List, Optional, Union
-import copy
+
 import numpy as np
-import effector.visualization as vis
+
 import effector.helpers as helpers
+import effector.visualization as vis
 from effector.global_effect import GlobalEffectBase
 
 
@@ -249,7 +251,7 @@ class PDP(PDPBase):
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
     ):
-        """
+        r"""
         Constructor of the PDP class.
 
         Definition:
@@ -392,7 +394,7 @@ class PDP(PDPBase):
             show_avg_output,
             y_limits,
             use_vectorized,
-            show_plot
+            show_plot,
         )
 
         if not show_plot:
@@ -410,7 +412,7 @@ class DerPDP(PDPBase):
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
     ):
-        """
+        r"""
         Constructor of the DerivativePDP class.
 
         Definition:

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -1,9 +1,11 @@
 import typing
-from typing import Callable, List, Optional, Union, Tuple
-import effector.visualization as vis
-import effector.helpers as helpers
-from effector.global_effect import GlobalEffectBase
+from typing import Callable, List, Optional, Tuple, Union
+
 import numpy as np
+
+import effector.helpers as helpers
+import effector.visualization as vis
+from effector.global_effect import GlobalEffectBase
 
 try:
     import shap
@@ -15,9 +17,10 @@ try:
 except ImportError:
     shapiq = None
 
+from scipy.interpolate import interp1d
+
 import effector.axis_partitioning as ap
 import effector.utils as utils
-from scipy.interpolate import interp1d
 
 
 class ShapDP(GlobalEffectBase):
@@ -32,7 +35,7 @@ class ShapDP(GlobalEffectBase):
         shap_values: Optional[np.ndarray] = None,
         backend: str = "shap",
     ):
-        """
+        r"""
         Constructor of the ShapDP class.
 
         ??? note "Definition"
@@ -149,7 +152,6 @@ class ShapDP(GlobalEffectBase):
         data = self.data
         model = self.model
 
-
         if self.shap_values is None:
             # prepare arguments
             explainer_kwargs = explainer_kwargs.copy() if explainer_kwargs else {}
@@ -178,8 +180,14 @@ class ShapDP(GlobalEffectBase):
                 explanation_defaults = {"budget": budget}
             else:
                 raise ValueError("`backend` should be either 'shap' or 'shapiq'")
-            explainer_kwargs = {**explainer_defaults, **explainer_kwargs}  # User args override defaults
-            explanation_kwargs = {**explanation_defaults, **explanation_kwargs}  # User args override defaults
+            explainer_kwargs = {
+                **explainer_defaults,
+                **explainer_kwargs,
+            }  # User args override defaults
+            explanation_kwargs = {
+                **explanation_defaults,
+                **explanation_kwargs,
+            }  # User args override defaults
 
             # actual code
             if self.backend == "shap":
@@ -189,7 +197,9 @@ class ShapDP(GlobalEffectBase):
             elif self.backend == "shapiq":
                 explainer = shapiq.Explainer(model, **explainer_kwargs)
                 explanations = explainer.explain_X(data, **explanation_kwargs)
-                self.shap_values = np.stack([ex.get_n_order_values(1) for ex in explanations])
+                self.shap_values = np.stack(
+                    [ex.get_n_order_values(1) for ex in explanations]
+                )
             else:
                 raise ValueError("`backend` should be either 'shap' or 'shapiq'")
 
@@ -200,7 +210,9 @@ class ShapDP(GlobalEffectBase):
         if isinstance(binning_method, str):
             binning_method = ap.return_default(binning_method)
 
-        limits = binning_method.find_limits(data[:, feature], self.shap_values[:, feature], self.axis_limits[:, feature])
+        limits = binning_method.find_limits(
+            data[:, feature], self.shap_values[:, feature], self.axis_limits[:, feature]
+        )
 
         # assert bins can be computed else raise error
         assert limits is not False, (
@@ -212,19 +224,35 @@ class ShapDP(GlobalEffectBase):
             "the parameters of the method"
         )
         # compute the bin effect
-        feature_effect_dict = utils.compute_ale_params(data[:, feature], self.shap_values[:, feature], limits)
+        feature_effect_dict = utils.compute_ale_params(
+            data[:, feature], self.shap_values[:, feature], limits
+        )
         feature_effect_dict["alg_params"] = binning_method
 
         # Compute bin edges and bin centers
         bin_centers = (limits[:-1] + limits[1:]) / 2
 
         # Create piecewise linear interpolation
-        mean_spline = interp1d(bin_centers, feature_effect_dict["bin_effect"], kind='linear', fill_value="extrapolate")
-        var_spline = interp1d(bin_centers, feature_effect_dict["bin_variance"], kind='linear', fill_value="extrapolate")
+        mean_spline = interp1d(
+            bin_centers,
+            feature_effect_dict["bin_effect"],
+            kind="linear",
+            fill_value="extrapolate",
+        )
+        var_spline = interp1d(
+            bin_centers,
+            feature_effect_dict["bin_variance"],
+            kind="linear",
+            fill_value="extrapolate",
+        )
 
         # compute norm constant
         if centering == "zero_integral":
-            x_norm = np.linspace(self.axis_limits[0, feature], self.axis_limits[1, feature], points_for_centering)
+            x_norm = np.linspace(
+                self.axis_limits[0, feature],
+                self.axis_limits[1, feature],
+                points_for_centering,
+            )
             y_norm = mean_spline(x_norm)
             norm_const = np.mean(y_norm)
         elif centering == "zero_start":
@@ -251,7 +279,7 @@ class ShapDP(GlobalEffectBase):
         shap_explainer_kwargs: Optional[dict] = None,
         shap_explanation_kwargs: Optional[dict] = None,
     ) -> None:
-        """Fit the SHAP Dependence Plot to the data.
+        r"""Fit the SHAP Dependence Plot to the data.
 
         Notes:
             The SHAP Dependence Plot (SDP) $\hat{f}^{SDP}_j(x_j)$ is a spline fit to
@@ -380,7 +408,7 @@ class ShapDP(GlobalEffectBase):
                 points_for_centering,
                 budget,
                 shap_explainer_kwargs,
-                shap_explanation_kwargs
+                shap_explanation_kwargs,
             )
             self.is_fitted[s] = True
             self.fit_args["feature_" + str(s)] = {

--- a/effector/helpers.py
+++ b/effector/helpers.py
@@ -1,7 +1,7 @@
-import typing
-import numpy as np
 import re
+import typing
 
+import numpy as np
 
 BIG_M = 1e8
 EPS = 1e-8
@@ -12,7 +12,7 @@ def prep_features(feat: typing.Union[str, list], D) -> list:
     assert type(feat) in [list, str, int]
     if feat == "all":
         feat = [i for i in range(D)]
-    elif type(feat) == int:
+    elif isinstance(feat, int):
         feat = [feat]
     return feat
 
@@ -58,17 +58,17 @@ def prep_dale_fit_params(par: dict):
         par["bin_method"] = "fixed"
 
     if "nof_bins" in par.keys():
-        assert type(par["nof_bins"]) == int
+        assert isinstance(par["nof_bins"], int)
     else:
         par["nof_bins"] = 100
 
     if "max_nof_bins" in par.keys():
-        assert type(par["max_nof_bins"]) == int
+        assert isinstance(par["max_nof_bins"], int)
     else:
         par["max_nof_bins"] = 20
 
     if "min_points_per_bin" in par.keys():
-        assert type(par["max_nof_bins"]) == int
+        assert isinstance(par["min_points_per_bin"], int)
     else:
         par["min_points_per_bin"] = None
 
@@ -77,7 +77,7 @@ def prep_dale_fit_params(par: dict):
 
 def prep_ale_fit_params(par: dict):
     if "nof_bins" in par.keys():
-        assert type(par["nof_bins"]) == int
+        assert isinstance(par["nof_bins"], int)
     else:
         par["nof_bins"] = 100
     return par
@@ -136,10 +136,13 @@ def indices_within_limits(data: np.ndarray, axis_limits: np.ndarray) -> np.ndarr
     for feature in range(dim):
         accept_left = data[:, feature] >= axis_limits[0, feature]
         accept_right = data[:, feature] <= axis_limits[1, feature]
-        accept_indices = np.logical_and.reduce([accept_indices, accept_left, accept_right])
+        accept_indices = np.logical_and.reduce(
+            [accept_indices, accept_left, accept_right]
+        )
     assert np.sum(accept_indices) > 0
     return accept_indices
 
+
 def camel_to_snake(name: str) -> str:
     """Convert CamelCase to snake_case."""
-    return '_'.join(re.findall(r'[A-Z][a-z]*|\d+', name)).lower()
+    return "_".join(re.findall(r"[A-Z][a-z]*|\d+", name)).lower()

--- a/effector/models.py
+++ b/effector/models.py
@@ -1,6 +1,7 @@
-from effector import helpers
-import re
 import numpy as np
+
+from effector import helpers
+
 
 class Base:
     def __init__(self, name):
@@ -16,7 +17,7 @@ class Base:
 
 class ConditionalInteraction(Base):
     def __init__(self):
-        """Define a simple model.
+        r"""Define a simple model.
 
         $f(x_1, x_2, x_3) = -x_1^2\mathbb{1}_{x_2 < 0} + x_1^2\mathbb{1}_{x_2 \geq 0} + e^{x_3}$
 
@@ -34,8 +35,8 @@ class ConditionalInteraction(Base):
         """
         y = np.exp(x[:, 2])
         ind = x[:, 1] < 0
-        y[ind] += -x[ind, 0]**2
-        y[~ind] += x[~ind, 0]**2
+        y[ind] += -(x[ind, 0] ** 2)
+        y[~ind] += x[~ind, 0] ** 2
         return y
 
     def jacobian(self, x: np.ndarray) -> np.ndarray:
@@ -50,13 +51,14 @@ class ConditionalInteraction(Base):
         y = np.zeros_like(x)
         y[:, 2] = np.exp(x[:, 2])
         ind = x[:, 1] < 0
-        y[ind, 0] = -2*x[ind, 0]
-        y[~ind, 0] = 2*x[~ind, 0]
+        y[ind, 0] = -2 * x[ind, 0]
+        y[~ind, 0] = 2 * x[~ind, 0]
         return y
+
 
 class DoubleConditionalInteraction(Base):
     def __init__(self):
-        """Define a simple model.
+        r"""Define a simple model.
 
         $f(x_1, x_2, x_3) = -3x_1^2\mathbb{1}_{x_2 < 0}\mathbb{1}_{x_3 < 0} +
                             +x_1^2\mathbb{1}_{x_2 < 0}\mathbb{1}_{x_3 \geq 0}
@@ -79,10 +81,10 @@ class DoubleConditionalInteraction(Base):
         y = np.zeros(x.shape[0])
         ind1 = x[:, 1] < 0
         ind2 = x[:, 2] < 0
-        y[ind1 & ind2] = -3*x[ind1 & ind2, 0]**2
-        y[ind1 & ~ind2] = x[ind1 & ~ind2, 0]**2
+        y[ind1 & ind2] = -3 * x[ind1 & ind2, 0] ** 2
+        y[ind1 & ~ind2] = x[ind1 & ~ind2, 0] ** 2
         y[~ind1 & ind2] = -np.exp(x[~ind1 & ind2, 0])
-        y[~ind1 & ~ind2] = np.exp(3*x[~ind1 & ~ind2, 0])
+        y[~ind1 & ~ind2] = np.exp(3 * x[~ind1 & ~ind2, 0])
         return y
 
     def jacobian(self, x: np.ndarray) -> np.ndarray:
@@ -97,22 +99,23 @@ class DoubleConditionalInteraction(Base):
         y = np.zeros_like(x)
         ind1 = x[:, 1] < 0
         ind2 = x[:, 2] < 0
-        y[ind1 & ind2, 0] = -2*3*x[ind1 & ind2, 0]
-        y[ind1 & ~ind2, 0] = 2*x[ind1 & ~ind2, 0]
+        y[ind1 & ind2, 0] = -2 * 3 * x[ind1 & ind2, 0]
+        y[ind1 & ~ind2, 0] = 2 * x[ind1 & ~ind2, 0]
         y[~ind1 & ind2, 0] = -np.exp(x[~ind1 & ind2, 0])
-        y[~ind1 & ~ind2, 0] = 3*np.exp(3*x[~ind1 & ~ind2, 0])
+        y[~ind1 & ~ind2, 0] = 3 * np.exp(3 * x[~ind1 & ~ind2, 0])
         return y
-        
+
+
 class ConditionalInteraction4Regions(Base):
     def __init__(self):
         """
-        $f(x_1, x_2, x_3) = 
-        \begin{cases} 
+        $f(x_1, x_2, x_3) =
+        \begin{cases}
         -x_1^2 + e^{x_3}, & \text{if } x_2 < 0 \text{ and } x_3 < 0 \\
-        x_1^2 + e^{x_3}, & \text{if } x_2 < 0 \text{ and } x_3 \geq 0 \\
-        -x_1^4 + e^{x_3}, & \text{if } x_2 \geq 0 \text{ and } x_3 < 0 \\
-        x_1^4 + e^{x_3}, & \text{if } x_2 \geq 0 \text{ and } x_3 \geq 0
-        \end{cases}
+        x_1^2 + e^{x_3}, & \text{if } x_2 < 0 \text{ and } x_3 \\geq 0 \\
+        -x_1^4 + e^{x_3}, & \text{if } x_2 \\geq 0 \text{ and } x_3 < 0 \\
+        x_1^4 + e^{x_3}, & \text{if } x_2 \\geq 0 \text{ and } x_3 \\geq 0
+        \\end{cases}
         """
         super().__init__(name=self.__class__.__name__)
 
@@ -132,9 +135,9 @@ class ConditionalInteraction4Regions(Base):
         mask3 = (x[:, 1] >= 0) & (x[:, 2] < 0)
         mask4 = (x[:, 1] >= 0) & (x[:, 2] >= 0)
 
-        y[mask1] += -x[mask1, 0] ** 2
+        y[mask1] += -(x[mask1, 0] ** 2)
         y[mask2] += x[mask2, 0] ** 2
-        y[mask3] += -x[mask3, 0] ** 4
+        y[mask3] += -(x[mask3, 0] ** 4)
         y[mask4] += x[mask4, 0] ** 4
 
         return y
@@ -163,6 +166,7 @@ class ConditionalInteraction4Regions(Base):
         y[mask4, 0] = 4 * x[mask4, 0] ** 3
 
         return y
+
 
 class GeneralInteraction(Base):
     def __init__(self):

--- a/effector/regional_effect.py
+++ b/effector/regional_effect.py
@@ -1,14 +1,17 @@
+import copy
+import typing
+from typing import Callable, List, Optional, Tuple, Union
+
 import numpy as np
+
 import effector.helpers as helpers
 import effector.space_partitioning
 import effector.utils as utils
-from effector.space_partitioning import Best, Tree
-from effector.global_effect_ale import RHALE, ALE
+from effector.global_effect_ale import ALE, RHALE
 from effector.global_effect_pdp import PDP, DerPDP
 from effector.global_effect_shap import ShapDP
-from typing import Callable, Optional, Union, List, Tuple
-import typing
-import copy
+from effector.space_partitioning import Best, Tree
+
 
 class RegionalEffectBase:
     empty_symbol = helpers.EMPTY_SYMBOL
@@ -48,14 +51,17 @@ class RegionalEffectBase:
             # drop points outside of limits
             accept_indices = helpers.indices_within_limits(data, axis_limits)
             data = data[accept_indices, :]
-            data_effect = data_effect[accept_indices, :] if data_effect is not None else None
+            data_effect = (
+                data_effect[accept_indices, :] if data_effect is not None else None
+            )
         else:
             axis_limits = helpers.axis_limits_from_data(data)
         self.axis_limits: np.ndarray = axis_limits
 
-
         # data preprocessing (ii): select nof_instances from the remaining data
-        self.nof_instances, self.indices = helpers.prep_nof_instances(nof_instances, data.shape[0])
+        self.nof_instances, self.indices = helpers.prep_nof_instances(
+            nof_instances, data.shape[0]
+        )
         data = data[self.indices, :]
         data_effect = data_effect[self.indices, :] if data_effect is not None else None
 
@@ -88,8 +94,8 @@ class RegionalEffectBase:
 
         # parameters used when fitting the regional effect
         # self.method_args: typing.Dict = {}
-        self.kwargs_subregion_detection: typing.Dict = {} # subregion specific arguments
-        self.kwargs_fitting: typing.Dict = {} # fitting specific arguments
+        self.kwargs_subregion_detection: typing.Dict = {}  # subregion specific arguments
+        self.kwargs_fitting: typing.Dict = {}  # fitting specific arguments
 
         # dictionary with all the information required for plotting or evaluating the regional effects
         self.partitioners: typing.Dict[str, Best] = {}
@@ -108,8 +114,12 @@ class RegionalEffectBase:
         """
         assert feature < self.dim, "Feature index out of bounds"
         if isinstance(space_partitioner, str):
-            assert space_partitioner in ["best", "cart"], "space_partitioner must be 'best' or 'cart'"
-            space_partitioner = space_partitioning.return_default(space_partitioner)
+            assert space_partitioner in ["best", "cart"], (
+                "space_partitioner must be 'best' or 'cart'"
+            )
+            space_partitioner = effector.space_partitioning.return_default(
+                space_partitioner
+            )
         else:
             space_partitioner = copy.deepcopy(space_partitioner)
 
@@ -123,7 +133,7 @@ class RegionalEffectBase:
             self.cat_limit,
             candidate_foc,
             self.feature_names,
-            self.target_name
+            self.target_name,
         )
         self.tree["feature_{}".format(feature)] = space_partitioner.fit()
 
@@ -149,7 +159,11 @@ class RegionalEffectBase:
         name = feature_tree.set_display_name(node.name, scale_x_list)
         active_indices = node.info["active_indices"]
         data = self.data[active_indices.astype(bool), :]
-        data_effect = self.data_effect[active_indices.astype(bool), :] if self.data_effect is not None else None
+        data_effect = (
+            self.data_effect[active_indices.astype(bool), :]
+            if self.data_effect is not None
+            else None
+        )
         feature_names = copy.deepcopy(self.feature_names)
         feature_names[feature] = name
 
@@ -201,12 +215,12 @@ class RegionalEffectBase:
             raise NotImplementedError
 
     def eval(
-            self,
-            feature: int,
-            node_idx: int,
-            xs: np.ndarray,
-            heterogeneity: bool = False,
-            centering: Union[bool, str] = True,
+        self,
+        feature: int,
+        node_idx: int,
+        xs: np.ndarray,
+        heterogeneity: bool = False,
+        centering: Union[bool, str] = True,
     ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """
         :point_right: Evaluate the regional effect for a given feature and node.
@@ -246,7 +260,7 @@ class RegionalEffectBase:
         centering = helpers.prep_centering(centering)
 
         kwargs = copy.deepcopy(self.kwargs_fitting)
-        kwargs['centering'] = centering
+        kwargs["centering"] = centering
 
         # select only the three out of all
         fe_method = self._create_fe_object(feature, node_idx, None)
@@ -264,14 +278,20 @@ class RegionalEffectBase:
         self.refit(kwargs["feature"])
 
         # select only the three out of all kwargs
-        fe_method = self._create_fe_object(kwargs["feature"], kwargs["node_idx"], kwargs["scale_x_list"])
+        fe_method = self._create_fe_object(
+            kwargs["feature"], kwargs["node_idx"], kwargs["scale_x_list"]
+        )
 
         kwargs_fitting = copy.deepcopy(self.kwargs_fitting)
-        kwargs_fitting['centering'] = kwargs["centering"]
+        kwargs_fitting["centering"] = kwargs["centering"]
         fe_method.fit(features=kwargs["feature"], **kwargs_fitting)
 
         plot_kwargs = copy.deepcopy(kwargs)
-        plot_kwargs["scale_x"] = kwargs["scale_x_list"][kwargs["feature"]] if kwargs["scale_x_list"] is not None else None
+        plot_kwargs["scale_x"] = (
+            kwargs["scale_x_list"][kwargs["feature"]]
+            if kwargs["scale_x_list"] is not None
+            else None
+        )
         plot_kwargs.pop("scale_x_list")
         plot_kwargs.pop("node_idx")
         return fe_method.plot(**plot_kwargs)

--- a/effector/regional_effect_ale.py
+++ b/effector/regional_effect_ale.py
@@ -1,14 +1,14 @@
 import typing
+from typing import Callable, List, Optional, Union
+
+import numpy as np
+from tqdm import tqdm
 
 import effector.space_partitioning
-from effector.regional_effect import RegionalEffectBase
-from effector import helpers, utils
-import numpy as np
-from effector.global_effect_ale import ALE, RHALE
-from tqdm import tqdm
 from effector import axis_partitioning as ap
-from typing import Callable, Optional, Union, List
-
+from effector import helpers, utils
+from effector.global_effect_ale import ALE, RHALE
+from effector.regional_effect import RegionalEffectBase
 
 BIG_M = helpers.BIG_M
 
@@ -109,7 +109,6 @@ class RegionalRHALE(RegionalEffectBase):
             target_name,
         )
 
-
     def compile(self):
         """Prepare everything for fitting, i.e., compute the gradients on data points."""
         if self.data_effect is None and self.model_jac is not None:
@@ -133,21 +132,37 @@ class RegionalRHALE(RegionalEffectBase):
                 instance_effects = self.data_effect[active_indices.astype(bool), :]
             else:
                 instance_effects = None
-            rhale = RHALE(data, self.model, self.model_jac, "all", self.axis_limits, instance_effects)
+            rhale = RHALE(
+                data,
+                self.model,
+                self.model_jac,
+                "all",
+                self.axis_limits,
+                instance_effects,
+            )
             try:
                 rhale.fit(features=foi, binning_method=binning_method, centering=False)
             except utils.AllBinsHaveAtMostOnePointError as e:
-                print(f"RegionalRHALE here: At a particular split, some bins had at most one point. I reject this split. \n Error: {e}")
+                print(
+                    f"RegionalRHALE here: At a particular split, some bins had at most one point. I reject this split. \n Error: {e}"
+                )
                 return BIG_M
             except Exception as e:
-                print(f"RegionalRHALE here: An unexpected error occurred. I reject this split. \n Error: {e}")
+                print(
+                    f"RegionalRHALE here: An unexpected error occurred. I reject this split. \n Error: {e}"
+                )
                 print(np.sum(active_indices))
                 return BIG_M
 
             # heterogeneity is the accumulated std at the end of the curve
-            xs = np.linspace(self.axis_limits[0, foi], self.axis_limits[1, foi], points_for_mean_heterogeneity)
+            xs = np.linspace(
+                self.axis_limits[0, foi],
+                self.axis_limits[1, foi],
+                points_for_mean_heterogeneity,
+            )
             _, z = rhale.eval(feature=foi, xs=xs, heterogeneity=True, centering=False)
             return np.mean(z)
+
         return heter
 
     def fit(
@@ -155,7 +170,12 @@ class RegionalRHALE(RegionalEffectBase):
         features: typing.Union[int, str, list] = "all",
         candidate_conditioning_features: typing.Union[str, list] = "all",
         space_partitioner: typing.Union[str, effector.space_partitioning.Best] = "best",
-        binning_method: typing.Union[str, ap.Fixed, ap.DynamicProgramming, ap.Greedy,] = "greedy",
+        binning_method: typing.Union[
+            str,
+            ap.Fixed,
+            ap.DynamicProgramming,
+            ap.Greedy,
+        ] = "greedy",
         points_for_mean_heterogeneity: int = 30,
     ):
         """
@@ -185,14 +205,21 @@ class RegionalRHALE(RegionalEffectBase):
             self.compile()
 
         if isinstance(space_partitioner, str):
-            space_partitioner = effector.space_partitioning.return_default(space_partitioner)
+            space_partitioner = effector.space_partitioning.return_default(
+                space_partitioner
+            )
 
-        assert space_partitioner.min_points_per_subregion >= 2, "min_points_per_subregion must be >= 2"
+        assert space_partitioner.min_points_per_subregion >= 2, (
+            "min_points_per_subregion must be >= 2"
+        )
         features = helpers.prep_features(features, self.dim)
         for feat in tqdm(features):
             # find global axis limits
             heter = self._create_heterogeneity_function(
-                feat, binning_method, space_partitioner.min_points_per_subregion, points_for_mean_heterogeneity
+                feat,
+                binning_method,
+                space_partitioner.min_points_per_subregion,
+                points_for_mean_heterogeneity,
             )
 
             self._fit_feature(
@@ -206,10 +233,14 @@ class RegionalRHALE(RegionalEffectBase):
         all_arguments.pop("self")
 
         # region splitting arguments are the first 8 arguments
-        self.kwargs_subregion_detection = {k: all_arguments[k] for k in list(all_arguments.keys())[:3]}
+        self.kwargs_subregion_detection = {
+            k: all_arguments[k] for k in list(all_arguments.keys())[:3]
+        }
 
         # centering, points_for_centering, use_vectorized
-        self.kwargs_fitting = {k: v for k, v in all_arguments.items() if k in ["binnning_method"]}
+        self.kwargs_fitting = {
+            k: v for k, v in all_arguments.items() if k in ["binnning_method"]
+        }
 
     def plot(
         self,
@@ -309,20 +340,29 @@ class RegionalALE(RegionalEffectBase):
             target_name,
         )
 
-    def _create_heterogeneity_function(self, foi, min_points, points_for_mean_heterogeneity):
+    def _create_heterogeneity_function(
+        self, foi, min_points, points_for_mean_heterogeneity
+    ):
         def heter(active_indices) -> float:
             if np.sum(active_indices) < min_points:
                 return BIG_M
 
-            data_effect = self.global_data_effect["feature_" + str(foi)][active_indices.astype(bool)]
+            data_effect = self.global_data_effect["feature_" + str(foi)][
+                active_indices.astype(bool)
+            ]
             data = self.data[active_indices.astype(bool), foi]
             bin_limits = self.global_bin_limits["feature_" + str(foi)]
 
             params = utils.compute_ale_params(data, data_effect, bin_limits)
 
-            xx = np.linspace(params["limits"][0], params["limits"][-1], points_for_mean_heterogeneity)
-            var = utils.apply_bin_value(x=xx, bin_limits=params["limits"], bin_value=params["bin_variance"])
+            xx = np.linspace(
+                params["limits"][0], params["limits"][-1], points_for_mean_heterogeneity
+            )
+            var = utils.apply_bin_value(
+                x=xx, bin_limits=params["limits"], bin_value=params["bin_variance"]
+            )
             return np.mean(var)
+
         return heter
 
     def fit(
@@ -331,7 +371,7 @@ class RegionalALE(RegionalEffectBase):
         candidate_conditioning_features: typing.Union["str", list] = "all",
         space_partitioner: typing.Union[str, effector.space_partitioning.Best] = "best",
         binning_method: typing.Union[str, ap.Fixed] = "fixed",
-        points_for_mean_heterogeneity: int = 30
+        points_for_mean_heterogeneity: int = 30,
     ):
         """
         Find subregions by minimizing the ALE-based heterogeneity.
@@ -357,19 +397,35 @@ class RegionalALE(RegionalEffectBase):
             points_for_mean_heterogeneity: number of equidistant points along the feature axis used for computing the mean heterogeneity
         """
         if isinstance(space_partitioner, str):
-            space_partitioner = effector.space_partitioning.return_default(space_partitioner)
+            space_partitioner = effector.space_partitioning.return_default(
+                space_partitioner
+            )
 
-        assert space_partitioner.min_points_per_subregion >= 2, "min_points_per_subregion must be >= 2"
+        assert space_partitioner.min_points_per_subregion >= 2, (
+            "min_points_per_subregion must be >= 2"
+        )
         features = helpers.prep_features(features, self.dim)
         for feat in tqdm(features):
             # fit global method
-            global_ale = ALE(self.data, self.model, nof_instances="all", axis_limits=self.axis_limits)
-            global_ale.fit(features=feat, binning_method=binning_method, centering=False)
-            self.global_data_effect["feature_" + str(feat)] = global_ale.data_effect_ale["feature_" + str(feat)]
-            self.global_bin_limits["feature_" + str(feat)] = global_ale.bin_limits["feature_" + str(feat)]
+            global_ale = ALE(
+                self.data, self.model, nof_instances="all", axis_limits=self.axis_limits
+            )
+            global_ale.fit(
+                features=feat, binning_method=binning_method, centering=False
+            )
+            self.global_data_effect["feature_" + str(feat)] = (
+                global_ale.data_effect_ale["feature_" + str(feat)]
+            )
+            self.global_bin_limits["feature_" + str(feat)] = global_ale.bin_limits[
+                "feature_" + str(feat)
+            ]
 
             # create heterogeneity function
-            heter = self._create_heterogeneity_function(feat, space_partitioner.min_points_per_subregion, points_for_mean_heterogeneity)
+            heter = self._create_heterogeneity_function(
+                feat,
+                space_partitioner.min_points_per_subregion,
+                points_for_mean_heterogeneity,
+            )
 
             # fit feature
             self._fit_feature(
@@ -383,10 +439,14 @@ class RegionalALE(RegionalEffectBase):
         all_arguments.pop("self")
 
         # region splitting arguments are the first 8 arguments
-        self.kwargs_subregion_detection = {k: all_arguments[k] for k in list(all_arguments.keys())[:3]}
+        self.kwargs_subregion_detection = {
+            k: all_arguments[k] for k in list(all_arguments.keys())[:3]
+        }
 
         # centering, points_for_centering, use_vectorized
-        self.kwargs_fitting = {k:v for k,v in all_arguments.items() if k in ["binnning_method"]}
+        self.kwargs_fitting = {
+            k: v for k, v in all_arguments.items() if k in ["binnning_method"]
+        }
 
     def plot(
         self,
@@ -402,4 +462,3 @@ class RegionalALE(RegionalEffectBase):
         kwargs = locals()
         kwargs.pop("self")
         self._plot(kwargs)
-

--- a/effector/regional_effect_pdp.py
+++ b/effector/regional_effect_pdp.py
@@ -1,11 +1,12 @@
 import typing
+
 import numpy as np
+from tqdm import tqdm
 
 import effector.space_partitioning
-from effector.regional_effect import RegionalEffectBase
 from effector import helpers
 from effector.global_effect_pdp import PDP, DerPDP
-from tqdm import tqdm
+from effector.regional_effect import RegionalEffectBase
 
 BIG_M = helpers.BIG_M
 
@@ -50,9 +51,8 @@ class RegionalPDPBase(RegionalEffectBase):
             yy = self.y_ice["feature_" + str(foi)][active_indices.astype(bool), :]
             z = np.var(yy, axis=0)
             return np.mean(z)
+
         return heter
-
-
 
 
 class RegionalPDP(RegionalPDPBase):
@@ -168,9 +168,13 @@ class RegionalPDP(RegionalPDPBase):
         """
 
         if isinstance(space_partitioner, str):
-            space_partitioner = effector.space_partitioning.return_default(space_partitioner)
+            space_partitioner = effector.space_partitioning.return_default(
+                space_partitioner
+            )
 
-        assert space_partitioner.min_points_per_subregion >= 2, "min_points_per_subregion must be >= 2"
+        assert space_partitioner.min_points_per_subregion >= 2, (
+            "min_points_per_subregion must be >= 2"
+        )
         features = helpers.prep_features(features, self.dim)
         for feat in tqdm(features):
             # define the global method
@@ -183,19 +187,23 @@ class RegionalPDP(RegionalPDPBase):
                 use_vectorized=use_vectorized,
             )
 
-            xx = np.linspace(self.axis_limits[:, feat][0], self.axis_limits[:, feat][1], points_for_mean_heterogeneity)
+            xx = np.linspace(
+                self.axis_limits[:, feat][0],
+                self.axis_limits[:, feat][1],
+                points_for_mean_heterogeneity,
+            )
             y_ice = pdp.eval(
-                    feature=feat,
-                    xs=xx,
-                    heterogeneity=True,
-                    centering=True,
-                    use_vectorized=use_vectorized,
-                    return_all=True
-                )
+                feature=feat,
+                xs=xx,
+                heterogeneity=True,
+                centering=True,
+                use_vectorized=use_vectorized,
+                return_all=True,
+            )
             self.y_ice["feature_" + str(feat)] = y_ice.T
 
             heter = self._create_heterogeneity_function(
-                foi = feat,
+                foi=feat,
                 min_points=space_partitioner.min_points_per_subregion,
             )
 
@@ -210,11 +218,19 @@ class RegionalPDP(RegionalPDPBase):
         all_arguments.pop("self")
 
         # region splitting arguments are the first 8 arguments
-        self.kwargs_subregion_detection = {k: all_arguments[k] for k in list(all_arguments.keys())[:3]}
-        self.kwargs_subregion_detection["points_for_mean_heterogeneity"] = points_for_mean_heterogeneity
+        self.kwargs_subregion_detection = {
+            k: all_arguments[k] for k in list(all_arguments.keys())[:3]
+        }
+        self.kwargs_subregion_detection["points_for_mean_heterogeneity"] = (
+            points_for_mean_heterogeneity
+        )
 
         # centering, points_for_centering, use_vectorized
-        self.kwargs_fitting = {k:v for k,v in all_arguments.items() if k in ["centering", "points_for_centering", "use_vectorized"]}
+        self.kwargs_fitting = {
+            k: v
+            for k, v in all_arguments.items()
+            if k in ["centering", "points_for_centering", "use_vectorized"]
+        }
 
     def plot(
         self,
@@ -352,13 +368,23 @@ class RegionalDerPDP(RegionalPDPBase):
         """
 
         if isinstance(space_partitioner, str):
-            space_partitioner = effector.space_partitioning.return_default(space_partitioner)
+            space_partitioner = effector.space_partitioning.return_default(
+                space_partitioner
+            )
 
-        assert space_partitioner.min_points_per_subregion >= 2, "min_points_per_subregion must be >= 2"
+        assert space_partitioner.min_points_per_subregion >= 2, (
+            "min_points_per_subregion must be >= 2"
+        )
         features = helpers.prep_features(features, self.dim)
         for feat in tqdm(features):
             # define the global method
-            pdp = DerPDP(self.data, self.model, self.model_jac, self.axis_limits, nof_instances="all")
+            pdp = DerPDP(
+                self.data,
+                self.model,
+                self.model_jac,
+                self.axis_limits,
+                nof_instances="all",
+            )
 
             pdp.fit(
                 features=feat,
@@ -366,19 +392,23 @@ class RegionalDerPDP(RegionalPDPBase):
                 use_vectorized=use_vectorized,
             )
 
-            xx = np.linspace(self.axis_limits[:, feat][0], self.axis_limits[:, feat][1], points_for_mean_heterogeneity)
+            xx = np.linspace(
+                self.axis_limits[:, feat][0],
+                self.axis_limits[:, feat][1],
+                points_for_mean_heterogeneity,
+            )
             y_ice = pdp.eval(
-                    feature=feat,
-                    xs=xx,
-                    heterogeneity=True,
-                    centering=False,
-                    use_vectorized=use_vectorized,
-                    return_all=True
-                )
+                feature=feat,
+                xs=xx,
+                heterogeneity=True,
+                centering=False,
+                use_vectorized=use_vectorized,
+                return_all=True,
+            )
             self.y_ice["feature_" + str(feat)] = y_ice.T
 
             heter = self._create_heterogeneity_function(
-                foi = feat,
+                foi=feat,
                 min_points=space_partitioner.min_points_per_subregion,
             )
 
@@ -393,11 +423,19 @@ class RegionalDerPDP(RegionalPDPBase):
         all_arguments.pop("self")
 
         # region splitting arguments are the first 8 arguments
-        self.kwargs_subregion_detection = {k: all_arguments[k] for k in list(all_arguments.keys())[:3]}
-        self.kwargs_subregion_detection["points_for_mean_heterogeneity"] = points_for_mean_heterogeneity
+        self.kwargs_subregion_detection = {
+            k: all_arguments[k] for k in list(all_arguments.keys())[:3]
+        }
+        self.kwargs_subregion_detection["points_for_mean_heterogeneity"] = (
+            points_for_mean_heterogeneity
+        )
 
         # centering, points_for_centering, use_vectorized
-        self.kwargs_fitting = {k:v for k,v in all_arguments.items() if k in ["centering", "points_for_centering", "use_vectorized"]}
+        self.kwargs_fitting = {
+            k: v
+            for k, v in all_arguments.items()
+            if k in ["centering", "points_for_centering", "use_vectorized"]
+        }
 
     def plot(
         self,

--- a/effector/regional_effect_shap.py
+++ b/effector/regional_effect_shap.py
@@ -1,15 +1,13 @@
 import typing
+from typing import Callable, List, Optional, Union
 
-import effector
-from effector.regional_effect import RegionalEffectBase
-from effector import helpers
 import numpy as np
 from tqdm import tqdm
-from typing import Callable, Optional, Union, List
+
+import effector
 from effector import axis_partitioning as ap
-from effector import utils
-
-
+from effector import helpers, utils
+from effector.regional_effect import RegionalEffectBase
 
 
 class RegionalShapDP(RegionalEffectBase):
@@ -110,18 +108,26 @@ class RegionalShapDP(RegionalEffectBase):
 
             data = self.data[active_indices.astype(bool), :]
             shap_values = self.global_shap_values[active_indices.astype(bool), :]
-            shap_dp = effector.ShapDP(data, self.model, self.axis_limits, "all", shap_values=shap_values)
+            shap_dp = effector.ShapDP(
+                data, self.model, self.axis_limits, "all", shap_values=shap_values
+            )
 
             try:
-                shap_dp.fit(features=foi, binning_method=binning_method, centering=False)
+                shap_dp.fit(
+                    features=foi, binning_method=binning_method, centering=False
+                )
             except utils.AllBinsHaveAtMostOnePointError as e:
-                print(f"RegionalShapDP here: At a particular split, some bins had at most one point. I reject this split. \n Error: {e}")
+                print(
+                    f"RegionalShapDP here: At a particular split, some bins had at most one point. I reject this split. \n Error: {e}"
+                )
                 return self.big_m
             except Exception as e:
-                print(f"RegionalShapDP here: An unexpected error occurred. I reject this split. \n Error: {e}")
+                print(
+                    f"RegionalShapDP here: An unexpected error occurred. I reject this split. \n Error: {e}"
+                )
                 return self.big_m
 
-            mean_spline = shap_dp.feature_effect["feature_" + str(foi)]["spline_mean"]
+            _mean_spline = shap_dp.feature_effect["feature_" + str(foi)]["spline_mean"]
 
             xs = np.linspace(self.axis_limits[0, foi], self.axis_limits[1, foi], 30)
             _, z = shap_dp.eval(feature=foi, xs=xs, centering=False, heterogeneity=True)
@@ -134,7 +140,9 @@ class RegionalShapDP(RegionalEffectBase):
         self,
         features: typing.Union[int, str, list],
         candidate_conditioning_features: typing.Union["str", list] = "all",
-        space_partitioner: typing.Union["str", effector.space_partitioning.Best] = "best",
+        space_partitioner: typing.Union[
+            "str", effector.space_partitioning.Best
+        ] = "best",
         binning_method: Union[str, ap.Greedy, ap.Fixed] = "greedy",
         budget: int = 512,
         shap_explainer_kwargs: Optional[dict] = None,
@@ -247,26 +255,34 @@ class RegionalShapDP(RegionalEffectBase):
         """
 
         if isinstance(space_partitioner, str):
-            space_partitioner = effector.space_partitioning.return_default(space_partitioner)
+            space_partitioner = effector.space_partitioning.return_default(
+                space_partitioner
+            )
 
-        assert space_partitioner.min_points_per_subregion >= 2, "min_points_per_subregion must be >= 2"
+        assert space_partitioner.min_points_per_subregion >= 2, (
+            "min_points_per_subregion must be >= 2"
+        )
         features = helpers.prep_features(features, self.dim)
 
         for feat in tqdm(features):
             # assert global SHAP values are available
             if self.global_shap_values is None:
-                global_shap_dp = effector.ShapDP(self.data, self.model, self.axis_limits, "all", backend=self.backend)
+                global_shap_dp = effector.ShapDP(
+                    self.data, self.model, self.axis_limits, "all", backend=self.backend
+                )
                 global_shap_dp.fit(
                     feat,
                     centering=False,
                     binning_method=binning_method,
                     budget=budget,
                     shap_explainer_kwargs=shap_explainer_kwargs,
-                    shap_explanation_kwargs=shap_explanation_kwargs
+                    shap_explanation_kwargs=shap_explanation_kwargs,
                 )
                 self.global_shap_values = global_shap_dp.shap_values
 
-            heter = self._create_heterogeneity_function(feat, space_partitioner.min_points_per_subregion, binning_method)
+            heter = self._create_heterogeneity_function(
+                feat, space_partitioner.min_points_per_subregion, binning_method
+            )
 
             self._fit_feature(
                 feat,
@@ -279,28 +295,31 @@ class RegionalShapDP(RegionalEffectBase):
         all_arguments.pop("self")
 
         # region splitting arguments are the first 3 arguments
-        self.kwargs_subregion_detection = {k: all_arguments[k] for k in list(all_arguments.keys())[:3]}
+        self.kwargs_subregion_detection = {
+            k: all_arguments[k] for k in list(all_arguments.keys())[:3]
+        }
 
         # fit kwargs
         self.kwargs_fitting = {
             "binning_method": binning_method,
             "budget": budget,
             "shap_explainer_kwargs": shap_explainer_kwargs,
-            "shap_explanation_kwargs": shap_explanation_kwargs
+            "shap_explanation_kwargs": shap_explanation_kwargs,
         }
 
-    def plot(self,
-             feature,
-             node_idx,
-             heterogeneity="shap_values",
-             centering=True,
-             nof_points=30,
-             scale_x_list=None,
-             scale_y=None,
-             nof_shap_values='all',
-             show_avg_output=False,
-             y_limits=None,
-             only_shap_values=False
+    def plot(
+        self,
+        feature,
+        node_idx,
+        heterogeneity="shap_values",
+        centering=True,
+        nof_points=30,
+        scale_x_list=None,
+        scale_y=None,
+        nof_shap_values="all",
+        show_avg_output=False,
+        y_limits=None,
+        only_shap_values=False,
     ):
         """
         Plot the regional SHAP.

--- a/effector/space_partitioning.py
+++ b/effector/space_partitioning.py
@@ -1,5 +1,7 @@
 import typing
+
 import numpy as np
+
 from effector import helpers, utils
 from effector.tree import Tree
 
@@ -95,8 +97,8 @@ class Base:
         pos = np.linspace(start, stop, nof_splits + 1)
         return pos[1:-1]
 
-    def _flatten_list(self, l):
-        return [item for sublist in l for item in sublist]
+    def _flatten_list(self, nested_list):
+        return [item for sublist in nested_list for item in sublist]
 
     @staticmethod
     def _get_comparison_symbol(foc_type, i):
@@ -108,7 +110,6 @@ class Base:
 
 
 class Best(Base):
-
     def __init__(
         self,
         min_heterogeneity_decrease_pcg: float = 0.1,
@@ -301,7 +302,6 @@ class Best(Base):
         i, j = np.unravel_index(
             np.argmin(matrix_weighted_heter, axis=None), matrix_weighted_heter.shape
         )
-        feature = ccf[i]
         position = candidate_split_positions[i][j]
 
         after_split_active_indices_list = self._split_dataset(
@@ -595,7 +595,7 @@ class BestLevelWise(Base):
                 optimal_splits = splits[1:]
             else:
                 # find first negative split
-                first_negative = np.where(split_valid == False)[0][0]
+                first_negative = np.where(~split_valid)[0][0]
 
                 # if first negative is the first split, return nothing
                 if first_negative == 0:
@@ -631,7 +631,6 @@ class BestLevelWise(Base):
         splits = self.important_splits if only_important else self.splits[1:]
 
         for i, split in enumerate(splits):
-
             # nof nodes to add
             nodes_to_add = len(split["after_split_nof_instances"])
 

--- a/effector/tree.py
+++ b/effector/tree.py
@@ -40,9 +40,9 @@ class Tree:
         if parent is None:
             return name
 
-        assert (
-            comp is not None and pos is not None
-        ), "Comparison and position must be provided if parent is specified."
+        assert comp is not None and pos is not None, (
+            "Comparison and position must be provided if parent is specified."
+        )
 
         name = f"{name} {self._comparison_str(comp)} {pos}"
 

--- a/effector/utils.py
+++ b/effector/utils.py
@@ -1,6 +1,8 @@
-import typing
-import numpy as np
 import copy
+import typing
+
+import numpy as np
+
 from effector import helpers
 
 BIG_M = helpers.BIG_M
@@ -9,13 +11,14 @@ EPS = helpers.EPS
 
 class AllBinsHaveAtMostOnePointError(ValueError):
     """Custom exception raised when all values in the input are NaN."""
+
     pass
 
 
 def compute_local_effects(
     data: np.ndarray, model: typing.Callable, limits: np.ndarray, feature: int
 ) -> np.ndarray:
-    """Compute the local effects, permuting the feature of interest using the bin limits.
+    r"""Compute the local effects, permuting the feature of interest using the bin limits.
 
     Notes:
         The function (a) allocates the points in the bins based on the feature of interest (foi)
@@ -112,7 +115,7 @@ def filter_points_in_bin(
 def compute_bin_effect(
     xs: np.ndarray, df_dxs: np.ndarray, limits: np.ndarray
 ) -> typing.Tuple[np.ndarray, np.ndarray]:
-    """Compute the mean effect in each bin.
+    r"""Compute the mean effect in each bin.
 
     Notes:
         The function (a) allocates the instances in the bins and (b) aggregates the instance-level effects to compute
@@ -168,7 +171,7 @@ def compute_bin_effect(
 def compute_bin_variance(
     xs: np.ndarray, df_dxs: np.ndarray, limits: np.ndarray, bin_effect_mean: np.ndarray
 ) -> np.ndarray:
-    """
+    r"""
     Compute the variance of the effect in each bin.
 
     Notes:
@@ -281,9 +284,9 @@ def fill_nans(x: np.ndarray) -> np.ndarray:
 
 
 def apply_bin_value(
-        x: np.ndarray,
-        bin_limits: np.ndarray,
-        bin_value: np.ndarray,
+    x: np.ndarray,
+    bin_limits: np.ndarray,
+    bin_value: np.ndarray,
 ):
     """Apply the bin effect to the points.
 
@@ -306,15 +309,12 @@ def apply_bin_value(
 
     # add the first and last bin value to the bin value
     bin_value = np.concatenate(
-        [
-            bin_value[0, np.newaxis],
-            bin_value,
-            bin_value[-1, np.newaxis]
-        ]
+        [bin_value[0, np.newaxis], bin_value, bin_value[-1, np.newaxis]]
     )
 
     # for each point return the bin effect
     return bin_value[ind]
+
 
 def compute_accumulated_effect(
     x: np.ndarray,
@@ -323,7 +323,7 @@ def compute_accumulated_effect(
     dx: np.ndarray,
     square: bool = False,
 ) -> np.ndarray:
-    """Compute the accumulated effect at each point `x`.
+    r"""Compute the accumulated effect at each point `x`.
 
     Notes:
         The function implements the following formula:
@@ -404,7 +404,9 @@ def compute_accumulated_effect(
     return y
 
 
-def compute_ale_params(xs: np.ndarray, bin_values: np.ndarray, bin_limits: np.ndarray) -> dict:
+def compute_ale_params(
+    xs: np.ndarray, bin_values: np.ndarray, bin_limits: np.ndarray
+) -> dict:
     """
     Compute all important parameters for the ALE plot.
 
@@ -433,7 +435,9 @@ def compute_ale_params(xs: np.ndarray, bin_values: np.ndarray, bin_limits: np.nd
 
     """
     # compute bin-widths
-    dx = np.array([bin_limits[i + 1] - bin_limits[i] for i in range(len(bin_limits) - 1)])
+    dx = np.array(
+        [bin_limits[i + 1] - bin_limits[i] for i in range(len(bin_limits) - 1)]
+    )
 
     # compute mean effect on each bin
     bin_effect_nans, points_per_bin = compute_bin_effect(xs, bin_values, bin_limits)
@@ -485,7 +489,7 @@ def get_feature_types(
 def compute_jacobian_numerically(
     model: typing.Callable, data: np.ndarray, eps: float = 1e-8
 ) -> np.ndarray:
-    """Compute the Jacobian of the model using finite differences.
+    r"""Compute the Jacobian of the model using finite differences.
 
     Notes:
         The function computes the Jacobian of the model using finite differences. The formula is:

--- a/effector/utils_integrate.py
+++ b/effector/utils_integrate.py
@@ -1,5 +1,5 @@
-import scipy.integrate as integrate
 import numpy as np
+import scipy.integrate as integrate
 
 
 def integrate_1d_quad(func, start, stop):
@@ -32,7 +32,7 @@ def integrate_1d_linspace(func, start, stop):
 
 
 def mean_1d_linspace(func, start, stop, nof_points=100):
-    """Computes \int_{start}^{stop} func(x) dx
+    r"""Computes \int_{start}^{stop} func(x) dx
     func(x) -> y: gets 1D np.array and return 1D np.array
 
     :param s: index of feature

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -1,10 +1,7 @@
-import matplotlib.pyplot as plt
-import numpy as np
 import typing
 
-import scipy.interpolate
-
-from effector import helpers
+import matplotlib.pyplot as plt
+import numpy as np
 
 
 def trans_affine(x, mu, std):
@@ -56,10 +53,7 @@ def ale_plot(
 
     """
     # assert ale_params contains needed quantities
-    assert all(
-        name in ale_params
-        for name in ["limits", "dx", "bin_effect"]
-    )
+    assert all(name in ale_params for name in ["limits", "dx", "bin_effect"])
 
     x = np.linspace(ale_params["limits"][0], ale_params["limits"][-1], 1000)
     y, std = accum_effect_func(feature, x, True, centering)
@@ -257,7 +251,6 @@ def plot_pdp_ice(
         plt.show(block=False)
     else:
         return fig, ax
-
 
 
 def plot_shap(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,22 @@ docs = [
 dev = [
     {include-group = "test"},
     {include-group = "docs"},
-    "black",
-    "flake8",
-    "isort",
+    "ruff",
 ]
 
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselected on the merge gate with '-m \"not slow\"')",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"effector/__init__.py" = ["F401"]
+"tests/*" = ["E731", "F403", "F405"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ test = [
     "coverage",
     "shap",
     "shapiq",
+    "numba>=0.60; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    "ucimlrepo",
 ]
 docs = [
     "mkdocs",

--- a/tests/notebook_execution.py
+++ b/tests/notebook_execution.py
@@ -1,22 +1,26 @@
 import os
+
 import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor
 import pytest
+from nbconvert.preprocessors import ExecutePreprocessor
 
 
-@pytest.mark.parametrize("notebook_filename", [
-    os.path.join("./../notebooks/synthetic-examples", file)
-    for file in os.listdir("./../notebooks/synthetic-examples") if file.endswith(".ipynb") and not file.startswith("06_efficiency")
-])
-
-
-
+@pytest.mark.parametrize(
+    "notebook_filename",
+    [
+        os.path.join("./../notebooks/synthetic-examples", file)
+        for file in os.listdir("./../notebooks/synthetic-examples")
+        if file.endswith(".ipynb") and not file.startswith("06_efficiency")
+    ],
+)
 def test_notebook_execution(notebook_filename):
-    with open(notebook_filename, 'r', encoding='utf-8') as f:
+    with open(notebook_filename, "r", encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
-    executor = ExecutePreprocessor(timeout=600, kernel_name='python3')
+    executor = ExecutePreprocessor(timeout=600, kernel_name="python3")
 
     try:
-        executor.preprocess(nb, {'metadata': {'path': './../notebooks/synthetic-examples'}})
+        executor.preprocess(
+            nb, {"metadata": {"path": "./../notebooks/synthetic-examples"}}
+        )
     except Exception as e:
         pytest.fail(f"Notebook {notebook_filename} failed to execute. Error: {e}")

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,6 +1,6 @@
 import numpy as np
-import effector
 
+import effector
 
 np.random.seed(21)
 
@@ -39,12 +39,12 @@ class TestExample2:
         if seed is not None:
             np.random.seed(seed)
 
-        x1 = np.concatenate((np.array([0]),
-                             np.random.uniform(0, 1, size=int(n-2)),
-                             np.array([1])))
-        x2 = np.concatenate((np.array([0]),
-                             np.random.uniform(0, 1, size=int(n-2)),
-                             np.array([1])))
+        x1 = np.concatenate(
+            (np.array([0]), np.random.uniform(0, 1, size=int(n - 2)), np.array([1]))
+        )
+        x2 = np.concatenate(
+            (np.array([0]), np.random.uniform(0, 1, size=int(n - 2)), np.array([1]))
+        )
         return np.stack([x1, x2]).T
 
     @staticmethod
@@ -57,11 +57,11 @@ class TestExample2:
 
     @staticmethod
     def ale_1(x):
-        return 2*x - 1
+        return 2 * x - 1
 
     @staticmethod
     def ale_2(x):
-        return -4*x + 2
+        return -4 * x + 2
 
     def test_dale(self):
         # generate data
@@ -82,16 +82,18 @@ class TestExample2:
         assert np.allclose(pred, gt, atol=self.atol)
 
         # DALE variable-size
-        dp = effector.axis_partitioning.DynamicProgramming(max_nof_bins=20, min_points_per_bin=10, cat_limit=1)
+        dp = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=20, min_points_per_bin=10, cat_limit=1
+        )
         dale.fit(binning_method=dp, centering=True)
 
         pred = dale.eval(feature=0, xs=x, centering=True)
         gt = self.ale_1(x)
-        assert np.allclose(pred, gt, atol=1.e-2)
+        assert np.allclose(pred, gt, atol=1.0e-2)
 
         pred = dale.eval(feature=1, xs=x, centering=True)
         gt = self.ale_2(x)
-        assert np.allclose(pred, gt, atol=1.e-2)
+        assert np.allclose(pred, gt, atol=1.0e-2)
 
 
 class TestBinEstimation:
@@ -102,7 +104,6 @@ class TestBinEstimation:
     @staticmethod
     def model(x, par):
         """f(x1, x2) = a + b*x1 + x1x2"""
-        ind_1 = np.logical_and(x[:, 0] >= par[0]["from"], x[:, 0] < par[0]["to"])
         ind_2 = np.logical_and(x[:, 0] >= par[1]["from"], x[:, 0] < par[1]["to"])
         ind_3 = np.logical_and(x[:, 0] >= par[2]["from"], x[:, 0] < par[2]["to"])
         ind_4 = np.logical_and(x[:, 0] >= par[3]["from"], x[:, 0] <= par[3]["to"])
@@ -199,7 +200,9 @@ class TestBinEstimation:
 
         # test Greedy
         min_points = 2
-        est = effector.axis_partitioning.Greedy(init_nof_bins=100, discount=.3, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.Greedy(
+            init_nof_bins=100, discount=0.3, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
 
         assert limits_greedy.size == 3
@@ -208,7 +211,9 @@ class TestBinEstimation:
 
         # test DP
         min_points = 2
-        est = effector.axis_partitioning.DynamicProgramming(max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
 
         assert limits_dp.size == 3
@@ -221,12 +226,16 @@ class TestBinEstimation:
         gt_limits = np.array([0, 1.0])
 
         min_points = 3
-        est = effector.axis_partitioning.Greedy(init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.Greedy(
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_greedy)
 
         min_points = 3
-        est = effector.axis_partitioning.DynamicProgramming(max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_dp)
 
@@ -235,12 +244,16 @@ class TestBinEstimation:
         gt_limits = np.array([0, 1.0])
 
         min_points = 4
-        est = effector.axis_partitioning.Greedy(init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.Greedy(
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_greedy)
 
         min_points = 4
-        est = effector.axis_partitioning.DynamicProgramming(max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_dp)
 
@@ -248,12 +261,16 @@ class TestBinEstimation:
         x, y_grad, axis_limits = self.create_4_data_points()
 
         min_points = 5
-        est = effector.axis_partitioning.Greedy(init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.Greedy(
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert limits_greedy is False
 
         min_points = 5
-        est = effector.axis_partitioning.DynamicProgramming(max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert limits_dp is False
 
@@ -263,7 +280,9 @@ class TestBinEstimation:
 
         # test Greedy
         min_points = 10
-        est = effector.axis_partitioning.Greedy(init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.Greedy(
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert (
             np.sum(
@@ -313,7 +332,9 @@ class TestBinEstimation:
 
         # test DP
         min_points = 10
-        est = effector.axis_partitioning.DynamicProgramming(max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1)
+        est = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+        )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert (
             np.sum(

--- a/tests/test_functional_gam.py
+++ b/tests/test_functional_gam.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
+
 import effector
+
 
 @pytest.mark.slow
 def test_gam():
@@ -15,16 +17,25 @@ def test_gam():
     atol = 0.1
     rtol = 0.1
 
-    data = np.stack([
+    data = np.stack(
+        [
             np.random.rand(N + 1),
             np.random.rand(N + 1),
-        ], axis=1)
+        ],
+        axis=1,
+    )
 
-    model = lambda x: x[:, 0]**3/5 + x[:, 1] ** 2/5
-    model_jac = lambda x: np.stack([3 * x[:, 0]**2/5, 2 * x[:, 1]/5], axis=1)
+    model = lambda x: x[:, 0] ** 3 / 5 + x[:, 1] ** 2 / 5
+    model_jac = lambda x: np.stack([3 * x[:, 0] ** 2 / 5, 2 * x[:, 1] / 5], axis=1)
 
     x = np.linspace(0, 1, T)
-    gt = {"x1": x**3/5, "x2": x**2/5, "heterogeneity": np.zeros_like(x), "x1_der": 3 * x**2/5, "x2_der": 2 * x/5}
+    gt = {
+        "x1": x**3 / 5,
+        "x2": x**2 / 5,
+        "heterogeneity": np.zeros_like(x),
+        "x1_der": 3 * x**2 / 5,
+        "x2_der": 2 * x / 5,
+    }
 
     # Define test cases
     test_cases = [
@@ -35,7 +46,7 @@ def test_gam():
         {"method": effector.ShapDP, "kwargs": {"backend": "shapiq"}},
         {"method": effector.ALE, "kwargs": {}},
         {"method": effector.RHALE, "kwargs": {"model_jac": None}},
-        {"method": effector.RHALE, "kwargs": {"model_jac": model_jac}}
+        {"method": effector.RHALE, "kwargs": {"model_jac": model_jac}},
     ]
 
     for test_case in test_cases:
@@ -48,7 +59,9 @@ def test_gam():
         print(eff)
         for feature in [0, 1]:
             # Evaluate the effector and retrieve results
-            y, heterogeneity = eff.eval(feature=feature, xs=x, heterogeneity=True, centering="zero_start")
+            y, heterogeneity = eff.eval(
+                feature=feature, xs=x, heterogeneity=True, centering="zero_start"
+            )
 
             np.allclose(heterogeneity, gt["heterogeneity"], atol=atol, rtol=rtol)
 

--- a/tests/test_functional_linear.py
+++ b/tests/test_functional_linear.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
+
 import effector
+
 
 @pytest.mark.slow
 def test_linear():
@@ -12,8 +14,8 @@ def test_linear():
 
     N = 100
     T = 100
-    rtol = .1
-    atol = .1
+    rtol = 0.1
+    atol = 0.1
 
     data = np.stack(
         [
@@ -43,7 +45,7 @@ def test_linear():
         {"method": effector.ShapDP, "init_kwargs": {"backend": "shapiq"}},
         {"method": effector.ALE, "init_kwargs": {}},
         {"method": effector.RHALE, "init_kwargs": {}},
-        {"method": effector.RHALE, "init_kwargs": {"model_jac": model_jac}}
+        {"method": effector.RHALE, "init_kwargs": {"model_jac": model_jac}},
     ]
 
     # Iterate through test cases
@@ -55,7 +57,9 @@ def test_linear():
         eff = effector_class(data, model, **kwargs)
 
         # Evaluate the effector and retrieve results
-        y, heterogeneity = eff.eval(feature=0, xs=x, heterogeneity=True, centering="zero_start")
+        y, heterogeneity = eff.eval(
+            feature=0, xs=x, heterogeneity=True, centering="zero_start"
+        )
 
         # Check assertions
         np.allclose(y, x, atol=atol, rtol=rtol)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,17 @@
 import effector
 
+
 def test_models():
     # Test ConditionalInteraction model
     for model in [
         effector.models.ConditionalInteraction(),
         effector.models.DoubleConditionalInteraction(),
         effector.models.ConditionalInteraction4Regions(),
-        effector.models.GeneralInteraction()
+        effector.models.GeneralInteraction(),
     ]:
-        x = effector.datasets.IndependentUniform(dim=3, low=-1, high=1).generate_data(1000, seed=21)
+        x = effector.datasets.IndependentUniform(dim=3, low=-1, high=1).generate_data(
+            1000, seed=21
+        )
 
         # Test predict method
         y_pred = model.predict(x)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,6 +1,7 @@
-import numpy as np
-import effector
 import matplotlib.pyplot as plt
+import numpy as np
+
+import effector
 
 
 def test_plots():

--- a/tests/test_regional_methods.py
+++ b/tests/test_regional_methods.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import effector
 
 
@@ -15,14 +16,15 @@ def test_regional():
         [
             np.random.uniform(-1, 1, N),
             np.random.uniform(-1, 1, N),
-            np.random.randint(0, 2, N)
+            np.random.randint(0, 2, N),
         ],
-        axis=1)
+        axis=1,
+    )
 
     def model(x):
         y = np.zeros_like(x[:, 0])
         ind = np.logical_and(x[:, 1] > 0, x[:, 2] == 0)
-        y[ind] = 5*x[ind, 0]
+        y[ind] = 5 * x[ind, 0]
         return y
 
     def model_jac(x):
@@ -39,7 +41,9 @@ def test_regional():
             reg_eff.fit(0)
             y, std = reg_eff.eval(0, 3, xs, heterogeneity=True, centering=True)
         elif method == "d-pdp":
-            reg_eff = effector.RegionalDerPDP(data, model, model_jac, nof_instances=1000)
+            reg_eff = effector.RegionalDerPDP(
+                data, model, model_jac, nof_instances=1000
+            )
             reg_eff.fit(0)
             y, std = reg_eff.eval(0, 3, xs, heterogeneity=True, centering=False)
         elif method == "ale":
@@ -51,14 +55,17 @@ def test_regional():
             reg_eff.fit(0)
             y, std = reg_eff.eval(0, 3, xs, heterogeneity=True)
         elif method == "shap":
-            reg_eff = effector.RegionalShapDP(data, model, nof_instances=100, backend="shap")
+            reg_eff = effector.RegionalShapDP(
+                data, model, nof_instances=100, backend="shap"
+            )
             reg_eff.fit(0)
             y, std = reg_eff.eval(0, 3, xs, heterogeneity=True)
         elif method == "shapiq":
-            reg_eff = effector.RegionalShapDP(data, model, nof_instances=100, backend="shapiq")
+            reg_eff = effector.RegionalShapDP(
+                data, model, nof_instances=100, backend="shapiq"
+            )
             reg_eff.fit(0)
             y, std = reg_eff.eval(0, 3, xs, heterogeneity=True)
 
-
-        np.allclose(y, 5*xs, atol=0.1, rtol=0.1)
+        np.allclose(y, 5 * xs, atol=0.1, rtol=0.1)
         np.allclose(std, 0, atol=0.1, rtol=0.1)

--- a/tests/test_space_partitioning.py
+++ b/tests/test_space_partitioning.py
@@ -1,5 +1,6 @@
-from effector.space_partitioning import *
 import numpy as np
+
+from effector.space_partitioning import *
 
 
 def test_space_partitioning():

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,5 +1,7 @@
-from effector.tree import Tree, Node
 import numpy as np
+
+from effector.tree import Tree
+
 
 def test_tree_get_level_stats():
     tree = Tree()
@@ -18,7 +20,7 @@ def test_tree_get_level_stats():
         "active_indices": np.array([True, False, True, False, True]),
         "foc_split_position": 3.0,
         "foc_type": "cont",
-        "candidate_split_positions": [0.0, 1.0, 2.0, 3.0, 4., 5.],
+        "candidate_split_positions": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
         "range": [0, 5],
         "level": 1,
     }
@@ -31,7 +33,7 @@ def test_tree_get_level_stats():
         "active_indices": np.array([False, True, False, True, False]),
         "foc_split_position": 3.0,
         "foc_type": "cont",
-        "candidate_split_positions": [0.0, 1.0, 2.0, 3.0, 4., 5.],
+        "candidate_split_positions": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
         "range": [0, 5],
         "level": 1,
     }
@@ -39,11 +41,7 @@ def test_tree_get_level_stats():
     tree.add_node("x2", "x1", info2)
     tree.add_node("x3", "x1", info3)
 
-    scale_x_list=[
-        {"mean": 3, "std":2},
-        {"mean": 3, "std":3},
-        {"mean": 3, "std":2}
-    ]
+    scale_x_list = [{"mean": 3, "std": 2}, {"mean": 3, "std": 3}, {"mean": 3, "std": 2}]
 
     tree.show_full_tree(scale_x_list)
     tree.show_level_stats()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -13,30 +13,16 @@ def test_pdp_1d_vectorized():
     N = 10
     T = 100
 
-    data = np.stack([
-        np.random.rand(N + 1),
-        np.linspace(0, 1, N+1)
-    ], axis=1)
+    data = np.stack([np.random.rand(N + 1), np.linspace(0, 1, N + 1)], axis=1)
 
     model = lambda x: x[:, 1] ** 2
-    model_jac = lambda x: (
-        np.stack(
-            [
-            np.zeros_like(x[:, 1]),
-            2 * x[:, 1]
-            ],
-        axis=1
-    ))
+    model_jac = lambda x: np.stack([np.zeros_like(x[:, 1]), 2 * x[:, 1]], axis=1)
 
     x = np.linspace(0, 1, T)
 
     # test the pdp version
     yy = effector.global_effect_pdp.ice_vectorized(
-        model=model,
-        model_jac=None,
-        data=data,
-        x=x,
-        feature=1
+        model=model, model_jac=None, data=data, x=x, feature=1
     )
 
     # ground truth
@@ -47,15 +33,10 @@ def test_pdp_1d_vectorized():
 
     # test the jacobian version
     yy = effector.global_effect_pdp.ice_vectorized(
-        model=model,
-        model_jac=model_jac,
-        data=data,
-        x=x,
-        feature=1,
-        return_d_ice=True
+        model=model, model_jac=model_jac, data=data, x=x, feature=1, return_d_ice=True
     )
 
-    yy_gt = np.stack([2*x for _ in range(N + 1)], axis=1)
+    yy_gt = np.stack([2 * x for _ in range(N + 1)], axis=1)
     diff = np.abs(yy_gt - yy)
     assert np.all(diff < 1e-6)
 
@@ -68,8 +49,6 @@ def test_pdp_1d_vectorized():
         feature=1,
         return_d_ice=True,
     )
-    yy_gt = np.stack([2*x for _ in range(N + 1)], axis=1)
+    yy_gt = np.stack([2 * x for _ in range(N + 1)], axis=1)
     diff = np.abs(yy - yy_gt)
     assert np.all(diff < 1e-6)
-
-

--- a/uv.lock
+++ b/uv.lock
@@ -220,50 +220,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[[package]]
 name = "bleach"
 version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -991,10 +947,7 @@ tutorials = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
     { name = "coverage" },
-    { name = "flake8" },
-    { name = "isort" },
     { name = "mkdocs" },
     { name = "mkdocs-glightbox" },
     { name = "mkdocs-material" },
@@ -1003,6 +956,7 @@ dev = [
     { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
     { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "shap", version = "0.51.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1052,10 +1006,7 @@ provides-extras = ["shap", "tutorials", "all"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black" },
     { name = "coverage" },
-    { name = "flake8" },
-    { name = "isort" },
     { name = "mkdocs" },
     { name = "mkdocs-glightbox" },
     { name = "mkdocs-material" },
@@ -1064,6 +1015,7 @@ dev = [
     { name = "numba", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=0.60" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
     { name = "shap" },
     { name = "shapiq" },
     { name = "ucimlrepo" },
@@ -1131,20 +1083,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
 ]
 
 [[package]]
@@ -1604,15 +1542,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -2497,15 +2426,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2767,15 +2687,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -3950,15 +3861,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4148,15 +4050,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4247,45 +4140,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -4808,6 +4662,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -617,8 +617,8 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -941,8 +941,8 @@ dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1000,6 +1000,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1007,6 +1008,7 @@ dev = [
     { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "shapiq", version = "1.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "shapiq", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ucimlrepo" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1017,6 +1019,7 @@ docs = [
 ]
 test = [
     { name = "coverage" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "shap", version = "0.49.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1024,6 +1027,7 @@ test = [
     { name = "shap", version = "0.52.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "shapiq", version = "1.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "shapiq", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ucimlrepo" },
 ]
 
 [package.metadata]
@@ -1057,10 +1061,12 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
+    { name = "numba", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=0.60" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "shap" },
     { name = "shapiq" },
+    { name = "ucimlrepo" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1071,10 +1077,12 @@ docs = [
 ]
 test = [
     { name = "coverage" },
+    { name = "numba", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=0.60" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "shap" },
     { name = "shapiq" },
+    { name = "ucimlrepo" },
 ]
 
 [[package]]
@@ -1340,8 +1348,8 @@ version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
 wheels = [
@@ -1964,8 +1972,8 @@ dependencies = [
     { name = "h5py" },
     { name = "ml-dtypes" },
     { name = "namex" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "optree" },
     { name = "packaging" },
     { name = "rich" },
@@ -2137,8 +2145,8 @@ version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -2160,6 +2168,15 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/66/6b2c49c7c68da48d17059882fdb9ad9ac9e5ac3f22b00874d7996e3c44a8/llvmlite-0.36.0.tar.gz", hash = "sha256:765128fdf5f149ed0b889ffbe2b05eb1717f8e20a5c87fa2b4018fbcce0fcfc9", size = 126219, upload-time = "2021-03-12T13:41:52.064Z" }
+
+[[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
@@ -2169,18 +2186,9 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/66/6b2c49c7c68da48d17059882fdb9ad9ac9e5ac3f22b00874d7996e3c44a8/llvmlite-0.36.0.tar.gz", hash = "sha256:765128fdf5f149ed0b889ffbe2b05eb1717f8e20a5c87fa2b4018fbcce0fcfc9", size = 126219, upload-time = "2021-03-12T13:41:52.064Z" }
-
-[[package]]
-name = "llvmlite"
-version = "0.47.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
     "python_full_version < '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
@@ -2420,8 +2428,8 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -2676,8 +2684,8 @@ version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -2928,19 +2936,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
-    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" } },
@@ -2955,11 +2951,24 @@ name = "numba"
 version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version < '3.11'",
 ]
 dependencies = [
     { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
 wheels = [
@@ -3059,6 +3068,15 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
+    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
     "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -3147,61 +3165,16 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "(python_full_version >= '3.14' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
-    "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
     { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
-    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
-    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
     { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
     { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
-    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
-    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
     { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
     { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
-    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
-    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
     { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
 ]
 
 [[package]]
@@ -3373,8 +3346,8 @@ dependencies = [
     { name = "liac-arff" },
     { name = "minio" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "packaging" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3615,8 +3588,8 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "python-dateutil" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
@@ -4933,8 +4906,8 @@ resolution-markers = [
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "threadpoolctl" },
@@ -5128,7 +5101,8 @@ resolution-markers = [
     "(python_full_version == '3.12.*' and platform_machine != 'x86_64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -5313,8 +5287,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cloudpickle" },
-    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
     { name = "packaging" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" } },
@@ -5379,9 +5355,12 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cloudpickle" },
-    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "llvmlite", version = "0.36.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numba", version = "0.53.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "packaging" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" } },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" } },
@@ -5460,7 +5439,8 @@ dependencies = [
     { name = "joblib" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" } },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" } },
     { name = "pillow" },
     { name = "requests" },
@@ -5558,8 +5538,8 @@ dependencies = [
     { name = "lightgbm" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
@@ -5587,8 +5567,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "nvidia-ml-py" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -5621,8 +5601,8 @@ dependencies = [
     { name = "libclang" },
     { name = "ml-dtypes" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin')" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "opt-einsum" },
     { name = "packaging" },
     { name = "protobuf" },


### PR DESCRIPTION
## Summary

Walked through the existing GitHub Actions setup item by item and modernized it:

- **publish_to_pypi.yml**: switched from pip/`actions/setup-python` to `uv` for consistency with the other workflows; gated publishing behind (a) a check that the tag points to a commit on `main`, (b) a full test run, and (c) a smoke test that installs the built wheel into a clean venv and imports it; auto-creates a GitHub Release with notes pulled from the matching `CHANGELOG.md` section after a successful publish.
- **run_tests.yml**: added a Python 3.10–3.13 test matrix. This surfaced a real `uv.lock` resolution bug — `shap`'s Mac-only `numba<0.63` cap was being reused as the pin for all platforms (since uv's default fork-strategy minimizes distinct versions across marker-forks), dragging in an unbuildable `llvmlite==0.36.0` on Linux for Python ≥3.11. Fixed by adding an explicit `numba>=0.60` constraint scoped to non-Mac platforms, forcing uv to resolve per-platform. Also added `ucimlrepo` to the `test` dependency group — `test_datasets.py` needs it but it only lived in the `tutorials` extra, so it silently failed on every Python version.
- **Lint**: replaced `black`/`flake8`/`isort` with `ruff` (faster, one tool for format+lint+import-sort), reformatted the codebase, and added a CI gate. Fixed a couple of real bugs ruff surfaced along the way: a latent `NameError` in `regional_effect.py`'s string-based `space_partitioner` fallback (never hit because every subclass pre-resolves the string first), and a copy-paste validation bug in `helpers.py` (`prep_dale_fit_params` validated `max_nof_bins` twice instead of `min_points_per_bin`).
- **Security/hygiene**: pinned `GITHUB_TOKEN` to `contents: read` (least privilege) across all workflows; added `concurrency` groups with `cancel-in-progress` to `run_tests.yml`/`lint.yml` (not to the docs-publish workflow, since it force-pushes to an external repo and canceling mid-push is riskier than letting runs queue).
- **Docs**: now also build (not deploy) on `pull_request`, so a broken mkdocs build is caught before merge instead of after.
- Added `.github/dependabot.yml` for `github-actions` and `pip` ecosystems, weekly.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] Full test suite passes locally on Python 3.10, 3.11, 3.12, 3.13
- [x] Verified the `uv.lock` fix resolves cleanly and `shap`/`shapiq` import correctly on all 4 versions
- [x] CI runs green on this PR (all 4 new/changed workflows: lint, tests matrix, docs PR-build)