### PR TITLE
refactor: correct-altitude cleanup of the compute/draw layers (D2, D4, D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - global effects: a centering-triggered auto-refit (e.g. `fit(centering=False, order=[...])` then `eval`/`plot` with centering) no longer discards the method-specific `fit` kwargs — `order`/`binning_method` (and `use_vectorized`) are replayed from the original `fit`, overriding only `centering`, instead of silently falling back to the defaults
 
+### Changed
+
+- internal (no output change): tightened the compute/draw boundary (R1). `visualization.plot_pdp_ice` no longer computes the mean line or std/std-err band from the raw ICE table — the PDP method hands it the pre-computed curve + band (the band is now definitionally `sqrt(eval_heter)`, the single source of heterogeneity). PDP's per-instance `norm_const` reduction moved from a `np.ndim` branch in the base `eval` to an overridable `_mean_norm_const` hook. Centering-grid resolution now flows from the single `helpers.NOF_INTERNAL_POINTS` knob instead of a hard-coded `30`.
+
 # [0.4.0] - 2026-07-06
 
 ### Breaking

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -242,7 +242,7 @@ class GlobalEffectBase(ABC):
         self,
         features: Union[int, str, list],
         centering: Union[bool, str],
-        points_for_centering: int = 30,
+        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         **fit_feature_kwargs,
     ) -> None:
         """The one fit skeleton every method shares (R1): normalize inputs,
@@ -268,7 +268,10 @@ class GlobalEffectBase(ABC):
             self.is_fitted[s] = True
 
     def _compute_norm_const(
-        self, feature: int, method: str = "zero_integral", nof_points: int = 30
+        self,
+        feature: int,
+        method: str = "zero_integral",
+        nof_points: int = helpers.NOF_INTERNAL_POINTS,
     ) -> float:
         """Compute the normalization constant from the evaluation kernel:
         `zero_integral` = the mean over the feature interval, `zero_start` =
@@ -374,6 +377,12 @@ class GlobalEffectBase(ABC):
 
         return False
 
+    def _mean_norm_const(self, norm_const):
+        """The scalar amount the centered mean effect subtracts. It is a scalar
+        for most methods (ALE/RHALE/ShapDP), so the stored value is returned as
+        is; PDP overrides this because its norm_const is a per-instance array."""
+        return norm_const
+
     def _refit(self, feature: int, centering=None) -> None:
         """Auto-refit for `feature`, replaying the kwargs of the user's last
         explicit `fit` and overriding **only** `centering`. This keeps a
@@ -440,7 +449,5 @@ class GlobalEffectBase(ABC):
         y = self._eval_unnorm(feature, xs)
         if centering is not False:
             norm_const = self.feature_effect["feature_" + str(feature)]["norm_const"]
-            # PDP stores a per-instance array (each ICE centers on its own);
-            # the shift of the mean effect is its average
-            y = y - (norm_const if np.ndim(norm_const) == 0 else np.mean(norm_const))
+            y = y - self._mean_norm_const(norm_const)
         return y

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -409,7 +409,7 @@ class ALE(ALEBase):
         features: typing.Union[int, str, list] = "all",
         *,
         centering: typing.Union[bool, str] = True,
-        points_for_centering: int = 30,
+        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         binning_method: typing.Union[str, ap.Fixed] = "fixed",
         order: typing.Union[None, str, list] = None,
     ) -> None:
@@ -620,7 +620,7 @@ class RHALE(ALEBase):
         features: typing.Union[int, str, list] = "all",
         *,
         centering: typing.Union[bool, str] = True,
-        points_for_centering: int = 30,
+        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         binning_method: typing.Union[
             str, ap.DynamicProgramming, ap.Greedy, ap.Fixed
         ] = "greedy",

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -56,7 +56,10 @@ class PDPBase(GlobalEffectBase):
         return {}
 
     def _compute_norm_const(
-        self, feature: int, method: str = "zero_integral", nof_points: int = 30
+        self,
+        feature: int,
+        method: str = "zero_integral",
+        nof_points: int = helpers.NOF_INTERNAL_POINTS,
     ):
         """(d-)PDP overrides the base: its normalization constant is
         *per-instance* — each ICE curve is centered on its own — so an
@@ -84,6 +87,11 @@ class PDPBase(GlobalEffectBase):
         y = self._predict(self.data, xx, feature, use_vectorized)
         return y[0]
 
