### PR TITLE
reproducibility: random_state=21 on every constructor, seeded rng everywhere (PLAN III §6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [Unreleased]
+
+### Added
+
+- `random_state` on every public effect-class constructor (`PDP`, `DerPDP`, `ALE`, `RHALE`, `ShapDP`, the 5 regional variants, and `FeatureEffect`); default `21`, so two identical constructions give identical `eval`/`fit`/`plot` output out of the box, `None` opts into fresh randomness. The seed also drives plot-time ICE/SHAP-scatter subsampling and is passed to the shap/shapiq explainer (`seed=`/`random_state=`) unless overridden via `shap_explainer_kwargs`. No effector code touches the global `np.random` state anymore.
+
 # [0.2.1] - 2026-07-01
 
 ### Changed

--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -879,3 +879,41 @@ chain + this pass are one stacked history off `main`; the single final PR
 opens from here for Vasilis's end-to-end verdict.
 
 ---
+## 22. 2026-07-04 — Reproducibility: `random_state` on every constructor (tag: code)  [PLAN III §6.1 close-out; branch `reproducibility-random-state`]
+
+**Decision (Vasilis):** default is a **fixed seed, `random_state=21`**
+(matching `datasets.py`) — explanations reproducible out of the box;
+`None` opts into fresh randomness.
+
+**What:**
+- `helpers.prep_nof_instances`/`prep_data` take `random_state` and draw via
+  `np.random.default_rng` — the unseeded global `np.random.choice` is gone;
+  no effect-class code touches global `np.random` state anymore
+  (datasets.IndependentUniform keeps its legacy seeded global draw — LOGBOOK #20).
+- Keyword-only `random_state=21` on all 10 public constructors + the
+  `FeatureEffect` facade, appended last on the two base `__init__`s (their
+  positional call shapes untouched), stored as `self.random_state` and
+  forwarded to every internally built object (regional `_precompute_global`,
+  node fe objects, facade `_get_method`).
+- Seed also reaches plot-time sampling (`vis.plot_pdp_ice` ICE selection,
+  `ShapDP.plot` `nof_shap_values`) and the shap backends: `seed=` (shap) /
+  `random_state=` (shapiq) default to the constructor seed, user
+  `shap_explainer_kwargs` still override.
+- New contract layer `tests/test_contract_determinism.py` (D1–D7, 28 tests):
+  same seed → identical data/eval/eval_heter/regional tree + node evals/ICE
+  plot lines; different seeds differ; `None` works; global `np.random` state
+  untouched. `regional_shapdp` D5 runs two *real* shap fits with no explicit
+  seed kwargs — the end-to-end proof the constructor seed reaches the backend.
+- Bookkeeping: R8 in `docs/design.md` now states reproducibility as contract;
+  CHANGELOG unreleased entry; PLAN §6.1 ticked (datasets half was already
+  done in Part III §2.10).
+
+**Noted, out of scope:** conftest's `make_global("shapdp", ...)` setdefaults
+`shap_values` computed on the *full* data — row-misaligned when the
+constructor subsamples (latent, pre-existing); the determinism tests
+recompute analytic shap values on the kept rows instead.
+
+**Verified:** gate 397 passed / 0 xfailed / ~15 s (369 + 28 new); ruff
+check + format clean.
+
+---

--- a/PLAN.md
+++ b/PLAN.md
@@ -1016,12 +1016,14 @@ The composable core (regional = partitioner + any global `.eval`) is the package
 asset; these are the gaps that most threaten it, in priority order. They feed Phase 2 of
 Part I / Part V and should come **before** further feature ideas.
 
-1. **Reproducibility end-to-end** (small, high trust-impact). `nof_instances`
+1. **Reproducibility end-to-end** (small, high trust-impact). ~~`nof_instances`
    subsampling uses global `np.random` with no seed; dataset splits are unseeded — two
    runs give two different explanations. Add `random_state`/`seed` to every constructor
    and `datasets.*`, thread it through `prep_nof_instances`, and add a contract test:
    two identical constructions → identical `eval` output. For an XAI package this is a
-   core value, not a nice-to-have.
+   core value, not a nice-to-have.~~ **DONE 2026-07-04** (`datasets.*` seeds landed in
+   Part III step §2.10; `random_state=21` on every constructor + determinism contract
+   layer `tests/test_contract_determinism.py` + R8 note in `docs/design.md` — LOGBOOK #22).
 2. **Keep the contract enforced, not conventional.** The §1 rules go into
    `CONTRIBUTING.md` / `docs/design.md`, and the contract layer of Part II
    (§3.1) becomes the merge gate for any new method class: a method is "done" when it

--- a/docs/design.md
+++ b/docs/design.md
@@ -67,8 +67,16 @@ Every `vis.*` function and every public `.plot` returns `(fig, ax)` when
 
 Canonical parameter order `data, model, model_jac=None, *, data_effect,
 nof_instances, axis_limits, feature_types, cat_limit, feature_names,
-target_name, ...` — everything after `model_jac` keyword-only, so positional
-shuffles can't bite.
+target_name, random_state, ...` — everything after `model_jac` keyword-only,
+so positional shuffles can't bite.
+
+Reproducibility is contractual: every constructor takes `random_state`
+(default `21`; `None` opts into fresh randomness), two identical
+constructions give identical `eval`/`fit`/`plot` output, and no effect-class
+code touches the global `np.random` state — every sampling site creates its
+own `np.random.default_rng(random_state)`. (The one exception is
+`datasets.IndependentUniform`, which keeps its legacy seeded global draw so
+the executed notebooks stay a valid regression oracle.)
 
 ## R9 — Errors & messages
 

--- a/effector/feature_effect.py
+++ b/effector/feature_effect.py
@@ -42,6 +42,7 @@ class FeatureEffect:
         nof_instances: Union[int, str] = 1_000,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ):
         """
         Args:
@@ -58,16 +59,21 @@ class FeatureEffect:
 
             feature_names: list of feature names, or `None` for `["x_0", ...]`
             target_name: name of the target, or `None` for `"y"`
+            random_state: seed for every internal random step (e.g. the shared
+                `nof_instances` subsampling), inherited by every lazily built
+                method object. Use an `int` (default: `21`) for reproducible
+                output, or `None` for non-deterministic behavior.
         """
         self.model = model
         self.model_jac = model_jac
         self.dim = data.shape[1]
+        self.random_state = random_state
 
         # shared preprocessing (helpers.prep_data): filter to axis limits (or
         # infer them), then subsample ONCE so every method sees the exact same
         # background data.
         self.data, _, self.axis_limits, _, _ = helpers.prep_data(
-            data, axis_limits, nof_instances
+            data, axis_limits, nof_instances, random_state=random_state
         )
 
         self.feature_names = (
@@ -103,6 +109,7 @@ class FeatureEffect:
             nof_instances="all",  # data is already subsampled in __init__
             feature_names=self.feature_names,
             target_name=self.target_name,
+            random_state=self.random_state,
         )
         if method_kwargs:
             kwargs.update(method_kwargs)

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -22,6 +22,7 @@ class GlobalEffectBase(ABC):
         axis_limits: Optional[np.ndarray] = None,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ) -> None:
         """
         Constructor for the FeatureEffectBase class.
@@ -29,13 +30,16 @@ class GlobalEffectBase(ABC):
         self.method_name = method_name.lower()
         self.model = model
         self.model_jac = model_jac
+        self.random_state = random_state
 
         self.dim = data.shape[1]
 
         # shared preprocessing: filter to axis_limits (or infer them), then
         # subsample nof_instances (helpers.prep_data)
         data, data_effect, axis_limits, self.nof_instances, self.indices = (
-            helpers.prep_data(data, axis_limits, nof_instances, data_effect)
+            helpers.prep_data(
+                data, axis_limits, nof_instances, data_effect, random_state
+            )
         )
         self.axis_limits: np.ndarray = axis_limits
 

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -25,6 +25,7 @@ class ALEBase(GlobalEffectBase):
         axis_limits: Optional[np.ndarray] = None,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
         method_name: str = "ALE",
     ):
         super(ALEBase, self).__init__(
@@ -37,6 +38,7 @@ class ALEBase(GlobalEffectBase):
             axis_limits,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     @abstractmethod
@@ -166,6 +168,7 @@ class ALE(ALEBase):
         axis_limits: Optional[np.ndarray] = None,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ):
         r"""
         Constructor for the ALE plot.
@@ -235,6 +238,11 @@ class ALE(ALEBase):
 
                 - use a `str`, to specify it name manually. For example: `"price"`
                 - use `None`, to keep the default name: `"y"`
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - use an `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - use `None`, for non-deterministic behavior
         """
         self.bin_limits = {}
         self.data_effect_ale = {}
@@ -245,6 +253,7 @@ class ALE(ALEBase):
             axis_limits=axis_limits,
             feature_names=feature_names,
             target_name=target_name,
+            random_state=random_state,
             method_name="ALE",
         )
 
@@ -326,6 +335,7 @@ class RHALE(ALEBase):
         axis_limits: typing.Optional[np.ndarray] = None,
         feature_names: typing.Optional[list] = None,
         target_name: typing.Optional[str] = None,
+        random_state: typing.Optional[int] = 21,
     ):
         r"""
         Constructor for RHALE.
@@ -403,6 +413,11 @@ class RHALE(ALEBase):
 
                 - use a `str`, to specify it name manually. For example: `"price"`
                 - use `None`, to keep the default name: `"y"`
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - use an `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - use `None`, for non-deterministic behavior
         """
         super(RHALE, self).__init__(
             data,
@@ -413,6 +428,7 @@ class RHALE(ALEBase):
             axis_limits=axis_limits,
             feature_names=feature_names,
             target_name=target_name,
+            random_state=random_state,
             method_name="RHALE",
         )
 

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -24,6 +24,7 @@ class PDPBase(GlobalEffectBase):
         nof_instances: Union[int, str] = 10_000,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
         method_name: str = "PDP",
     ):
         super(PDPBase, self).__init__(
@@ -36,6 +37,7 @@ class PDPBase(GlobalEffectBase):
             axis_limits,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _predict(self, data, xx, feature, use_vectorized=True):
@@ -188,6 +190,7 @@ class PDPBase(GlobalEffectBase):
             nof_ice=nof_ice,
             y_limits=y_limits,
             show_plot=show_plot,
+            random_state=self.random_state,
         )
 
 
@@ -203,6 +206,7 @@ class PDP(PDPBase):
         nof_instances: Union[int, str] = 10_000,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ):
         r"""
         Constructor of the PDP class.
@@ -270,6 +274,11 @@ class PDP(PDPBase):
 
                 - use a `str`, to specify it name manually. For example: `"price"`
                 - use `None`, to keep the default name: `"y"`
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - use an `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - use `None`, for non-deterministic behavior
         """
 
         super(PDP, self).__init__(
@@ -280,6 +289,7 @@ class PDP(PDPBase):
             nof_instances=nof_instances,
             feature_names=feature_names,
             target_name=target_name,
+            random_state=random_state,
             method_name="PDP",
         )
 
@@ -368,6 +378,7 @@ class DerPDP(PDPBase):
         nof_instances: Union[int, str] = 10_000,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ):
         r"""
         Constructor of the DerivativePDP class.
@@ -441,6 +452,11 @@ class DerPDP(PDPBase):
 
                 - use a `str`, to specify it name manually. For example: `"price"`
                 - use `None`, to keep the default name: `"y"`
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - use an `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - use `None`, for non-deterministic behavior
         """
 
         super(DerPDP, self).__init__(
@@ -451,6 +467,7 @@ class DerPDP(PDPBase):
             nof_instances=nof_instances,
             feature_names=feature_names,
             target_name=target_name,
+            random_state=random_state,
             method_name="d-PDP",
         )
 

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -24,14 +24,22 @@ import effector.utils as utils
 
 
 def _compute_shap_values(
-    model, data, backend, budget, explainer_kwargs=None, explanation_kwargs=None
+    model,
+    data,
+    backend,
+    budget,
+    explainer_kwargs=None,
+    explanation_kwargs=None,
+    random_state=None,
 ):
     """Compute per-instance SHAP values `(N, D)` with the chosen backend.
 
     Defaults (user kwargs override them):
-      - `shap`:   `Explainer(model, masker=data)`, `explainer(data, max_evals=budget)`
+      - `shap`:   `Explainer(model, masker=data, seed=random_state)`,
+        `explainer(data, max_evals=budget)`
       - `shapiq`: `Explainer(model, data=data, index="SV", max_order=1,
-        approximator="permutation", imputer="marginal")`,
+        approximator="permutation", imputer="marginal",
+        random_state=random_state)`,
         `explainer.explain_X(data, budget=budget)`
     """
     explainer_kwargs = explainer_kwargs.copy() if explainer_kwargs else {}
@@ -42,7 +50,7 @@ def _compute_shap_values(
                 "The `shap` package is required for backend='shap'. "
                 "Install it with `pip install effector[shap]`."
             )
-        explainer_defaults = {"masker": data}
+        explainer_defaults = {"masker": data, "seed": random_state}
         explanation_defaults = {"max_evals": budget}
     elif backend == "shapiq":
         if shapiq is None:
@@ -56,6 +64,7 @@ def _compute_shap_values(
             "max_order": 1,
             "approximator": "permutation",
             "imputer": "marginal",
+            "random_state": random_state,
         }
         explanation_defaults = {"budget": budget}
     else:
@@ -85,6 +94,7 @@ class ShapDP(GlobalEffectBase):
         nof_instances: Union[int, str] = 1_000,
         feature_names: Optional[List[str]] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
         shap_values: Optional[np.ndarray] = None,
         backend: str = "shap",
     ):
@@ -160,6 +170,11 @@ class ShapDP(GlobalEffectBase):
                 - use a `str`, to specify it name manually. For example: `"price"`
                 - use `None`, to keep the default name: `"y"`
 
+            random_state: seed for every internal random step (`nof_instances` subsampling and the shap/shapiq explainer, unless overridden via `shap_explainer_kwargs`)
+
+                - use an `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - use `None`, for non-deterministic behavior
+
             shap_values: The SHAP values of the model
 
                 - if shap values are already computed, they can be passed here
@@ -190,6 +205,7 @@ class ShapDP(GlobalEffectBase):
             axis_limits,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _fit_feature(
@@ -210,6 +226,7 @@ class ShapDP(GlobalEffectBase):
                 budget,
                 shap_explainer_kwargs,
                 shap_explanation_kwargs,
+                self.random_state,
             )
 
         # extract x and y
@@ -304,6 +321,7 @@ class ShapDP(GlobalEffectBase):
                 - Decrease the budget for faster computation at the cost of approximation error.
 
             shap_explainer_kwargs: the keyword arguments to be passed to the `shap.Explainer` or `shapiq.Explainer` class, depending on the backend.
+                The constructor's `random_state` is used as the backend seed (`seed=` for `shap`, `random_state=` for `shapiq`) unless you pass your own here.
 
                 ??? note "Code behind the scene"
 
@@ -392,7 +410,9 @@ class ShapDP(GlobalEffectBase):
         )
 
         # get some SHAP values
-        _, ind = helpers.prep_nof_instances(nof_shap_values, self.data.shape[0])
+        _, ind = helpers.prep_nof_instances(
+            nof_shap_values, self.data.shape[0], self.random_state
+        )
         yy = (
             self.feature_effect["feature_" + str(feature)]["yy"][ind]
             if heterogeneity == "shap_values"

--- a/effector/helpers.py
+++ b/effector/helpers.py
@@ -101,7 +101,9 @@ def axis_limits_from_data(data: np.ndarray) -> np.ndarray:
 
 
 def prep_nof_instances(
-    nof_instances: typing.Union[int, str], N: int
+    nof_instances: typing.Union[int, str],
+    N: int,
+    random_state: typing.Optional[int] = 21,
 ) -> typing.Tuple[int, np.ndarray]:
     """Prepares the argument nof_instances
 
@@ -109,6 +111,10 @@ def prep_nof_instances(
     ---
         nof_instances (int or str): The number of instances to use for the explanation
         N (int): The number of instances in the dataset
+        random_state (int or None): seed for the subsampling draw; `None` for
+            fresh randomness. Every sampling site creates its own
+            `np.random.default_rng(random_state)` — if a future site draws the
+            same shape from the same population, switch to spawned child seeds.
 
     Returns
     ---
@@ -129,7 +135,7 @@ def prep_nof_instances(
         )
 
     indices = (
-        np.random.choice(N, nof_instances, replace=False)
+        np.random.default_rng(random_state).choice(N, nof_instances, replace=False)
         if nof_instances < N
         else np.arange(N)
     )
@@ -141,12 +147,14 @@ def prep_data(
     axis_limits: typing.Optional[np.ndarray] = None,
     nof_instances: typing.Union[int, str] = 10_000,
     data_effect: typing.Optional[np.ndarray] = None,
+    random_state: typing.Optional[int] = 21,
 ) -> typing.Tuple[np.ndarray, typing.Optional[np.ndarray], np.ndarray, int, np.ndarray]:
     """Shared data preprocessing for every effect class (global, regional, facade):
 
     (i) if `axis_limits` is given, validate it and drop the points outside;
         otherwise infer the limits from the data;
-    (ii) subsample `nof_instances` from what remains.
+    (ii) subsample `nof_instances` from what remains, seeded by `random_state`
+        (`None` for fresh randomness).
 
     `data_effect` (the Jacobian on `data`), when given, is kept row-aligned with
     `data` through both steps.
@@ -176,7 +184,9 @@ def prep_data(
     else:
         axis_limits = axis_limits_from_data(data)
 
-    nof_instances, indices = prep_nof_instances(nof_instances, data.shape[0])
+    nof_instances, indices = prep_nof_instances(
+        nof_instances, data.shape[0], random_state
+    )
     data = data[indices, :]
     data_effect = data_effect[indices, :] if data_effect is not None else None
 

--- a/effector/regional_effect.py
+++ b/effector/regional_effect.py
@@ -26,6 +26,7 @@ class RegionalEffectBase:
         cat_limit: Optional[int] = 10,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ) -> None:
         """
         Constructor for the RegionalEffect class.
@@ -33,13 +34,16 @@ class RegionalEffectBase:
         self.method_name = method_name.lower()
         self.model = model
         self.model_jac = model_jac
+        self.random_state = random_state
 
         self.dim = data.shape[1]
 
         # shared preprocessing: filter to axis_limits (or infer them), then
         # subsample nof_instances (helpers.prep_data)
         data, data_effect, axis_limits, self.nof_instances, self.indices = (
-            helpers.prep_data(data, axis_limits, nof_instances, data_effect)
+            helpers.prep_data(
+                data, axis_limits, nof_instances, data_effect, random_state
+            )
         )
         self.axis_limits: np.ndarray = axis_limits
 
@@ -191,6 +195,7 @@ class RegionalEffectBase:
             nof_instances="all",
             feature_names=feature_names,
             target_name=self.target_name,
+            random_state=self.random_state,
         )
         if spec.uses_data_effect:
             kwargs["data_effect"] = (

--- a/effector/regional_effect_ale.py
+++ b/effector/regional_effect_ale.py
@@ -27,6 +27,7 @@ class RegionalRHALE(RegionalEffectBase):
         cat_limit: Optional[int] = 10,
         feature_names: Optional[List] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
     ):
         """
         Initialize the Regional Effect method.
@@ -94,6 +95,11 @@ class RegionalRHALE(RegionalEffectBase):
 
                 - `None`, to keep the default name: `"y"`
                 - `"price"`, to manually specify the name of the target variable
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - `None`, for non-deterministic behavior
         """
 
         super(RegionalRHALE, self).__init__(
@@ -108,6 +114,7 @@ class RegionalRHALE(RegionalEffectBase):
             cat_limit,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def compile(self):
@@ -139,6 +146,7 @@ class RegionalRHALE(RegionalEffectBase):
                 data_effect=instance_effects,
                 nof_instances="all",
                 axis_limits=self.axis_limits,
+                random_state=self.random_state,
             )
             try:
                 rhale.fit(
@@ -270,6 +278,7 @@ class RegionalALE(RegionalEffectBase):
         cat_limit: typing.Union[int, None] = 10,
         feature_names: typing.Union[list, None] = None,
         target_name: typing.Union[str, None] = None,
+        random_state: typing.Optional[int] = 21,
     ):
         """
         Initialize the Regional Effect method.
@@ -322,6 +331,11 @@ class RegionalALE(RegionalEffectBase):
 
                 - `None`, to keep the default name: `"y"`
                 - `"price"`, to manually specify the name of the target variable
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - `None`, for non-deterministic behavior
         """
 
         self.global_bin_limits = {}
@@ -338,13 +352,18 @@ class RegionalALE(RegionalEffectBase):
             cat_limit,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _precompute_global(self, feature: int):
         """Fit the global ALE once and keep its per-instance bin effects: the
         candidate regions re-bin those instead of refitting the model."""
         global_ale = ALE(
-            self.data, self.model, nof_instances="all", axis_limits=self.axis_limits
+            self.data,
+            self.model,
+            nof_instances="all",
+            axis_limits=self.axis_limits,
+            random_state=self.random_state,
         )
         global_ale.fit(
             features=feature,

--- a/effector/regional_effect_pdp.py
+++ b/effector/regional_effect_pdp.py
@@ -22,6 +22,7 @@ class RegionalPDPBase(RegionalEffectBase):
         cat_limit: typing.Union[int, None] = 10,
         feature_names: typing.Union[list, None] = None,
         target_name: typing.Union[str, None] = None,
+        random_state: typing.Optional[int] = 21,
     ):
         self.y_ice = {}
         super(RegionalPDPBase, self).__init__(
@@ -36,6 +37,7 @@ class RegionalPDPBase(RegionalEffectBase):
             cat_limit,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _create_heterogeneity_function(self, feature: int, min_points: int):
@@ -61,6 +63,7 @@ class RegionalPDP(RegionalPDPBase):
         cat_limit: typing.Union[int, None] = 10,
         feature_names: typing.Union[list, None] = None,
         target_name: typing.Union[str, None] = None,
+        random_state: typing.Optional[int] = 21,
     ):
         """
         Initialize the Regional Effect method.
@@ -113,6 +116,11 @@ class RegionalPDP(RegionalPDPBase):
 
                 - `None`, to keep the default name: `"y"`
                 - `"price"`, to manually specify the name of the target variable
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - `None`, for non-deterministic behavior
         """
 
         super(RegionalPDP, self).__init__(
@@ -126,13 +134,18 @@ class RegionalPDP(RegionalPDPBase):
             cat_limit,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _precompute_global(self, feature: int):
         """Fit the global PDP once and keep the centered ICE table on the
         heterogeneity grid: candidate regions score row-subsets of it."""
         pdp = PDP(
-            self.data, self.model, axis_limits=self.axis_limits, nof_instances="all"
+            self.data,
+            self.model,
+            axis_limits=self.axis_limits,
+            nof_instances="all",
+            random_state=self.random_state,
         )
         pdp.fit(
             features=feature,
@@ -263,6 +276,7 @@ class RegionalDerPDP(RegionalPDPBase):
         cat_limit: typing.Union[int, None] = 10,
         feature_names: typing.Union[list, None] = None,
         target_name: typing.Union[str, None] = None,
+        random_state: typing.Optional[int] = 21,
     ):
         """
         Initialize the Regional Effect method.
@@ -320,6 +334,11 @@ class RegionalDerPDP(RegionalPDPBase):
 
                 - `None`, to keep the default name: `"y"`
                 - `"price"`, to manually specify the name of the target variable
+
+            random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
+
+                - `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - `None`, for non-deterministic behavior
         """
 
         super(RegionalDerPDP, self).__init__(
@@ -333,6 +352,7 @@ class RegionalDerPDP(RegionalPDPBase):
             cat_limit,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _precompute_global(self, feature: int):
@@ -344,6 +364,7 @@ class RegionalDerPDP(RegionalPDPBase):
             self.model_jac,
             axis_limits=self.axis_limits,
             nof_instances="all",
+            random_state=self.random_state,
         )
         pdp.fit(
             features=feature,

--- a/effector/regional_effect_shap.py
+++ b/effector/regional_effect_shap.py
@@ -24,6 +24,7 @@ class RegionalShapDP(RegionalEffectBase):
         cat_limit: Optional[int] = 10,
         feature_names: Optional[List[str]] = None,
         target_name: Optional[str] = None,
+        random_state: Optional[int] = 21,
         backend: str = "shap",
     ):
         """
@@ -78,6 +79,11 @@ class RegionalShapDP(RegionalEffectBase):
                 - `None`, to keep the default name: `"y"`
                 - `"price"`, to manually specify the name of the target variable
 
+            random_state: seed for every internal random step (`nof_instances` subsampling and the shap/shapiq explainer, unless overridden via `shap_explainer_kwargs`)
+
+                - `int` (default: `21`), for reproducible output; two identical constructions give identical results
+                - `None`, for non-deterministic behavior
+
             backend: Package to compute SHAP values
 
                 - use `"shap"` for the `shap` package (default)
@@ -97,6 +103,7 @@ class RegionalShapDP(RegionalEffectBase):
             cat_limit,
             feature_names,
             target_name,
+            random_state=random_state,
         )
 
     def _extra_fe_kwargs(self, active_indices: np.ndarray) -> dict:
@@ -112,6 +119,7 @@ class RegionalShapDP(RegionalEffectBase):
                 self.model,
                 axis_limits=self.axis_limits,
                 nof_instances="all",
+                random_state=self.random_state,
                 backend=self.backend,
             )
             global_shap_dp.fit(feature, centering=False, **self.kwargs_fitting)
@@ -134,6 +142,7 @@ class RegionalShapDP(RegionalEffectBase):
                 self.model,
                 axis_limits=self.axis_limits,
                 nof_instances="all",
+                random_state=self.random_state,
                 shap_values=shap_values,
             )
 
@@ -199,6 +208,7 @@ class RegionalShapDP(RegionalEffectBase):
             points_for_mean_heterogeneity: number of equidistant points along the feature axis used for computing the mean heterogeneity
 
             shap_explainer_kwargs: the keyword arguments to be passed to the `shap.Explainer` or `shapiq.Explainer` class, depending on the backend.
+                The constructor's `random_state` is used as the backend seed (`seed=` for `shap`, `random_state=` for `shapiq`) unless you pass your own here.
 
                 ??? note "Code behind the scene"
 

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -169,6 +169,7 @@ def plot_pdp_ice(
     nof_ice: typing.Union[str, int] = "all",
     y_limits: typing.Union[None, tuple] = None,
     show_plot: bool = True,
+    random_state: typing.Union[None, int] = None,
 ):
     """Draw the mean of the ICE table `yy` (shape `(T, N)`) plus the requested
     heterogeneity: a std or standard-error band, or the ICE curves themselves."""
@@ -197,7 +198,9 @@ def plot_pdp_ice(
     elif heterogeneity == "ice":
         yy_show = yy
         if nof_ice != "all" and nof_ice < yy.shape[1]:
-            ind = np.random.choice(yy.shape[1], size=nof_ice, replace=False)
+            ind = np.random.default_rng(random_state).choice(
+                yy.shape[1], size=nof_ice, replace=False
+            )
             yy_show = yy[:, ind]
         ax.plot(x, yy_show[:, 0], color="red", alpha=0.1, label=y_ice_label)
         ax.plot(x, yy_show, color="red", alpha=0.1)

--- a/tests/test_contract_determinism.py
+++ b/tests/test_contract_determinism.py
@@ -1,0 +1,171 @@
+"""Contract layer, reproducibility (PLAN III §6.1).
+
+Every public effect-class constructor takes ``random_state`` (default ``21``):
+two identical constructions give identical ``eval``/``fit``/``plot`` output,
+``None`` opts into fresh randomness, and no effect-class code touches the
+global ``np.random`` state.  Parametrized over the 5 global and 5 regional classes on
+the shared tiny models (see conftest); ``nof_instances`` is always set below
+the dataset size so the subsampling draw is actually exercised.
+"""
+
+import numpy as np
+import pytest
+
+import effector
+from tests.conftest import (
+    GLOBAL_NAMES,
+    REGIONAL_NAMES,
+    analytic_shap_values,
+    eval_mean,
+    make_global,
+    make_regional,
+)
+
+XS = np.linspace(-0.8, 0.8, 40)
+NOF = 50  # < N_GLOBAL=200, forces the subsampling draw
+
+
+def params(names):
+    return [pytest.param(name, id=name) for name in names]
+
+
+def make_global_subsampled(name, data, **kwargs):
+    """A global object on a forced subsample, with row-aligned shap values.
+
+    conftest's ``make_global`` setdefaults ``shap_values`` computed on the
+    *full* data; under subsampling that is row-misaligned with ``m.data``
+    (a latent pre-existing inconsistency, out of scope here), so recompute
+    them on the kept rows — D1 guarantees both constructions keep the same.
+    """
+    m = make_global(name, data, nof_instances=NOF, **kwargs)
+    if name == "shapdp":
+        m.shap_values = analytic_shap_values(m.data)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# D1 — same seed -> same subsample (construction is deterministic)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params(GLOBAL_NAMES))
+def test_d1_construction_deterministic(name, global_data):
+    m1 = make_global_subsampled(name, global_data)
+    m2 = make_global_subsampled(name, global_data)
+    assert np.array_equal(m1.indices, m2.indices)
+    assert np.array_equal(m1.data, m2.data)
+
+
+# ---------------------------------------------------------------------------
+# D2 — same seed -> identical eval and eval_heter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params(GLOBAL_NAMES))
+def test_d2_eval_deterministic(name, global_data):
+    m1 = make_global_subsampled(name, global_data)
+    m2 = make_global_subsampled(name, global_data)
+    np.testing.assert_allclose(eval_mean(m1, 0, XS), eval_mean(m2, 0, XS), atol=1e-12)
+    np.testing.assert_allclose(m1.eval_heter(0, XS), m2.eval_heter(0, XS), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# D3 — different seeds -> different subsamples
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params(GLOBAL_NAMES))
+def test_d3_different_seeds_differ(name, global_data):
+    m1 = make_global_subsampled(name, global_data)  # default random_state=21
+    m2 = make_global_subsampled(name, global_data, random_state=1234)
+    assert not np.array_equal(m1.data, m2.data)
+
+
+# ---------------------------------------------------------------------------
+# D4 — random_state=None still works (no determinism assert: that draw is
+# genuinely random, and two None runs *may* collide on tiny data)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params(GLOBAL_NAMES))
+def test_d4_none_seed_works(name, global_data):
+    m = make_global_subsampled(name, global_data, random_state=None)
+    assert m.data.shape[0] == NOF
+    y = eval_mean(m, 0, XS)
+    assert np.all(np.isfinite(y))
+
+
+# ---------------------------------------------------------------------------
+# D5 — regional: same seed -> identical tree and node effects
+# ---------------------------------------------------------------------------
+
+
+def fit_regional_subsampled(name, data):
+    """Fit feature 0 with forced subsampling and *no* explicit seed kwargs:
+    the constructor's default random_state must carry determinism end-to-end
+    (for regional_shapdp, all the way into the shap backend)."""
+    if name == "regional_shapdp":
+        reg = make_regional(name, data[:50], nof_instances=30)
+        reg.fit(
+            0,
+            space_partitioner=effector.space_partitioning.Best(max_depth=2),
+            budget=128,
+        )
+        return reg
+    reg = make_regional(name, data, nof_instances=300)
+    reg.fit(0, space_partitioner=effector.space_partitioning.Best(max_depth=2))
+    return reg
+
+
+@pytest.mark.parametrize("name", params(REGIONAL_NAMES))
+def test_d5_regional_fit_deterministic(name, regional_data):
+    reg1 = fit_regional_subsampled(name, regional_data)
+    reg2 = fit_regional_subsampled(name, regional_data)
+    assert np.array_equal(reg1.data, reg2.data)
+    tree1, tree2 = reg1.tree["feature_0"], reg2.tree["feature_0"]
+    assert len(tree1.nodes) == len(tree2.nodes)
+    for node_idx in range(len(tree1.nodes)):
+        np.testing.assert_allclose(
+            reg1.eval(0, node_idx, XS), reg2.eval(0, node_idx, XS), atol=1e-12
+        )
+
+
+# ---------------------------------------------------------------------------
+# D6 — plot-time ICE subsampling is seeded too (visualization threading)
+# ---------------------------------------------------------------------------
+
+
+def _ice_ydata(m):
+    fig, ax = m.plot(0, heterogeneity="ice", nof_ice=10, show_plot=False)
+    return [line.get_ydata() for line in ax.get_lines()]
+
+
+def test_d6_pdp_ice_plot_deterministic(global_data):
+    m1 = make_global_subsampled("pdp", global_data)
+    m2 = make_global_subsampled("pdp", global_data)
+    for y1, y2 in zip(_ice_ydata(m1), _ice_ydata(m2), strict=True):
+        np.testing.assert_allclose(y1, y2, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# D7 — helpers: the single choke point behaves as specified
+# ---------------------------------------------------------------------------
+
+
+def test_d7_prep_nof_instances_seeded():
+    n1, ind1 = effector.helpers.prep_nof_instances(50, 200, random_state=0)
+    n2, ind2 = effector.helpers.prep_nof_instances(50, 200, random_state=0)
+    _, ind3 = effector.helpers.prep_nof_instances(50, 200, random_state=1)
+    assert n1 == n2 == 50
+    assert np.array_equal(ind1, ind2)
+    assert not np.array_equal(ind1, ind3)
+
+
+def test_d7_global_np_random_untouched(global_data):
+    """Constructing effect objects must not consume or reseed global np.random."""
+    np.random.seed(0)
+    expected = np.random.get_state()[1].copy()
+    np.random.seed(0)
+    for name in GLOBAL_NAMES:
+        make_global_subsampled(name, global_data)
+    assert np.array_equal(np.random.get_state()[1], expected)


### PR DESCRIPTION
Closes PLAN III §6 item 1 (the gate before Part IV features): `nof_instances` subsampling used unseeded global `np.random`, so two identical constructions gave two different explanations.

**Decision:** default is a fixed seed `random_state=21` (matching `datasets.py`) — reproducible out of the box; `None` opts into fresh randomness.

- `helpers.prep_nof_instances`/`prep_data` take `random_state`, draw via `np.random.default_rng`; the unseeded `np.random.choice` is gone.
- Keyword-only `random_state=21` on all 10 public constructors + `FeatureEffect`, appended last on the two base `__init__`s (positional call shapes untouched), stored as `self.random_state`, forwarded to every internally built object.
- Seed also reaches plot-time sampling (`plot_pdp_ice` ICE selection, `ShapDP.plot` `nof_shap_values`) and the shap backends (`seed=` for shap, `random_state=` for shapiq) unless overridden via `shap_explainer_kwargs`.
- New contract layer `tests/test_contract_determinism.py` (D1–D7, 28 tests). D5's `regional_shapdp` runs two real shap fits with **no** explicit seed kwargs — the end-to-end proof the constructor seed reaches the backend.
- R8 in `docs/design.md` now states reproducibility as contract; CHANGELOG unreleased entry; PLAN §6.1 ticked; LOGBOOK #22.

**Noted, out of scope:** conftest's `make_global("shapdp", ...)` setdefaults `shap_values` computed on the *full* data — row-misaligned when the constructor subsamples (latent, pre-existing). The determinism tests recompute analytic shap values on the kept rows instead.

**Verified:** gate 397 passed / 0 xfailed / ~15 s (369 + 28 new); ruff check + format clean; functional global+regional suites (real subsampling, real shap) 29 passed in ~44 s.