### PR TITLE
Make effector numpy-only: add from_dataframe, drop implicit DataFrame model-wrapping

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -67,7 +67,8 @@ Every `vis.*` function and every public `.plot` returns `(fig, ax)` when
 
 Canonical parameter order `data, model, model_jac=None, *, data_effect,
 nof_instances, axis_limits, schema, random_state, ...` — everything after
-`model_jac` keyword-only, so positional shuffles can't bite. All input
+`model_jac` keyword-only, so positional shuffles can't bite. `data` is a
+numpy array and `model`/`model_jac` are numpy→numpy callables (R10). All input
 metadata (names, types, target name, scaling) lives in the single `schema`
 argument (R10); metadata never appears as separate constructor kwargs.
 
@@ -86,12 +87,19 @@ or `logging` (not `print`) inside heterogeneity functions.
 
 ## R10 — Input contract
 
-**Accepted `data` types.** A 2-D numeric numpy array, or a pandas DataFrame.
-Anything else → `TypeError`. pandas is never a hard dependency: detection
-checks `sys.modules` only, and the numpy path never imports pandas (proven by
-a subprocess test). DataFrames are converted to a float numpy core matrix at
-the door (`effector.ingestion.ingest`, called before `helpers.prep_data` in
-every constructor); everything downstream is numpy-only.
+**Accepted `data` type.** A 2-D numeric numpy array. Anything else →
+`TypeError`; a pandas DataFrame is rejected with a pointer to
+`effector.from_dataframe`. effector is numpy-only — `data`, `model`, and
+`model_jac` all live in numpy, so the model is called exactly as given and is
+never wrapped. pandas is never a dependency of the compute path (the numpy door
+never imports it, proven by a subprocess test).
+
+**Model contract.** `model` is `Callable[[np.ndarray[N, D]], np.ndarray[N]]`
+and `model_jac` (optional) is `Callable[[np.ndarray[N, D]], np.ndarray[N, D]]`.
+A model trained on a DataFrame, a torch/tf tensor, or an sklearn `Pipeline` is
+the user's to wrap into a numpy→numpy callable — dtype, device, batching, and
+any DataFrame reconstruction included. See the *"effector is purely numpy
+based"* quickstart guide.
 
 **One metadata argument.** All input metadata travels in `schema=` — an
 `effector.Schema` (frozen dataclass) or a plain dict with the same keys:
@@ -100,36 +108,39 @@ every constructor); everything downstream is numpy-only.
 `ValueError` listing the valid ones. A schema is reusable across method
 constructions.
 
-**Define-or-infer.** Precedence per field: explicit schema field >
-DataFrame inference > numpy heuristic > synthesized default (`x_0…`, `"y"`).
+**Define-or-infer.** Precedence per field: explicit schema field > numpy
+heuristic > synthesized default (`x_0…`, `"y"`).
 
 **Feature-type taxonomy** — three-way, `"continuous" | "ordinal" | "nominal"`,
-with door-normalized aliases `"cont"` → continuous, `"cat"` → nominal.
-Inference:
+with door-normalized aliases `"cont"` → continuous, `"cat"` → nominal. From a
+numpy column:
 
 | source | rule |
 |---|---|
-| DataFrame float column | continuous |
-| DataFrame int column | ordinal if `nunique < cat_limit`, else continuous |
-| DataFrame bool column | ordinal (codes 0/1) |
-| DataFrame `Categorical(ordered=True)` | ordinal, declared category order kept |
-| DataFrame unordered category / object / string | nominal (codes via `astype("category")`) |
-| DataFrame datetime / other | `ValueError` |
 | numpy column, integer-valued, `nunique < cat_limit` | ordinal |
 | numpy column, otherwise | continuous — **nominal is never inferred from numpy** |
 
-Types decided by the *cardinality heuristic* (the two int rules) and not
-declared in the schema trigger one `UserWarning` naming the columns and the
-one-line `schema={"feature_types": [...]}` fix; dtype-decided types are
-silent. NaN anywhere in a DataFrame → `ValueError` naming the column.
+Types decided by the *cardinality heuristic* (the int rule) and not declared in
+the schema trigger one `UserWarning` naming the columns and the one-line
+`schema={"feature_types": [...]}` fix.
 
-**Model-call rule.** If `data` was a DataFrame, `model` (and `model_jac`) are
-always called with a reconstructed DataFrame: original column names/order,
-encoded columns decoded to their original values/dtypes, numeric columns
-float64, codes rounded and clipped to the nearest level. Escape hatch for
-array-expecting models: `lambda X: f(X.to_numpy())`. Precomputed
-`data_effect` / `shap_values` align with the *encoded* matrix and pass
-through untouched.
+**`from_dataframe` convenience.** `X, schema = effector.from_dataframe(df)`
+reads a DataFrame's column names, dtypes, and category levels into `(X, Schema)`
+so you can call any constructor as `Method(X, model, schema=schema)`. It
+converts *data* only — it never touches the model. dtype → type mapping:
+
+| DataFrame column | inferred type |
+|---|---|
+| float | continuous |
+| int | ordinal if `nunique < cat_limit`, else continuous |
+| bool | ordinal (codes 0/1) |
+| `Categorical(ordered=True)` | ordinal, declared category order kept |
+| unordered category / object / string | nominal (codes via `astype("category")`) |
+| datetime / other | `ValueError` |
+
+NaN anywhere → `ValueError` naming the column. The returned schema is a
+*proposal to inspect*: the int-column guess (ordinal vs continuous vs a
+label-encoded nominal) is the one thing no extractor can know for sure.
 
 **Scaling precedence.** `scale_x_list`/`scale_y` in the schema are
 construction-time defaults; a plot-time `scale_x`/`scale_y` dict overrides,
@@ -137,5 +148,5 @@ construction-time defaults; a plot-time `scale_x`/`scale_y` dict overrides,
 
 **One validation point.** `effector.ingestion.validate_metadata` (R9 style)
 checks name/type list lengths against `dim`, canonical type values, scale