+    def _mean_norm_const(self, norm_const):
+        # PDP's norm_const is per-instance (each ICE centers on its own); the
+        # mean-effect shift is their average
+        return np.mean(norm_const)
+
     def _eval_unnorm(self, feature: int, x: np.ndarray, heterogeneity: bool = False):
         """Kernel: uncentered mean (d-)ICE at `x`; with `heterogeneity`, also
         h(x) — the variance across the *per-instance centered* ICE curves for
@@ -109,7 +117,9 @@ class PDPBase(GlobalEffectBase):
                 )
             else:
                 xx = np.linspace(
-                    self.axis_limits[0, feature], self.axis_limits[1, feature], 30
+                    self.axis_limits[0, feature],
+                    self.axis_limits[1, feature],
+                    helpers.NOF_INTERNAL_POINTS,
                 )
                 per_instance_norm = np.mean(
                     self._predict(self.data, xx, feature, use_vectorized=True), axis=0
@@ -124,7 +134,7 @@ class PDPBase(GlobalEffectBase):
         features: Union[int, str, list] = "all",
         *,
         centering: Union[bool, str] = False,
-        points_for_centering: int = 30,
+        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         use_vectorized: bool = True,
     ):
         """
@@ -244,10 +254,22 @@ class PDPBase(GlobalEffectBase):
                 y_limits=y_limits,
                 show_plot=show_plot,
             )
