### PR TITLE
fix: 08_categorical_features notebook — numpy-only DataFrame path

### DIFF
--- a/notebooks/synthetic-examples/08_categorical_features.ipynb
+++ b/notebooks/synthetic-examples/08_categorical_features.ipynb
@@ -34,10 +34,10 @@
    "id": "8c6edcf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:22.926369Z",
-     "iopub.status.busy": "2026-07-06T12:41:22.926163Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.411733Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.410133Z"
+     "iopub.execute_input": "2026-07-07T12:51:19.293053Z",
+     "iopub.status.busy": "2026-07-07T12:51:19.292807Z",
+     "iopub.status.idle": "2026-07-07T12:51:20.813834Z",
+     "shell.execute_reply": "2026-07-07T12:51:20.812307Z"
     }
    },
    "outputs": [],
@@ -66,10 +66,10 @@
    "id": "5b429934",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.413873Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.413528Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.419201Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.417611Z"
+     "iopub.execute_input": "2026-07-07T12:51:20.816044Z",
+     "iopub.status.busy": "2026-07-07T12:51:20.815731Z",
+     "iopub.status.idle": "2026-07-07T12:51:20.822130Z",
+     "shell.execute_reply": "2026-07-07T12:51:20.820525Z"
     }
    },
    "outputs": [],
@@ -103,10 +103,10 @@
    "id": "e5fa8fde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.421484Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.421183Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.547121Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.545643Z"
+     "iopub.execute_input": "2026-07-07T12:51:20.823972Z",
+     "iopub.status.busy": "2026-07-07T12:51:20.823806Z",
+     "iopub.status.idle": "2026-07-07T12:51:20.950741Z",
+     "shell.execute_reply": "2026-07-07T12:51:20.949510Z"
     }
    },
    "outputs": [
@@ -132,10 +132,10 @@
    "id": "dc10a9ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.548916Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.548728Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.637495Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.636426Z"
+     "iopub.execute_input": "2026-07-07T12:51:20.952634Z",
+     "iopub.status.busy": "2026-07-07T12:51:20.952452Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.042340Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.040846Z"
     }
    },
    "outputs": [
@@ -168,10 +168,10 @@
    "id": "76e580c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.639660Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.639386Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.646106Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.644491Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.044277Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.044052Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.051423Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.049318Z"
     }
    },
    "outputs": [
@@ -208,10 +208,10 @@
    "id": "51ed0387",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.647896Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.647718Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.733463Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.732305Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.054262Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.054023Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.151339Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.150244Z"
     }
    },
    "outputs": [
@@ -247,10 +247,10 @@
    "id": "6aad7f73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.735442Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.735255Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.831200Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.829991Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.153405Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.153226Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.244135Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.243068Z"
     }
    },
    "outputs": [
@@ -287,10 +287,10 @@
    "id": "74b536e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.833113Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.832926Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.837555Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.836067Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.246316Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.246091Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.250648Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.249394Z"
     }
    },
    "outputs": [
@@ -326,10 +326,10 @@
    "id": "09373626",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.839587Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.839407Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.863651Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.862125Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.252638Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.252458Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.278380Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.276910Z"
     }
    },
    "outputs": [
@@ -346,7 +346,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 1/1 [00:00<00:00, 67.41it/s]"
+      "100%|██████████| 1/1 [00:00<00:00, 63.01it/s]"
      ]
     },
     {
@@ -397,10 +397,10 @@
    "id": "38bf1966",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.865995Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.865741Z",
-     "iopub.status.idle": "2026-07-06T12:41:24.955098Z",
-     "shell.execute_reply": "2026-07-06T12:41:24.953936Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.280028Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.279844Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.371090Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.369783Z"
     }
    },
    "outputs": [
@@ -425,10 +425,10 @@
    "id": "bba4cc63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:24.957060Z",
-     "iopub.status.busy": "2026-07-06T12:41:24.956858Z",
-     "iopub.status.idle": "2026-07-06T12:41:25.119241Z",
-     "shell.execute_reply": "2026-07-06T12:41:25.117443Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.373211Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.373030Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.533757Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.531983Z"
     }
    },
    "outputs": [
@@ -454,7 +454,7 @@
    "source": [
     "## Nominal features from a pandas DataFrame\n",
     "\n",
-    "With a DataFrame, string/`category` columns are encoded at the door and your model is always called with a reconstructed DataFrame (original dtypes). Plots translate the codes back to the category labels."
+    "effector is numpy-only, so a DataFrame is converted at the door with `effector.from_dataframe(df)`, which returns `(X, schema)`: `X` is the encoded `(N, D)` numpy matrix and `schema` carries the feature types and the category labels. Your model stays a plain numpy→numpy callable (it receives the encoded codes). Plots translate the codes back to the category labels via the schema."
    ]
   },
   {
@@ -463,10 +463,10 @@
    "id": "63dcbf8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:25.121293Z",
-     "iopub.status.busy": "2026-07-06T12:41:25.121113Z",
-     "iopub.status.idle": "2026-07-06T12:41:25.217530Z",
-     "shell.execute_reply": "2026-07-06T12:41:25.216432Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.536309Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.536089Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.629011Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.627979Z"
     }
    },
    "outputs": [
@@ -489,13 +489,20 @@
     "    \"x1\": rng.uniform(-1, 1, N2),\n",
     "})\n",
     "\n",
+    "# effector is numpy-only: convert the DataFrame to (X, schema) at the door.\n",
+    "X, schema_nominal = effector.from_dataframe(df)\n",
+    "levels = schema_nominal.category_names[0]  # e.g. ['blue', 'green', 'red']\n",
+    "\n",
+    "# the model is numpy->numpy; it receives the encoded codes in column 0.\n",
     "color_effect = {\"red\": 2.0, \"green\": 1.5, \"blue\": -1.0}\n",
+    "effect_by_code = np.array([color_effect[name] for name in levels])\n",
+    "green_code = levels.index(\"green\")\n",
     "\n",
-    "def df_model(d):\n",
-    "    base = d[\"color\"].map(color_effect).to_numpy(dtype=float)\n",
-    "    return base + 0.5 * d[\"x1\"].to_numpy() * (d[\"color\"] == \"green\").to_numpy()\n",
+    "def np_model(x):\n",
+    "    codes = x[:, 0].astype(int)\n",
+    "    return effect_by_code[codes] + 0.5 * x[:, 1] * (codes == green_code)\n",
     "\n",
-    "pdp_nominal = effector.PDP(df, df_model)\n",
+    "pdp_nominal = effector.PDP(X, np_model, schema=schema_nominal)\n",
     "pdp_nominal.plot(0, heterogeneity=\"ice\", centering=True)"
    ]
   },