-dict shapes (`{"mean","std"}`, `std != 0`), `cat_limit` sanity, and rejects a
-`continuous` label on an encoded (string-source) column.
+dict shapes (`{"mean","std"}`, `std != 0`), `cat_limit` sanity, and
+`category_names` lengths against the observed levels.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -3,6 +3,7 @@
 
 - [What are global and regional effects](./global_and_regional_effects/)
 - [An overview of `effector`'s API](./simple_api/)
+- [effector is purely numpy based](./pure_numpy/)
 - [Customize `.fit()`](./flexible_api/)
 
 ---

--- a/docs/docs/quickstart/pure_numpy.md
+++ b/docs/docs/quickstart/pure_numpy.md
@@ -1,0 +1,159 @@
+# effector is purely numpy based
+
+`effector` speaks one language: **numpy**. Both things you hand it live in numpy
+and nowhere else:
+
+- **`data`** — a 2-D numeric numpy array, shape `(N, D)`.
+- **`model`** (and the optional **`model_jac`**) — a `numpy → numpy` callable:
+  `X: (N, D) → (N,)` for the model, `→ (N, D)` for the Jacobian.
+- **metadata** — everything else (feature names, types, target name, scaling)
+  travels in a single `schema=` argument.
+
+That's the whole contract. If your model was trained in PyTorch, TensorFlow, or
+on a pandas DataFrame, **you** wrap it into a `numpy → numpy` function — and
+that wrapper is exactly where the framework-specific concerns (dtype, device,
+batching) belong, because only you know them.
+
+!!! tip "Why numpy?"
+    A numpy array is the one format PyTorch, TensorFlow, JAX, scikit-learn,
+    XGBoost, and plain Python functions all speak. Standing on numpy makes
+    `effector` **fast** (the model is called as-is, with zero per-call
+    conversion) and lets it explain **any** model without shipping a single
+    framework adapter.
+
+---
+
+## The base case: numpy in, numpy model
+
+Nothing to wrap — just call it.
+
+```python
+import numpy as np
+import effector
+
+X = np.random.uniform(-1, 1, (500, 3))            # (N, D) numpy
+model = lambda A: A[:, 0] + A[:, 1] * (A[:, 2] > 0)   # numpy -> numpy
+
+effector.PDP(X, model).plot(feature=0)
+```
+
+Add a `schema` whenever you want readable axes:
+
+```python
+schema = effector.Schema(feature_names=["age", "income", "region"])
+effector.PDP(X, model, schema=schema).plot(feature=0)
+```
+
+## PyTorch
+
+Wrap the network in a `numpy → numpy` function. This is the entire integration —
+and the natural home for `eval()`, `no_grad`, device, and dtype:
+
+```python
+import torch
+
+net.eval()
+device = next(net.parameters()).device
+
+def model(X):                                  # numpy (N, D) -> numpy (N,)
+    with torch.no_grad():
+        t = torch.as_tensor(X, dtype=torch.float32, device=device)
+        return net(t).cpu().numpy().ravel()
+
+effector.PDP(X, model).plot(feature=0)
+```
+
+!!! note "Bonus: exact gradients for RHALE / DerPDP"
+    The Jacobian is *also* just `numpy → numpy`, so you can hand `effector` the
+    **exact** autograd gradient instead of its numerical fallback:
+
+    ```python
+    def model_jac(X):                          # numpy (N, D) -> numpy (N, D)
+        t = torch.as_tensor(X, dtype=torch.float32,
+                            device=device).requires_grad_(True)
+        net(t).sum().backward()
+        return t.grad.cpu().numpy()
+
+    effector.RHALE(X, model, model_jac).plot(feature=0)
+    ```
+
+## TensorFlow / Keras
+
+Keras `.predict` already takes numpy in and returns numpy out, so the wrapper is
+almost a no-op:
+
+```python
+model = lambda X: net.predict(X, verbose=0).ravel()
+effector.PDP(X, model).plot(feature=0)
+```
+
+## Starting from a pandas DataFrame
+
+Most workflows begin with a DataFrame. Convert it **once** with
+`effector.from_dataframe`, which reads column names, dtypes, and category
+labels into `(X, schema)` — and never touches your model:
+
+```python
+import dataclasses
+import effector
+
+X_np, schema = effector.from_dataframe(df)     # numpy matrix + a populated Schema
+print(schema.feature_types)                    # inspect the guesses...
+# Schema is a frozen dataclass — override anything you don't like with replace:
+schema = dataclasses.replace(schema, feature_types=["ordinal", "continuous", "nominal"])
+
+effector.PDP(X_np, model, schema=schema).plot(feature=0)
+```
+
+!!! warning "Inspect the returned schema"
+    `from_dataframe` infers types from dtypes, but an **integer** column is
+    ambiguous — ordinal, continuous, or a label-encoded nominal are all
+    plausible. `effector` emits a `UserWarning` for those guesses; check them
+    and set `feature_types` explicitly when needed.
+
+## A model that consumes a DataFrame (e.g. an sklearn Pipeline)
+
+If your model *needs* a DataFrame (a `ColumnTransformer`/`OneHotEncoder` pipeline
+trained on string columns), reconstruct the frame **inside your wrapper**:
+
+```python
+levels = ["clear", "mist", "rain"]
+
+def model(X):                                  # numpy grid -> numpy predictions
+    frame = pd.DataFrame({
+        "hour":    X[:, 0],
+        "temp":    X[:, 1],
+        "weather": pd.Categorical.from_codes(
+            np.clip(np.round(X[:, 2]), 0, 2).astype(int), levels),
+    })
+    return pipeline.predict(frame)
+
+X_np, schema = effector.from_dataframe(df)
+effector.PDP(X_np, model, schema=schema).plot(feature=0)
+```
+
+You own the reconstruction, so it's visible and testable — `effector` never
+guesses how to call your model.
+
+---
+
+## What changed
+
+Passing a DataFrame straight into a constructor no longer works — it raises,
+with the fix in the message:
+
+```python
+effector.PDP(df, model)
+# TypeError: effector is numpy-only: `data` must be a 2-D numeric numpy array,
+#   not a pandas DataFrame. Convert it first:
+#       X, schema = effector.from_dataframe(df)
+#   and pass a numpy->numpy `model` ...
+```
+
+The one-line fix is `X, schema = effector.from_dataframe(df)`.
+
+---
+
+**See also:** the [API overview](./simple_api.md) for the full constructor
+signature, and the [design contract](../design.md) (R8 constructor contract,
+R10 input contract) for the authoritative spec.

--- a/docs/docs/quickstart/simple_api.md
+++ b/docs/docs/quickstart/simple_api.md
@@ -32,13 +32,13 @@ Then pick a global (1) or regional (2) Effect Method, to explain the ML model.
 ### Dataset
 
 ???+ note "A dataset, typically the test set"
-     A `np.ndarray` with shape `(N, D)` **or a pandas DataFrame** (R10).
-     A DataFrame brings its own metadata: column names become feature names and
-     dtypes decide the feature types (`float` → continuous, low-cardinality
-     `int` → ordinal, `category`/strings → nominal, ordered `category` →
-     ordinal). With a DataFrame, your model is always called with a
-     reconstructed DataFrame (original columns and dtypes) — if it expects a
-     raw array, wrap it: `lambda X: f(X.to_numpy())`.
+     A `np.ndarray` with shape `(N, D)` — effector is numpy-only (R10).
+     Started from a pandas DataFrame? Convert it once with
+     `X, schema = effector.from_dataframe(df)`: it reads column names, dtypes
+     (`float` → continuous, low-cardinality `int` → ordinal, `category`/strings
+     → nominal, ordered `category` → ordinal), and category labels into a
+     `Schema` you can inspect and tweak. It converts the data only — it never
+     touches your model.
 
 ???+ note "Metadata travels in one `schema` argument"
      Everything else (names, types, target name, axis un-scaling) goes into a
@@ -75,15 +75,23 @@ Then pick a global (1) or regional (2) Effect Method, to explain the ML model.
     X = bike_sharing_dataset.data.features 
     y = bike_sharing_dataset.data.targets 
 
-    # split data
+    # split data (still pandas DataFrames)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+
+    # effector is numpy-only: convert the DataFrame to (numpy, schema)
+    X_test_np, schema = effector.from_dataframe(X_test)
     ```
 ---
 ### ML model
 
 ???+ note "A trained black-box model"
 
-     Must be a `Callable` with signature `X: np.ndarray[N, D]) -> np.ndarray[N]`. 
+     Must be a numpy→numpy `Callable`, signature
+     `X: np.ndarray[N, D] -> np.ndarray[N]`. A model trained on a DataFrame, a
+     PyTorch/TensorFlow tensor, or an sklearn `Pipeline` is yours to wrap into
+     that shape — e.g. PyTorch:
+     `model = lambda X: net(torch.as_tensor(X, dtype=torch.float32)).detach().numpy().ravel()`.
+     See the [*effector is purely numpy based*](./pure_numpy.md) guide.
 
 
 === "synthetic example"

--- a/effector/__init__.py
+++ b/effector/__init__.py
@@ -11,7 +11,7 @@ from effector.feature_effect import FeatureEffect
 from effector.global_effect_ale import ALE, RHALE
 from effector.global_effect_pdp import PDP, DerPDP
 from effector.global_effect_shap import ShapDP
-from effector.ingestion import Schema
+from effector.ingestion import Schema, from_dataframe
 from effector.regional_effect_ale import RegionalALE, RegionalRHALE
 from effector.regional_effect_pdp import RegionalDerPDP, RegionalPDP
 from effector.regional_effect_shap import RegionalShapDP

--- a/effector/feature_effect.py
+++ b/effector/feature_effect.py
@@ -47,10 +47,10 @@ class FeatureEffect:
     ):
         """
         Args:
-            data: the design matrix — a `(N, D)` numpy array or a pandas
-                DataFrame (converted at the door, R10)
-            model: the black-box model, `Callable` `(N, D) -> (N,)`; called with
-                a reconstructed DataFrame when `data` is a DataFrame
+            data: the design matrix — a `(N, D)` numeric numpy array (R10;
+                start from a DataFrame via `effector.from_dataframe`)
+            model: the black-box model, a numpy->numpy `Callable`
+                `(N, D) -> (N,)`
             model_jac: the model Jacobian `(N, D) -> (N, D)`, optional. Needed by
                 `RHALE`; if omitted, `RHALE` falls back to numerical differentiation.
             axis_limits: `(2, D)` array of per-feature limits, or `None` to infer
@@ -64,8 +64,9 @@ class FeatureEffect:
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. the shared

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -67,8 +67,8 @@ class GlobalEffectBase(ABC):
         self.method_name = method_name.lower()
         self.random_state = random_state
 
-        # the one door for data + metadata (R10): DataFrame -> numpy core
-        # matrix + wrapped model; numpy passes through untouched
+        # the border crossing (R10): validate numpy `data`, resolve/auto-infer
+        # metadata; `model`/`model_jac` pass through as given (numpy-only)
         ing = ingestion.ingest(data, model, model_jac, schema=schema)
         data = ing.data
         self.model = ing.model
@@ -186,20 +186,17 @@ class GlobalEffectBase(ABC):
 
     def _level_display(self, feature: int, levels=None):
         """(positions, tick labels) for categorical plots: positions are the
-        level values; labels translate encoded categories (DataFrame source)
-        back to their original names. `None` labels keep numeric ticks.
-        `levels` overrides the ascending default (fit-order for nominal ALE)."""
+        level values; labels translate the `schema.category_names` map back to
+        the original level names. `None` labels keep numeric ticks. `levels`
+        overrides the ascending default (fit-order for nominal ALE)."""
         if levels is None:
             levels = self._levels(feature)
         cat_names = self.feature_metadata.category_names
         name_of = cat_names.get(feature) if cat_names else None
-        enc = self.feature_metadata.categories.get(feature)
         if name_of is not None:
             # schema category_names, resolved to a {level_value: name} map at
             # ingest — maps by value, so level subsets (regional nodes) are fine
             labels = [name_of.get(float(v), f"{v:g}") for v in levels]
-        elif enc is not None:
-            labels = [str(enc.levels[int(c)]) for c in levels.astype(int)]
         elif self.feature_types[feature] == ingestion.NOMINAL:
             labels = [f"{v:g}" for v in levels]
         else:

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -354,8 +354,9 @@ class ALE(ALEBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
@@ -552,8 +553,9 @@ class RHALE(ALEBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -345,8 +345,9 @@ class PDP(PDPBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
@@ -520,8 +521,9 @@ class DerPDP(PDPBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -164,8 +164,9 @@ class ShapDP(GlobalEffectBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (`nof_instances` subsampling and the shap/shapiq explainer, unless overridden via `shap_explainer_kwargs`)

--- a/effector/ingestion.py
+++ b/effector/ingestion.py
@@ -1,10 +1,17 @@
 """Input ingestion — the R10 contract (docs/design.md).
 
-One door for `data`: a 2-D numeric numpy array or a pandas DataFrame. DataFrames
-are converted to a float numpy core matrix here; everything downstream of the
-constructors is numpy-only. All metadata (names, types, target name, scaling)
-travels in a single `Schema`. pandas is never imported unless the caller already
-passed a DataFrame (detection checks `sys.modules` only).
+The border crossing. `data` must be a 2-D numeric numpy array and `model`
+(and `model_jac`) must be numpy-in / numpy-out callables — effector is
+numpy-only. `ingest` validates that, then auto-infers whatever metadata the
+caller did not declare in the `Schema` (names `x_0…`, the numpy type
+heuristic, target `"y"`).
+
+A pandas DataFrame is *not* accepted as `data`: it is hard-rejected with a
+pointer to `from_dataframe`, the opt-in convenience that reads a DataFrame's
+names/dtypes/levels into `(X, Schema)`. `from_dataframe` never touches the
+model — framework/DataFrame conversion is the user's wrapper's job. pandas is
+never imported unless the caller reaches for that helper (detection checks
+`sys.modules` only).
 """
 
 import sys
@@ -26,10 +33,11 @@ DEFAULT_CAT_LIMIT = 10
 class Schema:
     """The single metadata argument of every effector constructor (R10).
 
-    All fields are optional; whatever is not declared is inferred from the data
-    (DataFrame dtypes, or numpy heuristics) or synthesized (`x_0…`, `"y"`).
-    A `Schema` holds no data, so one instance can be reused across method
-    constructions. Constructors also accept a plain dict with the same keys.
+    All fields are optional; whatever is not declared is inferred from the numpy
+    data (type heuristic) or synthesized (`x_0…`, `"y"`). `effector.from_dataframe`
+    populates one from a DataFrame's names/dtypes/levels. A `Schema` holds no
+    data, so one instance can be reused across method constructions. Constructors
+    also accept a plain dict with the same keys.
 
     Fields:
         feature_names: one name per column.
@@ -74,9 +82,6 @@ class FeatureMetadata:
     feature_names: list
     feature_types: list  # canonical three-way strings
     cat_limit: int
-    categories: dict  # {col_idx: ColumnEncoding} for encoded DataFrame columns
-    from_dataframe: bool
-    column_dtypes: typing.Optional[dict]  # {col_name: original dtype} for DataFrames
     target_name: str
     scale_x_list: typing.Optional[list] = None
     scale_y: typing.Optional[dict] = None
@@ -85,8 +90,8 @@ class FeatureMetadata:
 
 @dataclass(frozen=True)
 class IngestResult:
-    data: np.ndarray  # the 2-D numeric core matrix
-    model: typing.Callable  # wrapped iff the input was a DataFrame
+    data: np.ndarray  # the 2-D numeric core matrix (the input array, unchanged)
+    model: typing.Callable  # the user's model, passed through untouched
     model_jac: typing.Optional[typing.Callable]
     meta: FeatureMetadata
 
@@ -203,7 +208,6 @@ def validate_metadata(
     scale_x_list: typing.Optional[list],
     scale_y: typing.Optional[dict],
     target_name: str,
-    categories: typing.Optional[dict] = None,
     category_names: typing.Optional[list] = None,
     level_counts: typing.Optional[dict] = None,
 ) -> None:
@@ -222,13 +226,6 @@ def validate_metadata(
                 f"invalid feature type {t!r} at position {j}; "
                 f"valid: {'/'.join(VALID_FEATURE_TYPES)}"
             )
-    if categories:
-        for j in categories:
-            if feature_types[j] == CONTINUOUS:
-                raise ValueError(
-                    f"feature {feature_names[j]!r} comes from a non-numeric column "
-                    f"and cannot be labeled 'continuous'"
-                )
     if scale_x_list is not None:
         if len(scale_x_list) != dim:
             raise ValueError(
@@ -323,45 +320,6 @@ def _encode_dataframe(df, cat_limit: int):
     return matrix, names, inferred_types, categories, column_dtypes, heuristic_idx
 
 
-def _make_frame_builder(columns: list, categories: dict) -> typing.Callable:
-    """Build the numpy-row → DataFrame reconstructor for the model-call rule (R10)."""
-    import pandas as pd
-
-    def build(X: np.ndarray):
-        X = np.asarray(X)
-        cols = {}
-        for j, name in enumerate(columns):
-            enc = categories.get(j)
-            if enc is None:
-                cols[name] = X[:, j].astype(np.float64)
-            else:
-                codes = np.clip(np.round(X[:, j]), 0, len(enc.levels) - 1).astype(int)
-                if enc.kind == "category":
-                    cols[name] = pd.Categorical.from_codes(
-                        codes, list(enc.levels), ordered=enc.ordered
-                    )
-                elif enc.kind == "bool":
-                    cols[name] = codes.astype(bool)
-                else:  # "object"
-                    cols[name] = np.asarray(enc.levels, dtype=object)[codes]
-        return pd.DataFrame(cols, columns=list(columns))
-
-    return build
-
-
-def _wrap_model(
-    fn: typing.Optional[typing.Callable], frame_builder
-) -> typing.Optional[typing.Callable]:
-    if fn is None:
-        return None
-
-    def wrapped(X):
-        return np.asarray(fn(frame_builder(X)))
-
-    wrapped.__wrapped__ = fn
-    return wrapped
-
-
 def _heuristic_warning(heuristic_info: list):
     detail = ", ".join(f"{name!r} -> {t}" for name, t in heuristic_info)
     warnings.warn(
@@ -382,65 +340,45 @@ def ingest(
     *,
     schema=None,
 ) -> IngestResult:
-    """The one door for `data` + metadata (R10); runs before `helpers.prep_data`.
+    """The border crossing for `data` + metadata (R10); runs before
+    `helpers.prep_data`.
 
-    numpy input passes through byte-identical (no dtype cast, model untouched).
-    DataFrame input is encoded to a float matrix and `model`/`model_jac` are
-    wrapped so they are always called with a reconstructed DataFrame.
+    `data` must be a 2-D numeric numpy array; `model`/`model_jac` pass through
+    untouched (effector is numpy-only, so they must already be numpy-in /
+    numpy-out). A pandas DataFrame is rejected with a pointer to
+    `from_dataframe`. Whatever the `Schema` does not declare is inferred here.
     """
     schema = _as_schema(schema)
     cat_limit = _prep_cat_limit(schema.cat_limit)
 
-    categories = {}
-    column_dtypes = None
-    heuristic_idx = []
-    from_dataframe = is_dataframe(data)
-
-    if from_dataframe:
-        (
-            matrix,
-            df_names,
-            inferred_types,
-            categories,
-            column_dtypes,
-            heuristic_idx,
-        ) = _encode_dataframe(data, cat_limit)
-    elif isinstance(data, np.ndarray):
-        if data.ndim != 2:
-            raise ValueError(f"data must be a 2D array, got {data.ndim} dimensions")
-        if data.dtype.kind not in "fiub":
-            raise TypeError(
-                f"data has non-numeric dtype {data.dtype}; "
-                f"pass a pandas DataFrame for string/categorical columns"
-            )
-        matrix = data
-        df_names = None
-        inferred_types = None
-    else:
+    if is_dataframe(data):
         raise TypeError(
-            f"data must be a 2D numpy array or a pandas DataFrame, "
-            f"got {type(data).__name__}"
+            "effector is numpy-only: `data` must be a 2-D numeric numpy array, "
+            "not a pandas DataFrame. Convert it first:\n"
+            "    X, schema = effector.from_dataframe(df)\n"
+            "and pass a numpy->numpy `model` (wrap a DataFrame/torch/tf model "
+            "yourself)."
         )
-
+    if not isinstance(data, np.ndarray):
+        raise TypeError(f"data must be a 2D numpy array, got {type(data).__name__}")
+    if data.ndim != 2:
+        raise ValueError(f"data must be a 2D array, got {data.ndim} dimensions")
+    if data.dtype.kind not in "fiub":
+        raise TypeError(
+            f"data has non-numeric dtype {data.dtype}; encode it to a numeric "
+            f"matrix first (see effector.from_dataframe for DataFrame columns)"
+        )
+    matrix = data
     dim = matrix.shape[1]
 
-    # define-or-infer: explicit schema field > DataFrame inference > numpy heuristic
+    # define-or-infer: explicit schema field > numpy heuristic > synthesized
     if schema.feature_names is not None:
         feature_names = [str(name) for name in schema.feature_names]
-    elif df_names is not None:
-        feature_names = df_names
     else:
         feature_names = ["x_" + str(i) for i in range(dim)]
 
     if schema.feature_types is not None:
         feature_types = normalize_feature_types(schema.feature_types, dim)
-    elif inferred_types is not None:
-        feature_types = inferred_types
-        # only the risky half of the int heuristic warns: int -> continuous is
-        # the expected reading, int -> ordinal may be a label-encoded nominal
-        risky = [j for j in heuristic_idx if feature_types[j] == ORDINAL]
-        if risky:
-            _heuristic_warning([(feature_names[j], feature_types[j]) for j in risky])
     else:
         feature_types = infer_feature_types(matrix, cat_limit)
         heuristic_info = [
@@ -466,15 +404,9 @@ def ingest(
         schema.scale_x_list,
         schema.scale_y,
         target_name,
-        categories,
         schema.category_names,
         level_counts,
     )
-
-    if from_dataframe:
-        frame_builder = _make_frame_builder(feature_names, categories)
-        model = _wrap_model(model, frame_builder)
-        model_jac = _wrap_model(model_jac, frame_builder)
 
     # resolve category_names (per-feature name list, one per ascending observed
     # level) to a {level_value: name} map, so it maps by value and survives to
@@ -492,12 +424,70 @@ def ingest(
         feature_names=feature_names,
         feature_types=feature_types,
         cat_limit=cat_limit,
-        categories=categories,
-        from_dataframe=from_dataframe,
-        column_dtypes=column_dtypes,
         target_name=target_name,
         scale_x_list=schema.scale_x_list,
         scale_y=schema.scale_y,
         category_names=category_names_map,
     )
     return IngestResult(data=matrix, model=model, model_jac=model_jac, meta=meta)
+
+
+def from_dataframe(df, *, cat_limit: int = DEFAULT_CAT_LIMIT):
+    """Extract a numpy matrix and a populated `Schema` from a pandas DataFrame.
+
+    A pure convenience for the common "I started from a DataFrame" case. It
+    reads column names, maps dtypes to feature types, and pulls categorical
+    level labels, returning `(X, schema)` so you can call any effector
+    constructor as `Method(X, model, schema=schema)`.
+
+    It does **not** touch your model: effector is numpy-only, so `model` must be
+    a numpy->numpy callable. If your model consumes a DataFrame (e.g. an sklearn
+    Pipeline), wrap it yourself into a numpy->numpy function.
+
+    The returned schema is a *proposal you should inspect* — in particular the
+    int-column type guess (ordinal vs continuous vs a label-encoded nominal) is
+    the one thing no extractor can know for sure. Override any field you don't
+    like before passing it on.
+
+    Args:
+        df: a pandas DataFrame with numeric / bool / categorical / string
+            columns (no missing values).
+        cat_limit: cardinality threshold for the int-column ordinal heuristic
+            (default 10), recorded on the returned schema.
+
+    Returns:
+        `(X, schema)` where `X` is a `(N, D)` float64 numpy array and `schema`
+        is an `effector.Schema` with `feature_names`, `feature_types`,
+        `cat_limit`, and `category_names` populated.
+    """
+    if not is_dataframe(df):
+        raise TypeError(
+            f"from_dataframe expects a pandas DataFrame, got {type(df).__name__}"
+        )
+    cat_limit = _prep_cat_limit(cat_limit)
+    matrix, names, inferred_types, categories, _dtypes, heuristic_idx = (
+        _encode_dataframe(df, cat_limit)
+    )
+
+    # human-readable level names, one per *observed* level in ascending code
+    # order — exactly the shape Schema.category_names expects, so an unused
+    # declared category never trips the length check downstream
+    category_names = [None] * len(names)
+    for j, enc in categories.items():
+        observed = np.unique(matrix[:, j])
+        category_names[j] = [str(enc.levels[int(c)]) for c in observed]
+    if not any(n is not None for n in category_names):
+        category_names = None
+
+    # same guidance the numpy door gives: only int -> ordinal is a risky guess
+    risky = [j for j in heuristic_idx if inferred_types[j] == ORDINAL]
+    if risky:
+        _heuristic_warning([(names[j], inferred_types[j]) for j in risky])
+
+    schema = Schema(
+        feature_names=names,
+        feature_types=inferred_types,
+        cat_limit=cat_limit,
+        category_names=category_names,
+    )
+    return matrix, schema

--- a/effector/regional_effect.py
+++ b/effector/regional_effect.py
@@ -33,8 +33,8 @@ class RegionalEffectBase:
         self.method_name = method_name.lower()
         self.random_state = random_state
 
-        # the one door for data + metadata (R10): DataFrame -> numpy core
-        # matrix + wrapped model; numpy passes through untouched. Type
+        # the border crossing (R10): validate numpy `data`, resolve/auto-infer
+        # metadata; `model`/`model_jac` pass through as given (numpy-only). Type
         # inference runs on the full data, before subsampling.
         ing = ingestion.ingest(data, model, model_jac, schema=schema)
         data = ing.data

--- a/effector/regional_effect_ale.py
+++ b/effector/regional_effect_ale.py
@@ -78,8 +78,9 @@ class RegionalRHALE(RegionalEffectBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
@@ -298,8 +299,9 @@ class RegionalALE(RegionalEffectBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)

--- a/effector/regional_effect_pdp.py
+++ b/effector/regional_effect_pdp.py
@@ -109,8 +109,9 @@ class RegionalPDP(RegionalPDPBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)
@@ -313,8 +314,9 @@ class RegionalDerPDP(RegionalPDPBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (e.g. `nof_instances` subsampling)

--- a/effector/regional_effect_shap.py
+++ b/effector/regional_effect_shap.py
@@ -65,8 +65,9 @@ class RegionalShapDP(RegionalEffectBase):
                 with any of the keys `feature_names`, `feature_types`,
                 `cat_limit`, `target_name`, `scale_x_list`, `scale_y`
 
-                - omitted fields are inferred from the data (DataFrame dtypes,
-                  numpy heuristics) or synthesized (`["x_0", ...]`, `"y"`)
+                - omitted fields are auto-inferred from `data` (numpy
+                  heuristics) or synthesized (`["x_0", ...]`, `"y"`); to start
+                  from a DataFrame use `effector.from_dataframe`
                 - explicit fields always win over inference
 
             random_state: seed for every internal random step (`nof_instances` subsampling and the shap/shapiq explainer, unless overridden via `shap_explainer_kwargs`)

--- a/tests/test_contract_ingestion.py
+++ b/tests/test_contract_ingestion.py
@@ -1,13 +1,16 @@
 """Contract layer for R10 — the input contract (docs/design.md R10).
 
 The load-bearing promises:
-- numpy in == DataFrame in: identical numbers out (exact, atol=0);
+- effector is numpy-only: `from_dataframe(df)` reproduces the numpy matrix so a
+  DataFrame origin gives identical numbers out (exact, atol=0);
 - every class exposes the resolved `feature_metadata`;
 - legacy aliases ("cont"/"cat") are normalized at the door and keep the
   categorical split path working;
 - internally built objects (regional nodes, facade sub-methods) inherit the
   parent's resolved metadata instead of re-inferring from subsets.
 """
+
+import dataclasses
 
 import numpy as np
 import pytest
@@ -26,7 +29,6 @@ from tests.conftest import (
     make_mixed_df,
     make_regional,
     make_regional_data,
-    mixed_df_model,
 )
 
 # ---------------------------------------------------------------------------
@@ -37,13 +39,14 @@ from tests.conftest import (
 @pytest.mark.parametrize("name", GLOBAL_NAMES)
 def test_r10_df_numpy_parity_eval(name):
     data = make_global_data()
-    df = make_global_df()
     xs = np.linspace(-0.8, 0.8, 7)
 
     m_np = make_global(name, data)
+    # from_dataframe must reproduce the numpy matrix exactly -> identical output
+    X_df, schema = effector.from_dataframe(make_global_df())
     # shap values must be an aligned ndarray on both paths (they bypass ingest)
     kwargs = {"shap_values": analytic_shap_values(data)} if name == "shapdp" else {}
-    m_df = make_global(name, df, **kwargs)
+    m_df = make_global(name, X_df, schema=schema, **kwargs)
     y_np = eval_mean(m_np, 0, xs, centering=False)
     y_df = eval_mean(m_df, 0, xs, centering=False)
     np.testing.assert_array_equal(y_np, y_df)
@@ -62,13 +65,11 @@ def test_r10_df_numpy_parity_regional_tree(name):
     types = ["continuous", "continuous", "ordinal"]
     reg_np = make_regional(name, data, schema={"feature_types": types})
     cls = effector.RegionalPDP if name == "regional_pdp" else effector.RegionalALE
-    # the model receives a reconstructed DataFrame on the DF path (R10) —
-    # an array-expecting model uses the documented escape hatch
-    reg_df = cls(
-        df,
-        lambda x: gated_model(x.to_numpy()),
-        schema={"feature_types": types},
-    )
+    # numpy-only: convert the DataFrame first, force the shared types, and feed
+    # the plain numpy model (the encoded matrix equals `data`)
+    X_df, schema = effector.from_dataframe(df)
+    schema = dataclasses.replace(schema, feature_types=types)
+    reg_df = cls(X_df, gated_model, schema=schema)
     part = effector.space_partitioning.Best(max_depth=2)
     reg_np.fit(0, space_partitioner=part)
     reg_df.fit(0, space_partitioner=part)
@@ -175,47 +176,20 @@ def test_r10_facade_submethods_inherit_types():
 
 
 # ---------------------------------------------------------------------------
-# R10.5 — the model-call rule, end to end
+# R10.5 — from_dataframe fidelity: the encoded matrix drives the methods
 # ---------------------------------------------------------------------------
-
-
-def test_r10_mixed_df_end_to_end():
-    df = make_mixed_df()
-    calls = []
-
-    def recording_model(x):
-        calls.append(
-            (
-                type(x).__name__,
-                str(x["color"].dtype),
-                bool(x["size"].cat.ordered),
-            )
-        )
-        return mixed_df_model(x)
-
-    with pytest.warns(UserWarning, match="cardinality heuristic"):
-        pdp = effector.PDP(df, recording_model)
-    xs = np.linspace(-0.5, 0.5, 5)
-    y = pdp.eval(0, xs, centering=False)
-
-    assert y.shape == (5,)
-    assert len(calls) > 0
-    for type_name, color_dtype, size_ordered in calls:
-        assert type_name == "DataFrame"
-        assert color_dtype == "category"
-        assert size_ordered is True
 
 
 def test_r10_mixed_df_shapdp_with_analytic_values():
     df = make_mixed_df()
-    matrix = ingestion.ingest(df, mixed_df_model).data
+    with pytest.warns(UserWarning, match="cardinality heuristic"):
+        matrix, schema = effector.from_dataframe(df)
     shap_values = 0.1 * (matrix - matrix.mean(axis=0))  # any aligned array
-    m = effector.ShapDP(
-        df,
-        mixed_df_model,
-        shap_values=shap_values,
-        schema={"feature_types": ["continuous", "ordinal", "nominal", "ordinal"]},
-    )
+
+    def model(X):  # mixed_df_model, expressed on the encoded matrix (numpy->numpy)
+        return 2.0 * X[:, 0] + X[:, 1] + X[:, 2] + 0.5 * X[:, 3]
+
+    m = effector.ShapDP(matrix, model, shap_values=shap_values, schema=schema)
     y = m.eval(0, np.linspace(-0.5, 0.5, 5), centering=False)
     assert y.shape == (5,)
 

--- a/tests/test_regional_categorical.py
+++ b/tests/test_regional_categorical.py
@@ -140,7 +140,7 @@ def test_shapdp_cat_plot_smoke(data, model):
     assert len(ax.patches) == 3
 
 
-def test_nominal_plot_uses_level_labels(model):
+def test_nominal_plot_uses_level_labels():
     import pandas as pd
 
     n = 400
@@ -151,11 +151,13 @@ def test_nominal_plot_uses_level_labels(model):
             "num": rng.uniform(-1, 1, n),
         }
     )
+    # numpy-only: convert once; the schema carries the "b"/"g"/"r" labels
+    X, schema = effector.from_dataframe(df)
 
-    def df_model(d):
-        return d["color"].cat.codes.to_numpy().astype(float) + d["num"].to_numpy()
+    def np_model(A):  # color code + num, on the encoded matrix
+        return A[:, 0] + A[:, 1]
 
-    pdp = effector.PDP(df, df_model)
+    pdp = effector.PDP(X, np_model, schema=schema)
     fig, ax = pdp.plot(0, heterogeneity="std", show_plot=False)
     labels = [t.get_text() for t in ax.get_xticklabels()]
     assert labels == ["b", "g", "r"]  # pandas sorts categories alphabetically

--- a/tests/test_unit_ingestion.py
+++ b/tests/test_unit_ingestion.py
@@ -1,22 +1,25 @@
 """Unit tests for effector/ingestion.py — the R10 input contract.
 
-Layer: unit (Tier-1, tiny N). The contract-level DF-vs-numpy parity tests live
-in tests/test_contract_ingestion.py.
+Layer: unit (Tier-1, tiny N). effector is numpy-only: constructors take a numpy
+`data` + a numpy->numpy `model`; a DataFrame is converted first with the
+`from_dataframe` convenience. The contract-level DF->numpy parity tests live in
+tests/test_contract_ingestion.py.
 """
 
 import subprocess
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
 import pytest
 
-from effector import ingestion
 from effector.ingestion import (
     CONTINUOUS,
     NOMINAL,
     ORDINAL,
     Schema,
+    from_dataframe,
     infer_feature_types,
     ingest,
     normalize_feature_types,
@@ -49,11 +52,6 @@ def _mixed_df(n=30):
     )
 
 
-def _df_model(df):
-    codes = df["color"].cat.codes.to_numpy()
-    return df["num"].to_numpy() * 2.0 + codes
-
-
 # ---------------------------------------------------------------------------
 # numpy path: passthrough + rejections
 # ---------------------------------------------------------------------------
@@ -63,10 +61,8 @@ def test_ingest_numpy_passthrough_identity():
     data = _num_data()
     res = ingest(data, _model)
     assert res.data is data  # no copy, no dtype cast
-    assert res.model is _model  # no wrapping on the numpy path
+    assert res.model is _model  # model is never wrapped
     assert res.model_jac is None
-    assert res.meta.from_dataframe is False
-    assert res.meta.categories == {}
 
 
 def test_ingest_numpy_int_dtype_not_cast():
@@ -83,13 +79,19 @@ def test_ingest_rejects_1d():
 
 def test_ingest_rejects_object_ndarray():
     data = np.array([["a", "b"], ["c", "d"]], dtype=object)
-    with pytest.raises(TypeError, match="pandas DataFrame"):
+    with pytest.raises(TypeError, match="non-numeric dtype"):
         ingest(data, _model)
 
 
 def test_ingest_rejects_unknown_type():
-    with pytest.raises(TypeError, match="numpy array or a pandas DataFrame"):
+    with pytest.raises(TypeError, match="must be a 2D numpy array"):
         ingest([[1.0, 2.0]], _model)
+
+
+def test_ingest_rejects_dataframe():
+    df = pd.DataFrame({"a": np.linspace(0, 1, 30)})
+    with pytest.raises(TypeError, match="from_dataframe"):
+        ingest(df, _model)
 
 
 # ---------------------------------------------------------------------------
@@ -125,59 +127,93 @@ def test_infer_numpy_never_nominal():
 
 
 # ---------------------------------------------------------------------------
-# DataFrame inference table
+# from_dataframe: dtype inference table + numpy/schema extraction
 # ---------------------------------------------------------------------------
 
 
-def test_infer_df_dtype_table():
+def test_from_dataframe_dtype_table():
     with pytest.warns(UserWarning, match="cardinality heuristic"):
-        res = ingest(_mixed_df(), _df_model)
-    assert res.meta.feature_types == [
+        X, schema = from_dataframe(_mixed_df())
+    assert schema.feature_types == [
         CONTINUOUS,  # float
         ORDINAL,  # int, nunique < cat_limit (heuristic)
         NOMINAL,  # unordered category
         ORDINAL,  # ordered category
         NOMINAL,  # object strings
     ]
-    assert res.meta.feature_names == ["num", "count", "color", "size", "label"]
-    assert res.meta.from_dataframe is True
+    assert schema.feature_names == ["num", "count", "color", "size", "label"]
+    assert X.dtype == np.float64 and X.shape == (30, 5)
 
 
-def test_infer_df_int_large_is_continuous_and_silent():
-    import warnings
-
+def test_from_dataframe_int_large_is_continuous_and_silent():
     df = pd.DataFrame({"a": np.arange(30)})
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)  # int->continuous is safe
-        res = ingest(df, _model)
-    assert res.meta.feature_types == [CONTINUOUS]
+        _, schema = from_dataframe(df)
+    assert schema.feature_types == [CONTINUOUS]
 
 
-def test_infer_df_bool_is_ordinal():
+def test_from_dataframe_bool_is_ordinal():
     df = pd.DataFrame({"a": np.tile([True, False], 15)})
-    res = ingest(df, _model)
-    assert res.meta.feature_types == [ORDINAL]
-    assert res.meta.categories[0].kind == "bool"
+    _, schema = from_dataframe(df)
+    assert schema.feature_types == [ORDINAL]
+    assert schema.category_names[0] == ["False", "True"]
 
 
-def test_ordered_category_levels_keep_declared_order():
+def test_from_dataframe_ordered_category_keeps_declared_order():
     with pytest.warns(UserWarning):
-        res = ingest(_mixed_df(), _df_model)
-    assert res.meta.categories[3].levels == ("S", "M", "L")  # not alphabetical
-    assert res.meta.categories[3].ordered is True
-    assert res.meta.categories[2].ordered is False
+        _, schema = from_dataframe(_mixed_df())
+    # ordered 'size' -> ordinal, labels in declared (not alphabetical) order
+    assert schema.feature_types[3] == ORDINAL
+    assert schema.category_names[3] == ["S", "M", "L"]
+    # unordered 'color' -> nominal
+    assert schema.feature_types[2] == NOMINAL
 
 
-def test_df_datetime_raises():
+def test_from_dataframe_datetime_raises():
     df = pd.DataFrame({"t": pd.date_range("2026-01-01", periods=5)})
     with pytest.raises(ValueError, match="unsupported dtype"):
-        ingest(df, _model)
+        from_dataframe(df)
 
 
-def test_nan_in_dataframe_raises_naming_column():
+def test_from_dataframe_nan_raises_naming_column():
     df = pd.DataFrame({"a": [1.0, np.nan, 3.0]})
     with pytest.raises(ValueError, match="'a'.*missing"):
-        ingest(df, _model)
+        from_dataframe(df)
+
+
+def test_from_dataframe_uses_column_names():
+    df = pd.DataFrame({"a": np.linspace(0, 1, 30), "b": np.linspace(0, 1, 30)})
+    _, schema = from_dataframe(df)
+    assert schema.feature_names == ["a", "b"]
+
+
+def test_from_dataframe_rejects_non_dataframe():
+    with pytest.raises(TypeError, match="expects a pandas DataFrame"):
+        from_dataframe(_num_data())
+
+
+def test_from_dataframe_roundtrip_numpy_and_schema():
+    df = pd.DataFrame(
+        {
+            "num": np.linspace(-1, 1, 6),
+            "grade": pd.Categorical(
+                ["low", "mid", "high", "low", "mid", "high"],
+                categories=["low", "mid", "high"],
+                ordered=True,
+            ),
+            "color": pd.Categorical(["r", "g", "b", "r", "g", "b"]),
+        }
+    )
+    X, schema = from_dataframe(df)
+    assert X.dtype == np.float64 and X.shape == (6, 3)
+    assert schema.feature_types == [CONTINUOUS, ORDINAL, NOMINAL]
+    assert schema.category_names[1] == ["low", "mid", "high"]  # ordered kept
+    assert schema.category_names[2] == ["b", "g", "r"]  # unordered -> sorted
+    np.testing.assert_array_equal(X[:, 1], df["grade"].cat.codes.to_numpy())
+    # the (X, schema) pair drives a constructor; labels resolve by value
+    res = ingest(X, _model, schema=schema)
+    assert res.meta.category_names[1] == {0.0: "low", 1.0: "mid", 2.0: "high"}
 
 
 # ---------------------------------------------------------------------------
@@ -204,10 +240,9 @@ def test_explicit_types_override_inference():
     assert res.meta.feature_types == [CONTINUOUS, ORDINAL]
 
 
-def test_explicit_names_override_df_columns():
-    df = pd.DataFrame({"a": np.linspace(0, 1, 30)})
-    res = ingest(df, _model, schema={"feature_names": ["renamed"]})
-    assert res.meta.feature_names == ["renamed"]
+def test_explicit_names_override_inference():
+    res = ingest(_num_data(), _model, schema={"feature_names": ["a", "b", "renamed"]})
+    assert res.meta.feature_names == ["a", "b", "renamed"]
 
 
 def test_schema_dataclass_and_dict_equivalent():
@@ -258,12 +293,6 @@ def test_cat_limit_too_small_raises():
         ingest(_num_data(), _model, schema={"cat_limit": 1})
 
 
-def test_continuous_label_on_string_column_raises():
-    df = pd.DataFrame({"s": ["a", "b", "a"] * 10})
-    with pytest.raises(ValueError, match="non-numeric column"):
-        ingest(df, _model, schema={"feature_types": ["continuous"]})
-
-
 def test_target_name_default_and_override():
     assert ingest(_num_data(), _model).meta.target_name == "y"
     res = ingest(_num_data(), _model, schema={"target_name": "price"})
@@ -282,8 +311,6 @@ def test_heuristic_warning_fires_for_numpy_int_columns():
 
 
 def test_heuristic_warning_silent_for_dtype_decided():
-    import warnings
-
     df = pd.DataFrame(
         {
             "num": np.linspace(0, 1, 30),
@@ -292,111 +319,14 @@ def test_heuristic_warning_silent_for_dtype_decided():
     )
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        ingest(df, _df_model_simple)
-
-
-def _df_model_simple(df):
-    return df["num"].to_numpy()
+        from_dataframe(df)
 
 
 def test_heuristic_warning_silenced_by_explicit_types():
     data = np.stack([np.tile(np.arange(3.0), 10), np.linspace(0, 1, 30)], axis=1)
-    import warnings
-
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
         ingest(data, _model, schema={"feature_types": ["ordinal", "cont"]})
-
-
-# ---------------------------------------------------------------------------
-# model wrapping / frame reconstruction
-# ---------------------------------------------------------------------------
-
-
-def test_frame_builder_roundtrip_exact():
-    df = _mixed_df()
-    with pytest.warns(UserWarning):
-        res = ingest(df, _df_model)
-    rebuilt = ingestion._make_frame_builder(
-        res.meta.feature_names, res.meta.categories
-    )(res.data)
-    assert list(rebuilt.columns) == list(df.columns)
-    pd.testing.assert_series_equal(
-        rebuilt["color"].reset_index(drop=True),
-        df["color"].reset_index(drop=True),
-        check_names=False,
-        check_categorical=False,
-    )
-    assert rebuilt["size"].cat.ordered
-    assert (rebuilt["label"].to_numpy() == df["label"].to_numpy()).all()
-    np.testing.assert_allclose(rebuilt["num"].to_numpy(), df["num"].to_numpy())
-
-
-def test_wrapped_model_receives_dataframe_with_original_dtypes():
-    df = _mixed_df()
-    seen = {}
-
-    def recording_model(x):
-        seen["type"] = type(x).__name__
-        seen["color_dtype"] = str(x["color"].dtype)
-        seen["color_values"] = set(x["color"].unique().tolist())
-        return x["num"].to_numpy()
-
-    with pytest.warns(UserWarning):
-        res = ingest(df, recording_model)
-    out = res.model(res.data)
-    assert seen["type"] == "DataFrame"
-    assert seen["color_dtype"] == "category"
-    assert seen["color_values"] <= {"r", "g", "b"}
-    np.testing.assert_allclose(out, df["num"].to_numpy())
-
-
-def test_wrapped_model_rounds_fractional_codes():
-    df = pd.DataFrame(
-        {"color": pd.Categorical(["r", "g", "b"] * 10), "num": np.linspace(0, 1, 30)}
-    )
-    seen = {}
-
-    def recording_model(x):
-        seen["values"] = set(x["color"].unique().tolist())
-        return x["num"].to_numpy()
-
-    res = ingest(df, recording_model)
-    x = res.data.copy()
-    x[:, 0] = x[:, 0] + 0.4  # fractional codes, as a grid sweep would produce
-    x[0, 0] = 99.0  # out of range -> clipped to the last level
-    res.model(x)
-    assert seen["values"] <= {"r", "g", "b"}
-
-
-def test_model_jac_wrapped_same_way():
-    df = pd.DataFrame({"num": np.linspace(0, 1, 30)})
-    seen = {}
-
-    def jac(x):
-        seen["type"] = type(x).__name__
-        return np.ones((len(x), 1))
-
-    res = ingest(df, _model_num, jac)
-    res.model_jac(res.data)
-    assert seen["type"] == "DataFrame"
-
-
-def _model_num(df):
-    return df["num"].to_numpy()
-
-
-def test_all_numeric_dataframe_still_wrapped():
-    df = pd.DataFrame({"num": np.linspace(0, 1, 30)})
-    seen = {}
-
-    def recording_model(x):
-        seen["type"] = type(x).__name__
-        return x["num"].to_numpy()
-
-    res = ingest(df, recording_model)
-    res.model(res.data)
-    assert seen["type"] == "DataFrame"  # one predictable rule, no special case
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

effector's input boundary accepted **either** a numpy array **or** a pandas DataFrame as `data`, and on the DataFrame path it silently **wrapped the user's `model`/`model_jac`** to re-call them with a reconstructed DataFrame (the "mirror contract"). This is dropped in favor of a single, strict numpy contract:

- **Speed** — the wrapped model reconstructed a DataFrame on *every* call (ICE grids, SHAP background, RHALE bins); numpy is zero-copy.
- **Fewer bugs** — the implicit, type-triggered contract switch hid reconstruction bugs *inside* effector (int→float64, category-order mismatches).
- **Universality** — "the user owns wrapping (dtype/device/batching)" now holds uniformly, so any framework (PyTorch/TF/JAX/sklearn) works via a thin numpy→numpy wrapper, with no framework adapters in the library.

## The contract (numpy-only)

- `data` — a 2-D numeric numpy array. Period.
- `model` / `model_jac` — `numpy (N,D) → (N,)` / `→ (N,D)`, called exactly as given (never wrapped).
- metadata travels only via `schema=`; `ingest()` is a border check that auto-infers what the `Schema` omits.
- a DataFrame passed as `data` is **hard-rejected** with a `TypeError` pointing to the new helper.

## New: `effector.from_dataframe(df) -> (X, schema)`

Pure metadata extraction — reads column names, dtypes→types, and category labels into `(numpy matrix, Schema)`. It **never touches the model**. The returned schema is a proposal to inspect (the int-column type guess is inherently ambiguous, and warns).

## Changes

- `ingestion.py` — numpy-only `ingest()`; deleted `_wrap_model`/`_make_frame_builder` and the dead `FeatureMetadata` fields (`categories`, `from_dataframe`, `column_dtypes`); added public `from_dataframe`.
- Downstream — dropped the now-unreachable label fallback in `global_effect._level_display`; exported `from_dataframe`; corrected stale comments/docstrings across the method files. Regional node metadata inheritance is unchanged (driven by level-subsetting, not DataFrames).
- Docs — rewrote `design.md` R10 (removed the "Model-call rule"), touched R8, updated `simple_api.md`, added the quickstart guide **"effector is purely numpy based"** (numpy / PyTorch+autograd / Keras / `from_dataframe` / sklearn-Pipeline examples).
- Tests — removed the ~6 wrapping tests; the DataFrame↔numpy *parity* contract became a `from_dataframe` *fidelity* contract; added reject + roundtrip tests.

## Verification

- Full fast suite (`pytest -m "not slow"`) green; `ruff format` + `ruff check` clean.
- Smoke: numpy path unchanged, DataFrame rejected with the pointer, `from_dataframe` roundtrip preserves categorical labels.
- PyTorch end-to-end (PDP + RHALE + RegionalRHALE with an autograd `model_jac`).
- `mkdocs build` succeeds; the new guide and its links resolve.