### PR TITLE
feat: add FeatureEffect facade for one-figure method comparison

### DIFF
--- a/effector/__init__.py
+++ b/effector/__init__.py
@@ -1,4 +1,5 @@
 from effector import axis_partitioning, datasets, models, space_partitioning
+from effector.feature_effect import FeatureEffect
 from effector.global_effect_ale import ALE, RHALE
 from effector.global_effect_pdp import PDP, DerPDP
 from effector.global_effect_shap import ShapDP

--- a/effector/feature_effect.py
+++ b/effector/feature_effect.py
@@ -1,0 +1,219 @@
+import warnings
+from typing import Callable, List, Optional, Union
+
+import numpy as np
+
+import effector.helpers as helpers
+import effector.visualization as vis
+from effector.global_effect_ale import ALE, RHALE
+from effector.global_effect_pdp import PDP
+from effector.global_effect_shap import ShapDP
+
+
+class FeatureEffect:
+    """Unified facade to compare global feature-effect methods on a single figure.
+
+    `FeatureEffect` holds the shared ingredients (`data`, `model`, feature/target
+    names, axis limits) once and lazily builds the underlying method objects
+    (`PDP`, `ALE`, `RHALE`, `ShapDP`) on demand. Its `plot` overlays the mean
+    effect of several methods for one feature on the same axis, so they can be
+    compared directly.
+
+    Notes:
+        - All methods share the *same* background data: the data is filtered to
+          `axis_limits` and subsampled to `nof_instances` once, then every method
+          is built on that identical subset. The only difference between the
+          curves is therefore the method itself.
+        - The comparison is meaningful only for *centered* effects (each method
+          uses a different reference level), so `plot` centers by default.
+        - `DerPDP` is intentionally not part of the pool: it lives in derivative
+          units and is not comparable with the output-unit methods.
+    """
+
+    # canonical name -> (class, needs model jacobian)
+    _REGISTRY = {
+        "pdp": (PDP, False),
+        "ale": (ALE, False),
+        "rhale": (RHALE, True),
+        "shapdp": (ShapDP, False),
+    }
+    _ALIASES = {"shap": "shapdp", "shap_dp": "shapdp", "shap-dp": "shapdp"}
+    _DISPLAY = {"pdp": "PDP", "ale": "ALE", "rhale": "RHALE", "shapdp": "SHAP-DP"}
+
+    def __init__(
+        self,
+        data: np.ndarray,
+        model: Callable,
+        model_jac: Optional[Callable] = None,
+        axis_limits: Optional[np.ndarray] = None,
+        nof_instances: Union[int, str] = 1_000,
+        feature_names: Optional[List] = None,
+        target_name: Optional[str] = None,
+    ):
+        """
+        Args:
+            data: the design matrix, shape `(N, D)`
+            model: the black-box model, `Callable` `(N, D) -> (N,)`
+            model_jac: the model Jacobian `(N, D) -> (N, D)`, optional. Needed by
+                `RHALE`; if omitted, `RHALE` falls back to numerical differentiation.
+            axis_limits: `(2, D)` array of per-feature limits, or `None` to infer
+                from the data.
+            nof_instances: number of instances shared across all methods.
+
+                - use an `int` to subsample
+                - use `"all"` to use every instance
+
+            feature_names: list of feature names, or `None` for `["x_0", ...]`
+            target_name: name of the target, or `None` for `"y"`
+        """
+        assert data.ndim == 2
+        self.model = model
+        self.model_jac = model_jac
+        self.dim = data.shape[1]
+
+        # filter to axis limits (or infer them), then subsample ONCE so every
+        # method sees the exact same background data.
+        if axis_limits is not None:
+            assert axis_limits.shape == (2, self.dim)
+            data = data[helpers.indices_within_limits(data, axis_limits), :]
+        else:
+            axis_limits = helpers.axis_limits_from_data(data)
+        self.axis_limits: np.ndarray = axis_limits
+
+        _, indices = helpers.prep_nof_instances(nof_instances, data.shape[0])
+        self.data: np.ndarray = data[indices, :]
+
+        self.feature_names = (
+            helpers.get_feature_names(self.dim)
+            if feature_names is None
+            else feature_names
+        )
+        self.target_name = "y" if target_name is None else target_name
+
+        # lazily instantiated method objects, keyed by canonical name
+        self._methods: dict = {}
+
+    def _canonical(self, name: str) -> str:
+        key = self._ALIASES.get(name.lower(), name.lower())
+        if key not in self._REGISTRY:
+            raise ValueError(
+                "Unknown method '{}'. Supported methods: {} (aliases: {}).".format(
+                    name, sorted(self._REGISTRY), sorted(self._ALIASES)
+                )
+            )
+        return key
+
+    def _get_method(self, name: str, method_kwargs: Optional[dict] = None):
+        """Build (and cache) the underlying effect object for `name`."""
+        key = self._canonical(name)
+        if key in self._methods:
+            return self._methods[key]
+
+        cls, needs_jac = self._REGISTRY[key]
+        kwargs = dict(
+            axis_limits=self.axis_limits,
+            nof_instances="all",  # data is already subsampled in __init__
+            feature_names=self.feature_names,
+            target_name=self.target_name,
+        )
+        if method_kwargs:
+            kwargs.update(method_kwargs)
+
+        if needs_jac:
+            if self.model_jac is None:
+                warnings.warn(
+                    "'{}' uses the model's jacobian, but `model_jac` was not passed "
+                    "to FeatureEffect. Falling back to numerical differentiation "
+                    "(slower and approximate) — pass `model_jac=...` for exact, "
+                    "faster results.".format(self._DISPLAY[key]),
+                    stacklevel=3,
+                )
+            obj = cls(self.data, self.model, self.model_jac, **kwargs)
+        else:
+            obj = cls(self.data, self.model, **kwargs)
+
+        self._methods[key] = obj
+        return obj
+
+    def plot(
+        self,
+        feature: int,
+        methods: Optional[List[str]] = None,
+        centering: Union[bool, str] = True,
+        nof_points: int = 100,
+        scale_x: Optional[dict] = None,
+        scale_y: Optional[dict] = None,
+        y_limits: Optional[List] = None,
+        show_avg_output: bool = False,
+        method_kwargs: Optional[dict] = None,
+        show_plot: bool = True,
+    ):
+        """Overlay the mean effect of several methods for one feature.
+
+        Args:
+            feature: index of the feature to plot
+            methods: list of method names to compare. Supported: `"PDP"`, `"ALE"`,
+                `"RHALE"`, `"ShapDP"` (alias `"SHAP"`). Defaults to
+                `["PDP", "ALE", "RHALE"]` (`ShapDP` is opt-in as it is slower and
+                needs the `shap` package).
+            centering: how to center the curves. The comparison is meaningful only
+                when centered, so `False` is coerced to `"zero_integral"`.
+
+                - `True` / `"zero_integral"`: center around the `y` axis
+                - `"zero_start"`: start each curve from `y=0`
+
+            nof_points: size of the shared evaluation grid
+            scale_x, scale_y: `None` or dict with keys `["mean", "std"]` to map the
+                axes back to the original units
+            y_limits: `None` or tuple, manual y-axis limits
+            show_avg_output: whether to draw the model's average output as a line
+            method_kwargs: optional `{method_name: {**constructor_kwargs}}` to
+                customize individual methods (e.g. `{"ShapDP": {"nof_instances": 300}}`)
+            show_plot: if `True`, show the figure; if `False`, return `(fig, ax)`
+        """
+        if methods is None:
+            methods = ["PDP", "ALE", "RHALE"]
+
+        centering = helpers.prep_centering(centering)
+        if centering is False:
+            warnings.warn(
+                "Comparing methods without centering is not meaningful (each method "
+                "uses a different reference level). Using centering='zero_integral'.",
+                stacklevel=2,
+            )
+            centering = "zero_integral"
+
+        # shared grid, shared across every method
+        xs = np.linspace(
+            self.axis_limits[0, feature], self.axis_limits[1, feature], nof_points
+        )
+
+        curves = {}
+        for name in methods:
+            mk = method_kwargs.get(name) if method_kwargs else None
+            obj = self._get_method(name, mk)
+            label = self._DISPLAY[self._canonical(name)]
+            curves[label] = obj.eval(
+                feature, xs, heterogeneity=False, centering=centering
+            )
+
+        avg_output = (
+            helpers.prep_avg_output(self.data, self.model, None, scale_y)
+            if show_avg_output
+            else None
+        )
+
+        ret = vis.plot_effect_comparison(
+            xs,
+            feature,
+            curves,
+            scale_x=scale_x,
+            scale_y=scale_y,
+            avg_output=avg_output,
+            feature_names=self.feature_names,
+            target_name=self.target_name,
+            y_limits=y_limits,
+            show_plot=show_plot,
+        )
+        if not show_plot:
+            return ret

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -253,6 +253,56 @@ def plot_pdp_ice(
         return fig, ax
 
 
+def plot_effect_comparison(
+    x: np.ndarray,
+    feature: int,
+    curves: dict,
+    scale_x: typing.Union[None, dict] = None,
+    scale_y: typing.Union[None, dict] = None,
+    avg_output: typing.Union[None, float] = None,
+    feature_names: typing.Union[None, list] = None,
+    target_name: typing.Union[None, str] = None,
+    y_limits: typing.Union[None, tuple] = None,
+    title: typing.Union[None, str] = None,
+    show_plot: bool = True,
+):
+    """Overlay the mean effect of several methods for one feature on a single axis.
+
+    Parameters
+    ----------
+    x: the common grid the curves are evaluated on, shape `(T,)`
+    feature: index of the feature being plotted
+    curves: mapping `{method_label: y}` where each `y` has shape `(T,)`
+    scale_x, scale_y: None or Dict with keys ['mean', 'std'] for de-normalization
+    avg_output: None or float, plotted as a horizontal reference line
+    """
+    fig, ax = plt.subplots()
+    ax.set_title("Feature Effect Comparison" if title is None else title)
+
+    x = x if scale_x is None else trans_affine(x, scale_x["mean"], scale_x["std"])
+
+    for label, y in curves.items():
+        y = y if scale_y is None else trans_affine(y, scale_y["mean"], scale_y["std"])
+        ax.plot(x, y, label=label)
+
+    if avg_output is not None:
+        ax.axhline(y=avg_output, color="black", linestyle="--", label="avg output")
+
+    feature_name = (
+        "x_%d" % (feature + 1) if feature_names is None else feature_names[feature]
+    )
+    ax.set_xlabel(feature_name)
+    ax.set_ylabel("y") if target_name is None else ax.set_ylabel(target_name)
+    ax.legend()
+    if y_limits is not None:
+        ax.set_ylim(y_limits[0], y_limits[1])
+
+    if show_plot:
+        plt.show(block=False)
+    else:
+        return fig, ax
+
+
 def plot_shap(
     x: np.ndarray,
     y: np.ndarray,

--- a/tests/test_feature_effect.py
+++ b/tests/test_feature_effect.py
@@ -61,7 +61,9 @@ def test_centering_false_is_coerced_with_warning():
     X = _linear_dataset()
     fe = effector.FeatureEffect(X, predict)
     with pytest.warns(UserWarning):
-        ret = fe.plot(feature=0, methods=["PDP", "ALE"], centering=False, show_plot=False)
+        ret = fe.plot(
+            feature=0, methods=["PDP", "ALE"], centering=False, show_plot=False
+        )
     assert ret is not None
 
 

--- a/tests/test_feature_effect.py
+++ b/tests/test_feature_effect.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+import effector
+
+
+def _linear_dataset(N=1000, seed=21):
+    np.random.seed(seed)
+    x1 = np.random.uniform(0, 1, size=N)
+    x2 = np.random.normal(loc=x1, scale=0.1)
+    x3 = np.random.uniform(0, 1, size=N)
+    return np.stack((x1, x2, x3), axis=-1)
+
+
+def predict(x):
+    return 7 * x[:, 0] - 3 * x[:, 1] + 4 * x[:, 2]
+
+
+def predict_grad(x):
+    df_dx1 = 7 * np.ones([x.shape[0]])
+    df_dx2 = -3 * np.ones([x.shape[0]])
+    df_dx3 = 4 * np.ones([x.shape[0]])
+    return np.stack([df_dx1, df_dx2, df_dx3], axis=-1)
+
+
+def test_comparison_returns_fig_ax():
+    X = _linear_dataset()
+    fe = effector.FeatureEffect(X, predict, model_jac=predict_grad)
+    for i in range(3):
+        ret = fe.plot(feature=i, methods=["PDP", "ALE", "RHALE"], show_plot=False)
+        assert ret is not None
+        fig, ax = ret
+        # one line per method (+ none extra, since show_avg_output is False)
+        assert len(ax.get_lines()) == 3
+
+
+def test_method_objects_are_cached():
+    X = _linear_dataset()
+    fe = effector.FeatureEffect(X, predict, model_jac=predict_grad)
+    fe.plot(feature=0, methods=["PDP", "ALE"], show_plot=False)
+    fe.plot(feature=1, methods=["PDP", "ALE"], show_plot=False)
+    assert set(fe._methods.keys()) == {"pdp", "ale"}
+
+
+def test_unknown_method_raises():
+    X = _linear_dataset()
+    fe = effector.FeatureEffect(X, predict)
+    with pytest.raises(ValueError):
+        fe.plot(feature=0, methods=["not_a_method"], show_plot=False)
+
+
+def test_rhale_without_jac_warns_and_still_works():
+    X = _linear_dataset()
+    fe = effector.FeatureEffect(X, predict)  # no model_jac
+    with pytest.warns(UserWarning):
+        ret = fe.plot(feature=0, methods=["RHALE"], show_plot=False)
+    assert ret is not None
+
+
+def test_centering_false_is_coerced_with_warning():
+    X = _linear_dataset()
+    fe = effector.FeatureEffect(X, predict)
+    with pytest.warns(UserWarning):
+        ret = fe.plot(feature=0, methods=["PDP", "ALE"], centering=False, show_plot=False)
+    assert ret is not None
+
+
+def test_shap_alias():
+    X = _linear_dataset()
+    fe = effector.FeatureEffect(X, predict)
+    assert fe._canonical("SHAP") == "shapdp"
+    assert fe._canonical("shap-dp") == "shapdp"


### PR DESCRIPTION
## What

Adds `effector.FeatureEffect`, a unified facade for **comparing global
feature-effect methods on a single figure**. It exposes the homogenization the
base classes already provide internally, at the user level:

```python
fe = effector.FeatureEffect(X, predict, model_jac=jac,
                            feature_names=..., target_name=...)
fe.plot(feature=3, methods=["PDP", "ALE", "RHALE", "ShapDP"])
```

Instead of instantiating and plotting each method separately, `FeatureEffect`
holds the shared ingredients once and overlays each method's **centered mean
effect** on one axis, so method differences are immediately visible.

## Design

- **Pool:** `PDP`, `ALE`, `RHALE`, `ShapDP`. `DerPDP` is intentionally excluded
  (derivative units — not comparable with output-unit methods).
- **Fair comparison:** the data is filtered to `axis_limits` and subsampled
  **once**, then every method is built on that identical background set — the
  only difference between curves is the method itself.
- **Centering is required** for a meaningful comparison; it defaults on and a
  `centering=False` is coerced to `zero_integral` with a warning.
- **`model_jac` is optional:** if `RHALE` is requested without it, the facade
  emits a gentle warning and falls back to numerical differentiation.
- Methods are built lazily and cached. Per-method constructor overrides via
  `method_kwargs` (e.g. `{"ShapDP": {"nof_instances": 300}}`).
- New rendering helper `visualization.plot_effect_comparison` (dedicated
  single-axis overlay; does not disturb the existing per-method plot functions).

## Scope (v1)

Mean curves only. Heterogeneity overlay and a regional-comparison mode are
deliberately left for follow-ups (each method visualizes heterogeneity
differently; merging those is a separate design).

## Tests

`tests/test_feature_effect.py` — 6 tests: overlay returns `(fig, ax)` with one
line per method, method caching, unknown-method error, RHALE-without-jac warning,
`centering=False` coercion, and the `ShapDP` alias. Existing plot tests still pass.