+        # R1: the method owns the compute. Derive the mean line and the
+        # std/std_err band here (from the ICE table we already have — one model
+        # pass, no re-eval); the plot layer only draws. The raw table is handed
+        # over only for the "ice" cloud, which genuinely needs every curve.
+        y_mean = yy.mean(axis=1)
+        band = None
+        if heterogeneity == "std":
+            band = np.std(yy, axis=1)
+        elif heterogeneity == "std_err":
+            band = np.std(yy, axis=1) / np.sqrt(yy.shape[1])
         return vis.plot_pdp_ice(
             x,
             feature,
-            yy=yy,
+            y_mean=y_mean,
+            band=band,
+            ice=yy if heterogeneity == "ice" else None,
             title=title,
             heterogeneity=heterogeneity,
             y_pdp_label="PDP" if self.method_name == "pdp" else "d-PDP",

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -321,7 +321,7 @@ class ShapDP(GlobalEffectBase):
         features: Union[int, str, List] = "all",
         *,
         centering: Union[bool, str] = True,
-        points_for_centering: int = 30,
+        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         binning_method: Union[str, ap.Greedy, ap.Fixed] = "greedy",
     ) -> None:
         r"""Fit the SHAP Dependence Plot to the data.

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -160,11 +160,13 @@ def ale_plot(
 def plot_pdp_ice(
     x,
     feature,
-    yy,
+    y_mean,
     title,
     heterogeneity,
     y_pdp_label,
     y_ice_label,
+    band=None,
+    ice=None,
     scale_x: typing.Union[None, dict] = None,
     scale_y: typing.Union[None, dict] = None,
     avg_output: typing.Union[None, float] = None,
@@ -176,38 +178,34 @@ def plot_pdp_ice(
     show_plot: bool = True,
     random_state: typing.Union[None, int] = None,
 ):
-    """Draw the mean of the ICE table `yy` (shape `(T, N)`) plus the requested
-    heterogeneity: a std or standard-error band, or the ICE curves themselves."""
+    """Draw the pre-computed PDP mean curve `y_mean` (shape `(T,)`) plus the
+    requested heterogeneity (R1 — nothing is computed here): a std/std-err
+    `band` (shape `(T,)`), or the raw ICE table `ice` (shape `(T, N)`) as a
+    curve cloud. A band is a spread, so it scales by `scale_y["std"]` only."""
     x = _scale_x(x, scale_x)
-    yy = _scale_y(yy, scale_y, is_derivative)
-    y_mean = np.mean(yy, axis=1)
+    y_mean = _scale_y(y_mean, scale_y, is_derivative)
 
     fig, ax = plt.subplots()
     t = theme.active()
     ax.set_title(title)
 
-    if heterogeneity == "std":
-        std = np.std(yy, axis=1)
-        ax.fill_between(
-            x, y_mean - std, y_mean + std, color=t.BAND, alpha=t.BAND_ALPHA, label="std"
-        )
-    elif heterogeneity == "std_err":
-        std_err = np.std(yy, axis=1) / np.sqrt(yy.shape[1])
+    if heterogeneity in ("std", "std_err"):
+        b = band if scale_y is None else trans_scale(band, scale_y["std"])
         ax.fill_between(
             x,
-            y_mean - std_err,
-            y_mean + std_err,
+            y_mean - b,
+            y_mean + b,
             color=t.BAND,
             alpha=t.BAND_ALPHA,
-            label="std_err",
+            label=heterogeneity,
         )
     elif heterogeneity == "ice":
-        yy_show = yy
-        if nof_ice != "all" and nof_ice < yy.shape[1]:
+        yy_show = _scale_y(ice, scale_y, is_derivative)
+        if nof_ice != "all" and nof_ice < yy_show.shape[1]:
             ind = np.random.default_rng(random_state).choice(
-                yy.shape[1], size=nof_ice, replace=False
+                yy_show.shape[1], size=nof_ice, replace=False
             )
-            yy_show = yy[:, ind]
+            yy_show = yy_show[:, ind]
         ax.plot(
             x,
             yy_show[:, 0],

--- a/tests/test_contract_plots.py
+++ b/tests/test_contract_plots.py
@@ -109,6 +109,32 @@ def test_stderr_band_is_standard_error(global_data):
     np.testing.assert_allclose(band, std / np.sqrt(n), rtol=0.05)
 
 
+def test_pdp_std_band_equals_eval_heter(global_data):
+    # R1 / D5: the plotted std band must be the method's heterogeneity, i.e.
+    # sqrt(eval_heter) at the drawn grid — not something recomputed in the plot
+    # layer. Reconstruct the band half-height from the fill polygon and compare.
+    m = make_global("pdp", global_data)
+    ret = m.plot(0, heterogeneity="std", centering="zero_integral", show_plot=False)
+    ax = _mean_axis(ret)
+    assert len(ax.collections) == 1
+    verts = ax.collections[0].get_paths()[0].vertices
+
+    line = _mean_line(ax, "PDP")
+    xs = line.get_xdata()
+    expected = np.sqrt(m.eval_heter(0, np.asarray(xs)))
+    band = np.array(
+        [
+            (
+                verts[np.isclose(verts[:, 0], x), 1].max()
+                - verts[np.isclose(verts[:, 0], x), 1].min()
+            )
+            / 2
+            for x in xs
+        ]
+    )
+    np.testing.assert_allclose(band, expected, atol=1e-8)
+
+
 # ---------------------------------------------------------------------------
 # y_limits / nof_ice / legend
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three altitude cleanups from the execution-graph review of the global path (Phase C, eval/plot). **No output change** — plots and values are identical; these move computation to the layer that owns it and remove a hard-coded constant. Full suite: 521 passed, 1 skipped.

## D5 — keep compute out of the plot layer (R1)
`visualization.plot_pdp_ice` was handed the raw `(T,N)` ICE table and computed the mean line + std/std_err bands itself — reproducing PDP's heterogeneity inside the draw layer (consistent with `eval_heter` only by formula-coincidence), and inconsistent with every other path (ALE/SHAP/categorical-PDP hand `vis` a pre-computed band).

Now the PDP method computes the mean + band from the ICE table **it already has** (one model pass, no re-eval) and hands `vis` the finished arrays; the raw table is passed only for the `"ice"` cloud, which genuinely needs every curve. The band is now definitionally `sqrt(eval_heter)` — a single source of heterogeneity. `vis.plot_pdp_ice` is pure draw.

- New contract test `test_pdp_std_band_equals_eval_heter` asserts the **drawn** band equals `sqrt(eval_heter)` at the grid.
- Verified the `"ice"` cloud, `std`, `std_err`, `False`, DerPDP, and **regional PDP** (which routes through the same global `_plot` → `plot_pdp_ice`) all still render.

## D4 — PDP norm_const reduction as a method hook
Base `eval` had `y - (nc if np.ndim(nc)==0 else np.mean(nc))` — the base knowing PDP stores a per-instance `norm_const` array. Moved to an overridable `_mean_norm_const` (base returns the scalar; PDP returns `np.mean`). Regional PDP reads the stored array directly and is unaffected.

## D2 — one centering-grid knob
`points_for_centering` / norm-const grid hard-coded `30` in six places now flow from `helpers.NOF_INTERNAL_POINTS` (value unchanged), realizing the documented "one knob, not three."

## Regional safety
Confirmed before touching: regional plotting delegates to `fe.plot()` (the updated global path); regional's own `y_ice` (subregion detection) and ALE's reused `data_effect_ale`/`bin_limits` are built independently and untouched by all three.