### PR TITLE
perf: hoist DP cost matrix — O(K³N)→O(K²N), byte-identical (PR-3/4)

### DIFF
--- a/effector/axis_partitioning.py
+++ b/effector/axis_partitioning.py
@@ -413,32 +413,31 @@ class DynamicProgramming(Base):
         nof_limits = max_nof_bins + 1
         nof_bins = max_nof_bins
 
+        # cost[i, j] = cost of a single bin spanning limit-index i..j. It does
+        # NOT depend on which bin (bin_index) it is, so build it ONCE here rather
+        # than recomputing `_cost_of_move` inside the bin_index loop as before —
+        # that dropped a full O(K) factor of redundant O(N) bin-cost scans
+        # (O(K^3 N) -> O(K^2 N)). Values are identical to `_cost_of_move(i, j)`.
+        cost = np.empty((nof_limits, nof_limits))
+        for i in range(nof_limits):
+            for j in range(nof_limits):
+                cost[i, j] = self._cost_of_move(i, j, max_nof_bins, discount)
+
         # init matrices
         matrix = np.ones((nof_limits, nof_bins)) * big_M
         argmatrix = np.ones((nof_limits, nof_bins)) * np.nan
 
-        # init first bin_index
-        bin_index = 0
-        for lim_index in range(nof_limits):
-            matrix[lim_index, bin_index] = self._cost_of_move(
-                bin_index, lim_index, max_nof_bins, discount
-            )
+        # first bin: cost of a single bin from index 0 to each limit
+        matrix[:, 0] = cost[0, :]
 
-        # for all other bins
+        # for all other bins: matrix[next, b] = min_before matrix[before, b-1] +
+        # cost[before, next]. `argmin(axis=0)` scans ascending `before`, the same
+        # tie-break the previous `np.argmin(tmp)` used; the addition order is
+        # preserved, so the result is byte-identical to the triple loop.
         for bin_index in range(1, max_nof_bins):
-            for lim_index_next in range(max_nof_bins + 1):
-                # find best solution
-                tmp = []
-                for lim_index_before in range(max_nof_bins + 1):
-                    tmp.append(
-                        matrix[lim_index_before, bin_index - 1]
-                        + self._cost_of_move(
-                            lim_index_before, lim_index_next, max_nof_bins, discount
-                        )
-                    )
-                # store best solution
-                matrix[lim_index_next, bin_index] = np.min(tmp)
-                argmatrix[lim_index_next, bin_index] = np.argmin(tmp)
+            prev = matrix[:, bin_index - 1][:, None] + cost
+            matrix[:, bin_index] = prev.min(axis=0)
+            argmatrix[:, bin_index] = prev.argmin(axis=0)
 
         # find indices
         self.method_outputs = {"matrix": matrix, "argmatrix": argmatrix}


### PR DESCRIPTION
Third of four PRs. **Stacked on #40.** DynamicProgramming efficiency, Stage 1 — **byte-identical output** (golden oracle), pure speedup.

## The redundancy
`_cost_of_move(before, next)` is independent of which bin (`bin_index`) it is, but the old triple loop recomputed it *inside* the `bin_index` loop — and each call is an O(N) `filter_points_in_bin` + `np.var` scan. Net **O(K³·N)** with a full factor of K wasted.

## The fix
Build the cost matrix `cost[i,j]` **once** (O(K²) unique bins × O(N)), then the DP recursion just reads it, with the per-bin fill vectorized:
```python
prev = matrix[:, b-1][:, None] + cost
matrix[:, b]    = prev.min(axis=0)
argmatrix[:, b] = prev.argmin(axis=0)
```
`argmin(axis=0)` scans ascending `before` — the same tie-break the old `np.argmin(tmp)` used — and the addition order is preserved, so the result is byte-identical. Net **O(K²·N)**.

## Measured (min_points=2, sin signal), old → new ms/call
| N | K | old | new | speedup |
|---|---|---|---|---|
| 10k | 20 | 164.8 | 8.5 | 19× |
| 10k | 40 | 1269 | 31.8 | 40× |
| 50k | 20 | 416.8 | 21.8 | 19× |
| 50k | 40 | 3298 | 80.5 | 41× |

## Verification
Golden `assert_array_equal` green (byte-identical), binning + categorical suites pass. PR-4 takes the cost-matrix build itself from O(K²·N) to O(N + K²) via prefix sums (the one place numerics can shift on measure-zero edge-on-grid inputs, gated separately).