### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # [Unreleased]
 
+# [0.3.0] - 2026-07-04
+
 ### Added
 
 - `random_state` on every public effect-class constructor (`PDP`, `DerPDP`, `ALE`, `RHALE`, `ShapDP`, the 5 regional variants, and `FeatureEffect`); default `21`, so two identical constructions give identical `eval`/`fit`/`plot` output out of the box, `None` opts into fresh randomness. The seed also drives plot-time ICE/SHAP-scatter subsampling and is passed to the shap/shapiq explainer (`seed=`/`random_state=`) unless overridden via `shap_explainer_kwargs`. No effector code touches the global `np.random` state anymore.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ maintainers = [
 license = {text = "MIT License"}
 requires-python = ">=3.10"
 keywords = ["explainability", "interpretability", "machine learning", "deep learning", "regional XAI", "feature effect"]
-version = "0.2.1"
+version = "0.3.0"
 readme = "README.md"
 dependencies = [
     "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "effector"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Version bump only: **0.2.1 → 0.3.0**, plus cutting the `[Unreleased]` changelog section into `[0.3.0] - 2026-07-04`.

The `random_state` reproducibility feature itself already merged via #29; this just tags the release.

Files: `pyproject.toml`, `uv.lock`, `CHANGELOG.md`.

After merge, push tag `v0.3.0` on the merged commit to trigger the PyPI publish workflow + auto GitHub Release.