### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# [0.2.1] - 2026-07-01
+
+### Changed
+
+- modernized GitHub Actions CI: replaced `black`/`flake8`/`isort` with `ruff`, added a Python 3.10-3.13 test matrix, gated PyPI publishing behind a main-ancestry check + test run + wheel smoke test, added a docs build-check on PRs, pinned workflow permissions, added concurrency cancellation, and added `dependabot.yml`
+- PyPI releases now auto-create a matching GitHub Release with notes from this changelog
+
+### Fixed
+
+- fixed a latent `NameError` in `RegionalEffectBase._fit_feature`'s string-based `space_partitioner` fallback (`effector/regional_effect.py`)
+- fixed `prep_dale_fit_params` validating `max_nof_bins` twice instead of `min_points_per_bin` (`effector/helpers.py`)
+
 # [0.2.0] - 2025-07-21
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ maintainers = [
 license = {text = "MIT License"}
 requires-python = ">=3.10"
 keywords = ["explainability", "interpretability", "machine learning", "deep learning", "regional XAI", "feature effect"]
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 dependencies = [
     "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "effector"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version to 0.2.1 and adds the matching CHANGELOG.md entry for everything merged since the v0.2.0 tag: the CI/lint modernization (#14) plus the two bug fixes it surfaced.

## Test plan

- [x] Test suite passes locally
- [ ] Once merged, tag `v0.2.1` on main to trigger publish_to_pypi.yml