@@ -515,10 +522,10 @@
    "id": "0d333920",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T12:41:25.219917Z",
-     "iopub.status.busy": "2026-07-06T12:41:25.219730Z",
-     "iopub.status.idle": "2026-07-06T12:41:25.329440Z",
-     "shell.execute_reply": "2026-07-06T12:41:25.328034Z"
+     "iopub.execute_input": "2026-07-07T12:51:21.630994Z",
+     "iopub.status.busy": "2026-07-07T12:51:21.630814Z",
+     "iopub.status.idle": "2026-07-07T12:51:21.735432Z",
+     "shell.execute_reply": "2026-07-07T12:51:21.734286Z"
     }
    },
    "outputs": [
@@ -534,7 +541,7 @@
     }
    ],
    "source": [
-    "ale_nominal = effector.ALE(df, df_model)\n",
+    "ale_nominal = effector.ALE(X, np_model, schema=schema_nominal)\n",
     "ale_nominal.fit(0, centering=\"zero_start\", order=\"similarity\")\n",
     "ale_nominal.plot(0, centering=\"zero_start\")"
    ]


### PR DESCRIPTION
Independent of the binning rework — fixes a **pre-existing** failure on `main`: `test_notebooks.py::test_notebook_executes[08_categorical_features]`.

## Cause
The nominal-feature section fed a pandas DataFrame straight to `effector.PDP(df, df_model)` / `effector.ALE(df, df_model)`. The numpy-only contract (shipped in 0.4.0, #34) rejects DataFrames:
```
TypeError: effector is numpy-only: `data` must be a 2-D numeric numpy array, not a pandas DataFrame.
```
The cells and their surrounding prose still described the old auto-wrapping behavior that #34 removed.

## Fix
Convert at the door with `effector.from_dataframe(df)` → `(X, schema)`, and make the model numpy→numpy (it reads the encoded category codes in column 0, mapped back to effects via `schema.category_names`). Updated the markdown to describe the numpy-only path. Re-executed the notebook so committed outputs match.

## Verification
`test_notebook_executes[08_categorical_features]` passes (was failing on main). This restores the full suite to green.