### PR TITLE
fix: auto-refit preserves the fit's method kwargs (order/binning_method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # [Unreleased]
 
+### Fixed
+
+- global effects: a centering-triggered auto-refit (e.g. `fit(centering=False, order=[...])` then `eval`/`plot` with centering) no longer discards the method-specific `fit` kwargs — `order`/`binning_method` (and `use_vectorized`) are replayed from the original `fit`, overriding only `centering`, instead of silently falling back to the defaults
+
 # [0.4.0] - 2026-07-06
 
 ### Breaking

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -318,7 +318,7 @@ class GlobalEffectBase(ABC):
             the heterogeneity curve h(xs), `(T,)`, non-negative
         """
         if self.requires_refit(feature, centering=False):
-            self.fit(features=feature)
+            self._refit(feature)
         return self._eval_unnorm(feature, xs, heterogeneity=True)[1]
 
     def payload(self, feature: int) -> dict:
@@ -327,7 +327,7 @@ class GlobalEffectBase(ABC):
         and variances for (RH)ALE, splines and shap values for ShapDP, the
         normalization constants for PDP)."""
         if self.requires_refit(feature, centering=False):
-            self.fit(features=feature)
+            self._refit(feature)
         return dict(self.feature_effect["feature_" + str(feature)])
 
     def heter_score(self, feature: int) -> float:
@@ -374,6 +374,26 @@ class GlobalEffectBase(ABC):
 
         return False
 
+    def _refit(self, feature: int, centering=None) -> None:
+        """Auto-refit for `feature`, replaying the kwargs of the user's last
+        explicit `fit` and overriding **only** `centering`. This keeps a
+        method-specific fit config (`order`, `binning_method`, …) intact when a
+        later `eval`/`plot` forces a refit because centering changed; without
+        it the refit would silently fall back to the method defaults.
+
+        Falls back to a plain default fit when the feature was never fitted
+        (nothing recorded to replay)."""
+        prev = self.fit_args.get("feature_" + str(feature))
+        if prev is None:
+            if centering is None:
+                self.fit(features=feature)
+            else:
+                self.fit(features=feature, centering=centering)
+            return
+        replay = {k: v for k, v in prev.items() if k != "centering"}
+        eff_centering = prev["centering"] if centering is None else centering
+        self._fit_loop(feature, eff_centering, **replay)
+
     def eval(
         self,
         feature: int,
@@ -409,7 +429,7 @@ class GlobalEffectBase(ABC):
         centering = helpers.prep_centering(centering)
 
         if self.requires_refit(feature, centering):
-            self.fit(features=feature, centering=centering)
+            self._refit(feature, centering)
 
         if not self.axis_limits[0, feature] < self.axis_limits[1, feature]:
             raise ValueError(

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -186,9 +186,7 @@ class PDPBase(GlobalEffectBase):
         # the ICE table is the method's own object: computed by the kernel and
         # centered with the stored per-instance norms (payload state)
         if self.requires_refit(feature, centering):
-            self.fit(
-                features=feature, centering=centering, use_vectorized=use_vectorized
-            )
+            self._refit(feature, centering)
         yy = self._predict(self.data, x, feature, use_vectorized)
         if centering is not False:
             norm_consts = self.feature_effect["feature_" + str(feature)]["norm_const"]

--- a/tests/test_functional_categorical.py
+++ b/tests/test_functional_categorical.py
@@ -298,6 +298,26 @@ def test_ale_explicit_order_permutes_accumulation(data, model):
     np.testing.assert_allclose(y, expected, atol=1e-10)
 
 
+def test_ale_refit_on_centering_change_preserves_order(data, model):
+    # D3 regression: fitting uncentered with a custom order and then evaluating
+    # centered forces an auto-refit (norm_const is None). That refit must replay
+    # the fit's `order`, not fall back to the default ascending order.
+    order = [2.0, 0.0, 1.0]
+
+    ale = effector.ALE(data, model.predict, nof_instances="all", schema=SCHEMA)
+    ale.fit(0, centering=False, order=order)
+    y = ale.eval(0, np.array(order), centering="zero_integral")
+
+    # the custom order must survive the centering-triggered refit
+    np.testing.assert_array_equal(ale.feature_effect["feature_0"]["levels"], order)
+
+    # and the centered answer must equal fitting centered with that order upfront
+    ref = effector.ALE(data, model.predict, nof_instances="all", schema=SCHEMA)
+    ref.fit(0, centering="zero_integral", order=order)
+    y_ref = ref.eval(0, np.array(order), centering="zero_integral")
+    np.testing.assert_allclose(y, y_ref, atol=1e-10)
+
+
 def test_ale_order_list_with_multiple_features_raises(data, model):
     ale = effector.ALE(data, model.predict, schema=SCHEMA)
     with pytest.raises(ValueError, match="exactly one categorical"):


### PR DESCRIPTION
From the execution-graph review, Phase B (fit loop). Confirmed correctness bug.

## The bug
A later `eval`/`plot`/`eval_heter` with a different `centering` than the one used at `fit` correctly triggers a refit (`requires_refit`). But the refit called `self.fit(features=feature[, centering=...])` with **all other kwargs at their per-method defaults**, silently discarding the method-specific config the user passed to `fit` — most importantly ALE/RHALE's `order` and `binning_method`.

Repro (was `CLOBBERED: True`, now `False`):
```python
ale.fit(feature=0, centering=False, order=[3,1,2,0])
ale.eval(feature=0, centering=True)   # refit fires (norm_const is None)
# before: stored level order reset to [0,1,2,3]
```

## The fix
The full fit config is already recorded at fit time in `self.fit_args[key]` — the refit path just wasn't using it. New `GlobalEffectBase._refit(feature, centering=None)` **replays** `fit_args[key]`, overriding **only** `centering` (and falls back to a plain default fit when the feature was never fitted). All four auto-refit sites — `eval`, `eval_heter`, `payload`, PDP `_plot` — route through it.

This matches the agreed semantics: a differing arg (centering) triggers a refit that changes *only* that arg; everything else stays as the user's `fit` set it.

## Tests
- New regression: `test_ale_refit_on_centering_change_preserves_order` — asserts the order survives the refit **and** the centered result equals fitting centered with that order upfront.
- Full suite: 520 passed, 1 skipped.

## Not in scope (logged)
`points_for_centering` uses a hard-coded default `30` rather than the `helpers.NOF_INTERNAL_POINTS` "one knob" — cosmetic DRY, left for a separate change.