### PR TITLE
Land axis_partitioning rework on main + runtime-guide update

### DIFF
--- a/docs/docs/notebooks/guides/efficiency_global.md
+++ b/docs/docs/notebooks/guides/efficiency_global.md
@@ -335,6 +335,32 @@ Adding the two parts, we have the total runtime:
 | **ALE**         | $2 t_f$                       | $2 D t_f$                      |
 | **RHALE**       | $t_f$                         | $t_f$                          |
 
+### Binning cost: the role of `K` and `binning_method`
+
+The table above folds binning into the constants by using `Fixed(nof_bins=20)`. But **ALE and RHALE bin the local effects inside `.fit()`**, and that step has its own cost — a pure-numpy pass over the $N$ local effects, *independent of the model*. With $K$ the number of bins, the per-feature binning cost $C_\text{bin}$ depends on the `binning_method`:
+
+| `binning_method` | complexity | notes |
+|---|---|---|
+| `Fixed` | $O(N)$ | uniform grid; ALE's only option, RHALE-capable |
+| `Greedy` | $O(K \cdot N)$ | adaptive one-pass merge; **RHALE default** |
+| `DynamicProgramming` | $O(N + K^2)$ | globally optimal bins |
+
+Because it touches no model, $C_\text{bin}$ is negligible against any nonzero $t_f$ — **as long as it stays sub-model-call.** The catch is that it is paid **per feature** ($D \cdot C_\text{bin}$), so a slow binner over many features can quietly dominate when $t_f$ is small.
+
+Measured at $N = 50{,}000$ (per feature): `Fixed` ≈ 1.5 ms, `Greedy` ≈ 8 ms, `DynamicProgramming` ≈ 1.5 ms.
+
+!!! note "DynamicProgramming used to be the landmine"
+    `DynamicProgramming` was previously $O(K^3 N)$: at $N = 50{,}000,\ K = 40$ it cost **≈ 3.3 s per feature** (≈ **66 s** for $D = 20$) — which could dwarf the model itself for fast $t_f$, and even make RHALE slower than PDP. It is now $O(N + K^2)$ (**≈ 1.5 ms**, a ~2000× speedup), so the binning method no longer changes the runtime picture.
+
+Making binning explicit, the totals for the two accumulation-based methods become:
+
+| Method | $T$ (all features) |
+|---|---|
+| **ALE** | $2 D\, t_f + D \cdot O(N)$ |
+| **RHALE** | $t_f + D \cdot C_\text{bin}(N, K, \texttt{binning\_method})$ |
+
+RHALE still needs only **one** Jacobian pass for all $D$ features, so it stays model-bound: for realistic $t_f$, $C_\text{bin}$ is milliseconds and any `binning_method` is a fine choice.
+
 ## SHAP-DP
 
 SHAP-DP is a much slower method, compared to the others. Let's see how it scales with $N$ and $t_f$.

--- a/effector/axis_partitioning.py
+++ b/effector/axis_partitioning.py
@@ -1,4 +1,5 @@
 import copy
+import dataclasses
 import enum
 import typing
 
@@ -17,8 +18,24 @@ class NoBinningReason(enum.Enum):
     Each member's ``.value`` is the human-readable sentence."""
 
     SINGLE_UNIQUE_VALUE = "all points share a single value"
-    TOO_FEW_POINTS = "fewer points than min_points"
-    FIXED_GRID_UNDERFILLED = "the fixed uniform grid leaves a bin under min_points"
+    TOO_FEW_POINTS = "fewer points than min_points_per_bin"
+    FIXED_GRID_UNDERFILLED = (
+        "the fixed uniform grid leaves a bin under min_points_per_bin"
+    )
+
+
+@dataclasses.dataclass
+class Constraints:
+    """Feasibility rules any valid 1D partition must obey — algorithm-agnostic.
+
+    Kept separate from each optimizer's *method parameters* (which shape the
+    objective and the search, e.g. ``discount``, ``init_nof_bins``): constraints
+    say what a *valid* partition is, params say how a given method looks for one.
+    The shared ``Base`` guards read only these.
+    """
+
+    min_points_per_bin: int = 0  # a bin with fewer points is invalid (0 == no minimum)
+    max_nof_bins: typing.Optional[int] = None  # never emit more (None == unbounded)
 
 
 class Base:
@@ -29,7 +46,9 @@ class Base:
     value ``y``, and produces bin edges over a range ``x_lims`` that keep the
     within-bin variance of ``y`` low. Callers translate their own quantities
     (feature columns, local effects, SHAP values, ...) into this ``x``/``y``
-    vocabulary at the boundary.
+    vocabulary at the boundary — including feature types: the binner always
+    operates on continuous positions (ordinal features reach it as integer level
+    codes via `adapt_for_categorical`; nominal features never reach it).
     """
 
     big_M = helpers.BIG_M
@@ -37,26 +56,32 @@ class Base:
     def __init__(
         self,
         name: str,
-        method_args: typing.Dict[str, typing.Any],
+        constraints: Constraints,
+        params: typing.Dict[str, typing.Any],
     ):
         """Initializer.
 
         Parameters
         ----------
         name: the method's canonical name (e.g. "fixed", "greedy")
-        method_args: the method's hyperparameters; `find_limits` reads them
-            (all subclasses store at least `min_points`)
+        constraints: the feasibility rules (min points per bin, max #bins)
+        params: the method's own parameters (objective/search knobs)
         """
         self.name = name
+
+        # constraints (shared vocabulary) vs params (method-specific)
+        self.constraints = constraints
+        # normalize the min_points contract so guards never see None (0 == "no
+        # minimum"); also removes the latent Fixed(min_points_per_bin=None) crash
+        if self.constraints.min_points_per_bin is None:
+            self.constraints.min_points_per_bin = 0
+        self.params: typing.Dict[str, typing.Any] = params
 
         # set in _preprocess_find
         self.x_min = None
         self.x_max = None
         self.x = None
         self.y = None
-
-        # arguments passed to method find
-        self.method_args: typing.Dict[str, typing.Any] = method_args
 
         # set in method find
         self.method_outputs: typing.Dict[str, typing.Any] = {}
@@ -89,9 +114,8 @@ class Base:
         Returns:
             An ascending float array `(K+1,)` of bin edges with `edges[0] ==
             x_min` and `edges[-1] == x_max`; **or** the literal `False` when no
-            binning satisfies the method's constraints. A degenerate but valid
-            "one bin" result is the 2-element `[x_min, x_max]` — that is *not* a
-            failure.
+            binning satisfies the constraints. A degenerate but valid "one bin"
+            result is the 2-element `[x_min, x_max]` — that is *not* a failure.
 
         Failure is a *fact, not a severity*: the optimizer never raises. It
         returns `False` and records `self.no_binning_reason` (a
@@ -125,8 +149,14 @@ class Base:
         `self.no_binning_reason`) if the method's own constraints fail."""
         raise NotImplementedError
 
+    def _set_candidate_bin_count(self, k: int) -> None:
+        """Set how many candidate bins the method considers. Used by
+        `adapt_for_categorical` to run a continuous binner over the K-1 ordinal
+        level transitions. Each optimizer maps `k` to its own bin-count knob."""
+        raise NotImplementedError
+
     def _bin_cost(self, start, stop, discount):
-        min_points = self.method_args["min_points"]
+        min_points = self.constraints.min_points_per_bin
         nof_points = self.x.shape[0]
         x, y = utils.filter_points_in_bin(self.x, self.y, np.array([start, stop]))
 
@@ -145,10 +175,7 @@ class Base:
         Returns:
             Boolean, True if the bin is valid, False otherwise
         """
-        min_points = self.method_args["min_points"]
-        if min_points is None:
-            return True
-
+        min_points = self.constraints.min_points_per_bin
         filtered_points, _ = utils.filter_points_in_bin(
             self.x, None, np.array([start, stop])
         )
@@ -165,8 +192,8 @@ class Base:
         if len(np.unique(self.x)) == 1:
             return NoBinningReason.SINGLE_UNIQUE_VALUE
 
-        # if there are fewer than min_points, no binning is possible
-        if self.x.size < self.method_args["min_points"]:
+        # if there are fewer than min_points_per_bin, no binning is possible
+        if self.x.size < self.constraints.min_points_per_bin:
             return NoBinningReason.TOO_FEW_POINTS
 
         return None
@@ -177,7 +204,7 @@ class Base:
         Returns:
             Boolean, True if the only possible binning is all points in one bin, False otherwise
         """
-        min_points = self.method_args["min_points"]
+        min_points = self.constraints.min_points_per_bin
         # if x is categorical (single point on the axis), only one bin is possible
         is_categorical = np.allclose(self.x_min, self.x_max)
 
@@ -186,12 +213,8 @@ class Base:
         return is_categorical or enough_for_one_bin
 
     def _preprocess_find(self, x, y, x_lims):
-        # reset per-call state; normalize the min_points contract so subclasses
-        # and guards never see None (0 == "no minimum"). This also removes the
-        # latent `x.size < None` TypeError for `Fixed(min_points_per_bin=None)`.
+        # reset per-call state
         self.no_binning_reason = None
-        if self.method_args.get("min_points") is None:
-            self.method_args["min_points"] = 0
 
         self.x_min: float = x_lims[0] if x_lims is not None else x.min()
         self.x_max: float = x_lims[1] if x_lims is not None else x.max()
@@ -234,22 +257,20 @@ class Greedy(Base):
         init_nof_bins: int = 20,
         min_points_per_bin: int = 2,
         discount: float = 0.3,
-        cat_limit: int = 10,
     ):
         assert min_points_per_bin >= 2, "min_points_per_bin should be at least 2"
-        method_args = {
-            "init_nof_bins": init_nof_bins,
-            "min_points": min_points_per_bin,
-            "discount": discount,
-            "cat_limit": cat_limit,
-        }
-        super(Greedy, self).__init__("greedy", method_args)
+        constraints = Constraints(min_points_per_bin=min_points_per_bin)
+        params = {"init_nof_bins": init_nof_bins, "discount": discount}
+        super(Greedy, self).__init__("greedy", constraints, params)
+
+    def _set_candidate_bin_count(self, k: int) -> None:
+        self.params["init_nof_bins"] = k
 
     def _search(self) -> np.ndarray:
         x_min = self.x_min
         x_max = self.x_max
-        init_nof_bins = self.method_args["init_nof_bins"]
-        discount = self.method_args["discount"]
+        init_nof_bins = self.params["init_nof_bins"]
+        discount = self.params["discount"]
 
         # limits with high resolution
         limits, _ = np.linspace(
@@ -313,22 +334,24 @@ class DynamicProgramming(Base):
         max_nof_bins: int = 20,
         min_points_per_bin: int = 2,
         discount: float = 0.3,
-        cat_limit: int = 10,
     ):
         assert min_points_per_bin >= 2, "min_points_per_bin should be at least 2"
-        method_args = {
-            "max_nof_bins": max_nof_bins,
-            "min_points": min_points_per_bin,
-            "discount": discount,
-            "cat_limit": cat_limit,
-        }
-        super(DynamicProgramming, self).__init__("dynamic_programming", method_args)
+        constraints = Constraints(
+            min_points_per_bin=min_points_per_bin, max_nof_bins=max_nof_bins
+        )
+        params = {"discount": discount}
+        super(DynamicProgramming, self).__init__(
+            "dynamic_programming", constraints, params
+        )
+
+    def _set_candidate_bin_count(self, k: int) -> None:
+        self.constraints.max_nof_bins = k
 
     def _collapse_to_one_bin(self) -> bool:
         # DP's dedicated single-bin shortcut folds into the collapse policy: an
         # explicit request for one bin yields the same [x_min, x_max] as the
         # generic "only one bin possible" case.
-        return self._only_one_bin_possible() or self.method_args["max_nof_bins"] == 1
+        return self._only_one_bin_possible() or self.constraints.max_nof_bins == 1
 
     def _index_to_position(self, index_start, index_stop, K):
         dx = (self.x_max - self.x_min) / K
@@ -383,8 +406,8 @@ class DynamicProgramming(Base):
         return limits, dx_list
 
     def _search(self) -> np.ndarray:
-        max_nof_bins = self.method_args["max_nof_bins"]
-        discount = self.method_args["discount"]
+        max_nof_bins = self.constraints.max_nof_bins
+        discount = self.params["discount"]
 
         big_M = self.big_M
         nof_limits = max_nof_bins + 1
@@ -425,15 +448,13 @@ class DynamicProgramming(Base):
 
 
 class Fixed(Base):
-    def __init__(
-        self, nof_bins: int = 20, min_points_per_bin: int = 0, cat_limit: int = 10
-    ):
-        method_args = {
-            "nof_bins": nof_bins,
-            "min_points": min_points_per_bin,
-            "cat_limit": cat_limit,
-        }
-        super(Fixed, self).__init__("fixed", method_args)
+    def __init__(self, nof_bins: int = 20, min_points_per_bin: int = 0):
+        constraints = Constraints(min_points_per_bin=min_points_per_bin)
+        params = {"nof_bins": nof_bins}
+        super(Fixed, self).__init__("fixed", constraints, params)
+
+    def _set_candidate_bin_count(self, k: int) -> None:
+        self.params["nof_bins"] = k
 
     def _collapse_to_one_bin(self) -> bool:
         # Fixed honors the requested bin count exactly: it never collapses to a
@@ -443,7 +464,7 @@ class Fixed(Base):
         return False
 
     def _search(self) -> typing.Union[np.ndarray, bool]:
-        nof_bins = self.method_args["nof_bins"]
+        nof_bins = self.params["nof_bins"]
 
         limits, _ = np.linspace(
             self.x_min, self.x_max, num=nof_bins + 1, endpoint=True, retstep=True
@@ -459,10 +480,7 @@ def adapt_for_categorical(method: Base, nof_levels: int) -> Base:
     integer level codes 0..K-1, so Greedy/DP merging over the K-1 transitions
     becomes *adaptive level grouping* (method_semantics.md, RHALE-ordinal)."""
     method = copy.deepcopy(method)
-    nof_transitions = nof_levels - 1
-    for key in ("init_nof_bins", "max_nof_bins", "nof_bins"):
-        if key in method.method_args:
-            method.method_args[key] = nof_transitions
+    method._set_candidate_bin_count(nof_levels - 1)
     return method
 
 

--- a/effector/axis_partitioning.py
+++ b/effector/axis_partitioning.py
@@ -1,3 +1,5 @@
+import copy
+import enum
 import typing
 
 import matplotlib.pyplot as plt
@@ -8,7 +10,28 @@ import effector.theme as theme
 import effector.utils as utils
 
 
+class NoBinningReason(enum.Enum):
+    """Machine-readable reason an optimizer returned ``False`` from
+    ``find_limits`` — the *why* behind the outcome, so a higher-level caller can
+    branch on it and ``utils.raise_if_no_binning`` can render a specific message.
+    Each member's ``.value`` is the human-readable sentence."""
+
+    SINGLE_UNIQUE_VALUE = "all points share a single value"
+    TOO_FEW_POINTS = "fewer points than min_points"
+    FIXED_GRID_UNDERFILLED = "the fixed uniform grid leaves a bin under min_points"
+
+
 class Base:
+    """A standalone 1D bin optimizer.
+
+    This module is deliberately self-contained: it knows nothing about the rest
+    of the package. It works purely on 1D points ``x`` and an optional per-point
+    value ``y``, and produces bin edges over a range ``x_lims`` that keep the
+    within-bin variance of ``y`` low. Callers translate their own quantities
+    (feature columns, local effects, SHAP values, ...) into this ``x``/``y``
+    vocabulary at the boundary.
+    """
+
     big_M = helpers.BIG_M
 
     def __init__(
@@ -26,11 +49,11 @@ class Base:
         """
         self.name = name
 
-        # set immediately
-        self.xs_min = None
-        self.xs_max = None
-        self.data = None
-        self.data_effect = None
+        # set in _preprocess_find
+        self.x_min = None
+        self.x_max = None
+        self.x = None
+        self.y = None
 
         # arguments passed to method find
         self.method_args: typing.Dict[str, typing.Any] = method_args
@@ -38,25 +61,82 @@ class Base:
         # set in method find
         self.method_outputs: typing.Dict[str, typing.Any] = {}
 
-        # limits: None if not set, False if no binning is possible, np.ndarray (N, 2) if binning is possible
-        self.limits: typing.Union[None, False, np.ndarray] = None
+        # limits: None if not set, False if no binning is possible, np.ndarray (K+1,) otherwise
+        self.limits: typing.Union[None, bool, np.ndarray] = None
+
+        # when `find_limits` returns False, why (see NoBinningReason); None otherwise
+        self.no_binning_reason: typing.Optional[NoBinningReason] = None
+
+    # ------------------------------------------------------------------ #
+    # The template method: shared preprocessing + degenerate guards + a   #
+    # single subclass hook (`_search`). Subclasses implement `_search`    #
+    # (and optionally override `_collapse_to_one_bin`); they do NOT       #
+    # override `find_limits`.                                             #
+    # ------------------------------------------------------------------ #
+    def find_limits(self, x, y, x_lims) -> typing.Union[np.ndarray, bool]:
+        """Find bin edges for a 1D set of points.
+
+        Contract
+        --------
+        Inputs:
+            x: 1D float array `(N,)` — the points to bin.
+            y: 1D float array `(N,)` — a per-point value whose within-bin
+                variance drives bin cost, or `None` for optimizers that do not
+                use it (e.g. `Fixed`).
+            x_lims: `[min, max]` length-2 sequence, or `None` to derive them from
+                `x.min()/max()`.
+
+        Returns:
+            An ascending float array `(K+1,)` of bin edges with `edges[0] ==
+            x_min` and `edges[-1] == x_max`; **or** the literal `False` when no
+            binning satisfies the method's constraints. A degenerate but valid
+            "one bin" result is the 2-element `[x_min, x_max]` — that is *not* a
+            failure.
+
+        Failure is a *fact, not a severity*: the optimizer never raises. It
+        returns `False` and records `self.no_binning_reason` (a
+        `NoBinningReason`). The caller decides what to do with it — the global
+        effect methods treat it as fatal via `utils.raise_if_no_binning`, while
+        the regional subregion search treats it as a normal "skip this
+        candidate".
+        """
+        self._preprocess_find(x, y, x_lims)
+
+        reason = self._none_valid_binning()
+        if reason is not None:
+            self.no_binning_reason = reason
+            self.limits = False
+        elif self._collapse_to_one_bin():
+            self.limits = np.array([self.x_min, self.x_max])
+        else:
+            self.limits = self._search()
+        return self.limits
+
+    def _collapse_to_one_bin(self) -> bool:
+        """Policy hook: should the whole range collapse into a single bin?
+        Default = yes when only one bin is possible. `Fixed` overrides this to
+        `False` (it never collapses); `DynamicProgramming` also folds in its
+        `max_nof_bins == 1` shortcut."""
+        return self._only_one_bin_possible()
+
+    def _search(self) -> typing.Union[np.ndarray, bool]:
+        """Subclass kernel: the actual edge search, run only once the shared
+        guards have passed. Returns ascending edges, or `False` (setting
+        `self.no_binning_reason`) if the method's own constraints fail."""
+        raise NotImplementedError
 
     def _bin_cost(self, start, stop, discount):
         min_points = self.method_args["min_points"]
-        nof_points = self.data.shape[0]
-        data = self.data
-        data_effect = self.data_effect
-        data, data_effect = utils.filter_points_in_bin(
-            data, data_effect, np.array([start, stop])
-        )
+        nof_points = self.x.shape[0]
+        x, y = utils.filter_points_in_bin(self.x, self.y, np.array([start, stop]))
 
         # compute cost
         thres = max(min_points, 2)
-        if data_effect.size < thres:
+        if y.size < thres:
             cost = self.big_M
         else:
-            discount_for_more_points = 1 - discount * (data_effect.size / nof_points)
-            cost = np.var(data_effect) * (stop - start) * discount_for_more_points
+            discount_for_more_points = 1 - discount * (y.size / nof_points)
+            cost = np.var(y) * (stop - start) * discount_for_more_points
         return cost
 
     def _bin_valid(self, start, stop):
@@ -69,28 +149,27 @@ class Base:
         if min_points is None:
             return True
 
-        xs = self.data
-        # dy_dxs = self.data_effect[:, self.feature]
         filtered_points, _ = utils.filter_points_in_bin(
-            xs, None, np.array([start, stop])
+            self.x, None, np.array([start, stop])
         )
         valid = filtered_points.size >= min_points
         return valid
 
-    def _none_valid_binning(self):
-        """Check if it is impossible to create any binning
+    def _none_valid_binning(self) -> typing.Optional[NoBinningReason]:
+        """Why no binning at all is possible, or `None` if some binning exists.
 
-        Returns:
-            Boolean, True if it is impossible to create any binning, False otherwise
+        A `NoBinningReason` member is truthy, so `if self._none_valid_binning():`
+        still reads as a predicate while also carrying the reason.
         """
-        # if there is only one unique value, then it is impossible to create any binning
-        cond_1 = len(np.unique(self.data)) == 1
+        # if there is only one unique value, no binning is possible
+        if len(np.unique(self.x)) == 1:
+            return NoBinningReason.SINGLE_UNIQUE_VALUE
 
-        # if there are less than min_points, then it is impossible to create any binning
-        cond_2 = self.data.size < self.method_args["min_points"]
+        # if there are fewer than min_points, no binning is possible
+        if self.x.size < self.method_args["min_points"]:
+            return NoBinningReason.TOO_FEW_POINTS
 
-        # if either is true, then it is impossible to create any binning
-        return cond_1 or cond_2
+        return None
 
     def _only_one_bin_possible(self):
         """Check if the only possible binning is all points in one bin
@@ -99,48 +178,45 @@ class Base:
             Boolean, True if the only possible binning is all points in one bin, False otherwise
         """
         min_points = self.method_args["min_points"]
-        # if xs is categorical, then only one bin is possible
-        is_categorical = np.allclose(self.xs_min, self.xs_max)
+        # if x is categorical (single point on the axis), only one bin is possible
+        is_categorical = np.allclose(self.x_min, self.x_max)
 
-        # if xs is not categorical, then one bin is possible if there are enough points only in one bin
-        dy_dxs = self.data_effect
-        enough_for_one_bin = min_points <= dy_dxs.size < 2 * min_points
+        # otherwise, one bin is possible if there are enough points for exactly one
+        enough_for_one_bin = min_points <= self.y.size < 2 * min_points
         return is_categorical or enough_for_one_bin
 
-    def _preprocess_find(self, data, data_effect, axis_limits):
-        self.xs_min: float = axis_limits[0] if axis_limits is not None else data.min()
-        self.xs_max: float = axis_limits[1] if axis_limits is not None else data.max()
-        self.data: np.ndarray = data
-        self.data_effect: np.ndarray = data_effect
+    def _preprocess_find(self, x, y, x_lims):
+        # reset per-call state; normalize the min_points contract so subclasses
+        # and guards never see None (0 == "no minimum"). This also removes the
+        # latent `x.size < None` TypeError for `Fixed(min_points_per_bin=None)`.
+        self.no_binning_reason = None
+        if self.method_args.get("min_points") is None:
+            self.method_args["min_points"] = 0
 
-    def find_limits(
-        self, data, data_effect, axis_limits
-    ) -> typing.Union[np.ndarray, bool]:
-        """Find the optimal binning for the feature: `(K+1,)` bin limits, or
-        `False` when no valid binning exists."""
-        raise NotImplementedError
+        self.x_min: float = x_lims[0] if x_lims is not None else x.min()
+        self.x_max: float = x_lims[1] if x_lims is not None else x.max()
+        self.x: np.ndarray = x
+        self.y: np.ndarray = y
 
     def plot(self, feature=0, block=False):
         assert self.limits is not None
-        assert self.data is not None
-        assert self.data_effect is not None
+        assert self.x is not None
+        assert self.y is not None
 
         limits = self.limits
 
         plt.figure()
         plt.title("Bin splitting for feature %d" % feature)
-        xs = self.data
-        dy_dxs = self.data_effect
         plt.plot(
-            xs,
-            dy_dxs,
+            self.x,
+            self.y,
             color=theme.active().MEAN,
             marker="o",
             linestyle="none",
             label="local effects",
         )
-        y_min = np.min(dy_dxs)
-        y_max = np.max(dy_dxs)
+        y_min = np.min(self.y)
+        y_max = np.max(self.y)
         plt.vlines(limits, ymin=y_min, ymax=y_max, linestyles="dashed", label="bins")
         plt.xlabel("x_%d" % feature)
         plt.ylabel("dy/dx_%d" % feature)
@@ -169,75 +245,66 @@ class Greedy(Base):
         }
         super(Greedy, self).__init__("greedy", method_args)
 
-    def find_limits(
-        self, data, data_effect, axis_limits
-    ) -> typing.Union[np.ndarray, bool]:
-
-        self._preprocess_find(data, data_effect, axis_limits)
-        xs_min = self.xs_min
-        xs_max = self.xs_max
+    def _search(self) -> np.ndarray:
+        x_min = self.x_min
+        x_max = self.x_max
         init_nof_bins = self.method_args["init_nof_bins"]
         discount = self.method_args["discount"]
 
-        if self._none_valid_binning():
-            self.limits = False
-        elif self._only_one_bin_possible():
-            self.limits = np.array([self.xs_min, self.xs_max])
-        else:
-            # limits with high resolution
-            limits, _ = np.linspace(
-                xs_min, xs_max, num=init_nof_bins + 1, endpoint=True, retstep=True
-            )
+        # limits with high resolution
+        limits, _ = np.linspace(
+            x_min, x_max, num=init_nof_bins + 1, endpoint=True, retstep=True
+        )
 
-            # merging
-            i = 0
-            merged_limits = [limits[0]]
-            while i < init_nof_bins:
-                # left limit is the last item of the merged_limits list
-                left_lim = merged_limits[-1]
+        # merging
+        i = 0
+        merged_limits = [limits[0]]
+        while i < init_nof_bins:
+            # left limit is the last item of the merged_limits list
+            left_lim = merged_limits[-1]
 
-                # choose whether to close the bin
-                if i == init_nof_bins - 1:
-                    # if last bin, close it
-                    close_bin = True
-                else:
-                    # bin_1, the bin if I close it here
-                    bin_1_loss = self._bin_cost(left_lim, limits[i + 1], discount)
-                    bin_1_valid = self._bin_valid(left_lim, limits[i + 1])
+            # choose whether to close the bin
+            if i == init_nof_bins - 1:
+                # if last bin, close it
+                close_bin = True
+            else:
+                # bin_1, the bin if I close it here
+                bin_1_loss = self._bin_cost(left_lim, limits[i + 1], discount)
+                bin_1_valid = self._bin_valid(left_lim, limits[i + 1])
 
-                    # bin_2: the bin if I close it in the next limit
-                    bin_2_loss = self._bin_cost(left_lim, limits[i + 2], discount)
-                    bin_2_valid = self._bin_valid(left_lim, limits[i + 2])
+                # bin_2: the bin if I close it in the next limit
+                bin_2_loss = self._bin_cost(left_lim, limits[i + 2], discount)
+                bin_2_valid = self._bin_valid(left_lim, limits[i + 2])
 
-                    # if both bins valid
-                    if bin_1_valid and bin_2_valid:
-                        # if first zero, second positive -> close
-                        if bin_1_loss == 0.0 and bin_2_loss > 0:
-                            close_bin = True
-                        # if both zero, keep it (we could close as well)
-                        elif bin_1_loss == 0.0 and bin_2_loss == 0:
-                            close_bin = False
-                        # if both positive, compare and decide
-                        else:
-                            close_bin = False if bin_2_loss <= bin_1_loss else True
-                    else:
-                        # if either invalid, keep open
+                # if both bins valid
+                if bin_1_valid and bin_2_valid:
+                    # if first zero, second positive -> close
+                    if bin_1_loss == 0.0 and bin_2_loss > 0:
+                        close_bin = True
+                    # if both zero, keep it (we could close as well)
+                    elif bin_1_loss == 0.0 and bin_2_loss == 0:
                         close_bin = False
+                    # if both positive, compare and decide
+                    else:
+                        close_bin = False if bin_2_loss <= bin_1_loss else True
+                else:
+                    # if either invalid, keep open
+                    close_bin = False
 
-                # if close_bin, then add the next limit to the merged_limits
-                if close_bin:
-                    merged_limits.append(limits[i + 1])
+            # if close_bin, then add the next limit to the merged_limits
+            if close_bin:
+                merged_limits.append(limits[i + 1])
 
-                i += 1
+            i += 1
 
-            # if last bin is without enough points, merge it with the previous
-            if not self._bin_valid(merged_limits[-2], merged_limits[-1]):
-                merged_limits = merged_limits[:-2] + merged_limits[-1:]
+        # if last bin is without enough points, merge it with the previous
+        if not self._bin_valid(merged_limits[-2], merged_limits[-1]):
+            merged_limits = merged_limits[:-2] + merged_limits[-1:]
 
-            # store result
-            self.limits = np.array(merged_limits)
-            self.method_outputs = {"limits": self.limits}
-        return self.limits
+        # store result
+        result = np.array(merged_limits)
+        self.method_outputs = {"limits": result}
+        return result
 
 
 class DynamicProgramming(Base):
@@ -257,10 +324,16 @@ class DynamicProgramming(Base):
         }
         super(DynamicProgramming, self).__init__("dynamic_programming", method_args)
 
+    def _collapse_to_one_bin(self) -> bool:
+        # DP's dedicated single-bin shortcut folds into the collapse policy: an
+        # explicit request for one bin yields the same [x_min, x_max] as the
+        # generic "only one bin possible" case.
+        return self._only_one_bin_possible() or self.method_args["max_nof_bins"] == 1
+
     def _index_to_position(self, index_start, index_stop, K):
-        dx = (self.xs_max - self.xs_min) / K
-        start = self.xs_min + index_start * dx
-        stop = self.xs_min + index_stop * dx
+        dx = (self.x_max - self.x_min) / K
+        start = self.x_min + index_start * dx
+        stop = self.x_min + index_stop * dx
         return start, stop
 
     def _cost_of_move(self, index_before, index_next, K, discount):
@@ -285,7 +358,7 @@ class DynamicProgramming(Base):
             "argmatrix not found in method_outputs"
         )
         argmatrix = self.method_outputs["argmatrix"]
-        dx = (self.xs_max - self.xs_min) / K
+        dx = (self.x_max - self.x_min) / K
 
         lim_indices = [int(argmatrix[-1, -1])]
         for j in range(K - 2, 0, -1):
@@ -303,65 +376,52 @@ class DynamicProgramming(Base):
                 lim_indices_1.append(lim)
                 before = lim
 
-        limits = self.xs_min + np.array(lim_indices_1) * dx
+        limits = self.x_min + np.array(lim_indices_1) * dx
         dx_list = np.array(
             [limits[i + 1] - limits[i] for i in range(limits.shape[0] - 1)]
         )
         return limits, dx_list
 
-    def find_limits(self, data, data_effect, axis_limits):
-        """Find the optimal binning."""
-        self._preprocess_find(data, data_effect, axis_limits)
+    def _search(self) -> np.ndarray:
         max_nof_bins = self.method_args["max_nof_bins"]
-        min_points = self.method_args["min_points"]
         discount = self.method_args["discount"]
 
-        self.min_points = min_points
         big_M = self.big_M
         nof_limits = max_nof_bins + 1
         nof_bins = max_nof_bins
 
-        if self._none_valid_binning():
-            self.limits = False
-        elif self._only_one_bin_possible():
-            self.limits = np.array([self.xs_min, self.xs_max])
-            self.dx_list = np.array([self.xs_max - self.xs_min])
-        elif max_nof_bins == 1:
-            self.limits = np.array([self.xs_min, self.xs_max])
-            self.dx_list = np.array([self.xs_max - self.xs_min])
-        else:
-            # init matrices
-            matrix = np.ones((nof_limits, nof_bins)) * big_M
-            argmatrix = np.ones((nof_limits, nof_bins)) * np.nan
+        # init matrices
+        matrix = np.ones((nof_limits, nof_bins)) * big_M
+        argmatrix = np.ones((nof_limits, nof_bins)) * np.nan
 
-            # init first bin_index
-            bin_index = 0
-            for lim_index in range(nof_limits):
-                matrix[lim_index, bin_index] = self._cost_of_move(
-                    bin_index, lim_index, max_nof_bins, discount
-                )
+        # init first bin_index
+        bin_index = 0
+        for lim_index in range(nof_limits):
+            matrix[lim_index, bin_index] = self._cost_of_move(
+                bin_index, lim_index, max_nof_bins, discount
+            )
 
-            # for all other bins
-            for bin_index in range(1, max_nof_bins):
-                for lim_index_next in range(max_nof_bins + 1):
-                    # find best solution
-                    tmp = []
-                    for lim_index_before in range(max_nof_bins + 1):
-                        tmp.append(
-                            matrix[lim_index_before, bin_index - 1]
-                            + self._cost_of_move(
-                                lim_index_before, lim_index_next, max_nof_bins, discount
-                            )
+        # for all other bins
+        for bin_index in range(1, max_nof_bins):
+            for lim_index_next in range(max_nof_bins + 1):
+                # find best solution
+                tmp = []
+                for lim_index_before in range(max_nof_bins + 1):
+                    tmp.append(
+                        matrix[lim_index_before, bin_index - 1]
+                        + self._cost_of_move(
+                            lim_index_before, lim_index_next, max_nof_bins, discount
                         )
-                    # store best solution
-                    matrix[lim_index_next, bin_index] = np.min(tmp)
-                    argmatrix[lim_index_next, bin_index] = np.argmin(tmp)
+                    )
+                # store best solution
+                matrix[lim_index_next, bin_index] = np.min(tmp)
+                argmatrix[lim_index_next, bin_index] = np.argmin(tmp)
 
-            # find indices
-            self.method_outputs = {"matrix": matrix, "argmatrix": argmatrix}
-            self.limits, _ = self._argmatrix_to_limits(max_nof_bins)
-            self.method_outputs["limits"] = self.limits
-        return self.limits
+        # find indices
+        self.method_outputs = {"matrix": matrix, "argmatrix": argmatrix}
+        limits, _ = self._argmatrix_to_limits(max_nof_bins)
+        self.method_outputs["limits"] = limits
+        return limits
 
 
 class Fixed(Base):
@@ -375,37 +435,29 @@ class Fixed(Base):
         }
         super(Fixed, self).__init__("fixed", method_args)
 
-    def find_limits(self, data, data_effect, axis_limits):
-        self._preprocess_find(data, data_effect, axis_limits)
-        nof_bins = self.method_args["nof_bins"]
-        min_points = self.method_args["min_points"]
+    def _collapse_to_one_bin(self) -> bool:
+        # Fixed honors the requested bin count exactly: it never collapses to a
+        # single bin — it returns the uniform grid or False (B6). Opting out here
+        # also keeps `_only_one_bin_possible` (which reads y.size) off the path,
+        # since Fixed is called with y=None.
+        return False
 
-        # early return, like Greedy/DP — B6 was this result being overwritten
-        if self._none_valid_binning():
-            self.limits = False
-            return self.limits
+    def _search(self) -> typing.Union[np.ndarray, bool]:
+        nof_bins = self.method_args["nof_bins"]
 
         limits, _ = np.linspace(
-            self.xs_min, self.xs_max, num=nof_bins + 1, endpoint=True, retstep=True
+            self.x_min, self.x_max, num=nof_bins + 1, endpoint=True, retstep=True
         )
-        if min_points is not None and not all(
-            self._bin_valid(limits[i], limits[i + 1]) for i in range(nof_bins)
-        ):
-            self.limits = False
-        else:
-            self.limits = limits
-
-        return self.limits
+        if not all(self._bin_valid(limits[i], limits[i + 1]) for i in range(nof_bins)):
+            self.no_binning_reason = NoBinningReason.FIXED_GRID_UNDERFILLED
+            return False
+        return limits
 
 
-# the single alias table for binning-method strings (R6): validation and
-# resolution both read it, so they cannot disagree
 def adapt_for_categorical(method: Base, nof_levels: int) -> Base:
     """A copy of `method` whose candidate bin edges land exactly on the
     integer level codes 0..K-1, so Greedy/DP merging over the K-1 transitions
     becomes *adaptive level grouping* (method_semantics.md, RHALE-ordinal)."""
-    import copy
-
     method = copy.deepcopy(method)
     nof_transitions = nof_levels - 1
     for key in ("init_nof_bins", "max_nof_bins", "nof_bins"):
@@ -414,6 +466,8 @@ def adapt_for_categorical(method: Base, nof_levels: int) -> Base:
     return method
 
 
+# the single alias table for binning-method strings (R6): validation and
+# resolution both read it, so they cannot disagree
 VALID_METHODS = {
     "fixed": Fixed,
     "greedy": Greedy,

--- a/effector/axis_partitioning.py
+++ b/effector/axis_partitioning.py
@@ -353,29 +353,6 @@ class DynamicProgramming(Base):
         # generic "only one bin possible" case.
         return self._only_one_bin_possible() or self.constraints.max_nof_bins == 1
 
-    def _index_to_position(self, index_start, index_stop, K):
-        dx = (self.x_max - self.x_min) / K
-        start = self.x_min + index_start * dx
-        stop = self.x_min + index_stop * dx
-        return start, stop
-
-    def _cost_of_move(self, index_before, index_next, K, discount):
-        """Compute the cost of move.
-
-        Computes the cost for moving from the index of the previous bin (index_before)
-        to the index of the next bin (index_next).
-        """
-
-        big_M = self.big_M
-        if index_before > index_next:
-            cost = big_M
-        elif index_before == index_next:
-            cost = 0
-        else:
-            start, stop = self._index_to_position(index_before, index_next, K)
-            cost = self._bin_cost(start, stop, discount)
-        return cost
-
     def _argmatrix_to_limits(self, K):
         assert "argmatrix" in self.method_outputs, (
             "argmatrix not found in method_outputs"
@@ -405,6 +382,53 @@ class DynamicProgramming(Base):
         )
         return limits, dx_list
 
+    def _bin_cost_matrix(self, max_nof_bins, discount):
+        """`cost[i, j]` = cost of a single bin spanning limit-index i..j, for all
+        i, j at once, in O(N + K^2).
+
+        Points are assigned to the K uniform grid cells and per-cell count / Σy /
+        Σy^2 are prefix-summed, so any bin's mean and variance are O(1). This
+        replaces the O(K^2 · N) matrix build (one O(N) `filter_points_in_bin` +
+        `np.var` per bin) with a single O(N) pass.
+
+        Boundary note: the grid cells are HALF-OPEN `[edge_m, edge_{m+1})`, unlike
+        `filter_points_in_bin` which is inclusive on both ends. The two agree on
+        every input except one where a point lands *exactly* on an interior grid
+        edge — measure-zero for continuous data, and impossible on the
+        integer-code categorical grid (positions are half-integers). Variance is
+        `E[y^2] - E[y]^2`, clamped at 0 to absorb floating-point noise (`np.var`
+        is non-negative by construction).
+        """
+        big_M = self.big_M
+        nof_limits = max_nof_bins + 1
+        nof_points = self.x.shape[0]
+        thres = max(self.constraints.min_points_per_bin, 2)
+        dx = (self.x_max - self.x_min) / max_nof_bins
+
+        cell = np.clip(((self.x - self.x_min) / dx).astype(int), 0, max_nof_bins - 1)
+        count = np.bincount(cell, minlength=max_nof_bins).astype(float)
+        sum_y = np.bincount(cell, self.y, minlength=max_nof_bins)
+        sum_y2 = np.bincount(cell, self.y * self.y, minlength=max_nof_bins)
+        cum_count = np.concatenate([[0.0], np.cumsum(count)])
+        cum_sum_y = np.concatenate([[0.0], np.cumsum(sum_y)])
+        cum_sum_y2 = np.concatenate([[0.0], np.cumsum(sum_y2)])
+
+        # n[i, j] / s[i, j] / q[i, j] over the points in cells [i, j)
+        n = cum_count[None, :] - cum_count[:, None]
+        s = cum_sum_y[None, :] - cum_sum_y[:, None]
+        q = cum_sum_y2[None, :] - cum_sum_y2[:, None]
+        idx = np.arange(nof_limits)
+        width = (idx[None, :] - idx[:, None]) * dx
+        with np.errstate(divide="ignore", invalid="ignore"):
+            mean = s / n
+            var = np.maximum(q / n - mean * mean, 0.0)
+        cost = var * width * (1.0 - discount * n / nof_points)
+        # under-filled bins (n < thres, which also covers i >= j) cost big_M...
+        cost = np.where(n < thres, big_M, cost)
+        # ...except a zero-width bin (i == j), which costs 0
+        np.fill_diagonal(cost, 0.0)
+        return cost
+
     def _search(self) -> np.ndarray:
         max_nof_bins = self.constraints.max_nof_bins
         discount = self.params["discount"]
@@ -413,15 +437,7 @@ class DynamicProgramming(Base):
         nof_limits = max_nof_bins + 1
         nof_bins = max_nof_bins
 
-        # cost[i, j] = cost of a single bin spanning limit-index i..j. It does
-        # NOT depend on which bin (bin_index) it is, so build it ONCE here rather
-        # than recomputing `_cost_of_move` inside the bin_index loop as before —
-        # that dropped a full O(K) factor of redundant O(N) bin-cost scans
-        # (O(K^3 N) -> O(K^2 N)). Values are identical to `_cost_of_move(i, j)`.
-        cost = np.empty((nof_limits, nof_limits))
-        for i in range(nof_limits):
-            for j in range(nof_limits):
-                cost[i, j] = self._cost_of_move(i, j, max_nof_bins, discount)
+        cost = self._bin_cost_matrix(max_nof_bins, discount)
 
         # init matrices
         matrix = np.ones((nof_limits, nof_bins)) * big_M
@@ -431,9 +447,8 @@ class DynamicProgramming(Base):
         matrix[:, 0] = cost[0, :]
 
         # for all other bins: matrix[next, b] = min_before matrix[before, b-1] +
-        # cost[before, next]. `argmin(axis=0)` scans ascending `before`, the same
-        # tie-break the previous `np.argmin(tmp)` used; the addition order is
-        # preserved, so the result is byte-identical to the triple loop.
+        # cost[before, next]. `argmin(axis=0)` scans ascending `before` (the
+        # tie-break the original `np.argmin(tmp)` used).
         for bin_index in range(1, max_nof_bins):
             prev = matrix[:, bin_index - 1][:, None] + cost
             matrix[:, bin_index] = prev.min(axis=0)

--- a/effector/axis_partitioning.py
+++ b/effector/axis_partitioning.py
@@ -413,32 +413,31 @@ class DynamicProgramming(Base):
         nof_limits = max_nof_bins + 1
         nof_bins = max_nof_bins
 
+        # cost[i, j] = cost of a single bin spanning limit-index i..j. It does
+        # NOT depend on which bin (bin_index) it is, so build it ONCE here rather
+        # than recomputing `_cost_of_move` inside the bin_index loop as before —
+        # that dropped a full O(K) factor of redundant O(N) bin-cost scans
+        # (O(K^3 N) -> O(K^2 N)). Values are identical to `_cost_of_move(i, j)`.
+        cost = np.empty((nof_limits, nof_limits))
+        for i in range(nof_limits):
+            for j in range(nof_limits):
+                cost[i, j] = self._cost_of_move(i, j, max_nof_bins, discount)
+
         # init matrices
         matrix = np.ones((nof_limits, nof_bins)) * big_M
         argmatrix = np.ones((nof_limits, nof_bins)) * np.nan
 
-        # init first bin_index
-        bin_index = 0
-        for lim_index in range(nof_limits):
-            matrix[lim_index, bin_index] = self._cost_of_move(
-                bin_index, lim_index, max_nof_bins, discount
-            )
+        # first bin: cost of a single bin from index 0 to each limit
+        matrix[:, 0] = cost[0, :]
 
-        # for all other bins
+        # for all other bins: matrix[next, b] = min_before matrix[before, b-1] +
+        # cost[before, next]. `argmin(axis=0)` scans ascending `before`, the same
+        # tie-break the previous `np.argmin(tmp)` used; the addition order is
+        # preserved, so the result is byte-identical to the triple loop.
         for bin_index in range(1, max_nof_bins):
-            for lim_index_next in range(max_nof_bins + 1):
-                # find best solution
-                tmp = []
-                for lim_index_before in range(max_nof_bins + 1):
-                    tmp.append(
-                        matrix[lim_index_before, bin_index - 1]
-                        + self._cost_of_move(
-                            lim_index_before, lim_index_next, max_nof_bins, discount
-                        )
-                    )
-                # store best solution
-                matrix[lim_index_next, bin_index] = np.min(tmp)
-                argmatrix[lim_index_next, bin_index] = np.argmin(tmp)
+            prev = matrix[:, bin_index - 1][:, None] + cost
+            matrix[:, bin_index] = prev.min(axis=0)
+            argmatrix[:, bin_index] = prev.argmin(axis=0)
 
         # find indices
         self.method_outputs = {"matrix": matrix, "argmatrix": argmatrix}

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -425,7 +425,7 @@ class ALE(ALEBase):
                 less than `15` unique values.
                 - If you want to change the parameters of the method, you pass an instance of the
                 class `effector.axis_partitioning.Fixed` with the desired parameters.
-                For example: `Fixed(nof_bins=20, min_points_per_bin=0, cat_limit=10)`
+                For example: `Fixed(nof_bins=20, min_points_per_bin=0)`
 
             centering: whether to compute the normalization constant for centering the plot:
 

--- a/effector/regional_effect_ale.py
+++ b/effector/regional_effect_ale.py
@@ -430,7 +430,7 @@ class RegionalALE(RegionalEffectBase):
                 `20` bins with at least `0` points per bin
                 - If you want to change the parameters of the method, you pass an instance of the
                 class `effector.axis_partitioning.Fixed` with the desired parameters.
-                For example: `Fixed(nof_bins=20, min_points_per_bin=0, cat_limit=10)`
+                For example: `Fixed(nof_bins=20, min_points_per_bin=0)`
         """
         self.kwargs_subregion_detection = {
             "features": features,

--- a/effector/utils.py
+++ b/effector/utils.py
@@ -18,11 +18,15 @@ class AllBinsHaveAtMostOnePointError(ValueError):
 
 def raise_if_no_binning(limits, feature: int, binning_method) -> None:
     """Shared guard after `find_limits`: a `False` result means no binning with
-    enough points per bin exists for this feature/strategy combination."""
+    enough points per bin exists for this feature/strategy combination. When the
+    optimizer recorded *why* (`binning_method.no_binning_reason`, a
+    `NoBinningReason`), surface that specific reason in the message."""
     if limits is False:
+        reason = getattr(binning_method, "no_binning_reason", None)
+        detail = f" ({reason.value})" if reason is not None else ""
         raise ValueError(
             f"Impossible to compute bins with enough points for feature "
-            f"{feature} and binning strategy {binning_method!r}. "
+            f"{feature} and binning strategy {binning_method!r}{detail}. "
             "Change the binning strategy or its parameters."
         )
 

--- a/notebooks/guides/efficiency_global.ipynb
+++ b/notebooks/guides/efficiency_global.ipynb
@@ -643,17 +643,7 @@
    "cell_type": "markdown",
    "id": "f58c1998-7564-43ae-b8d6-73a2d2b1379e",
    "metadata": {},
-   "source": [
-    "## Total Runtime\n",
-    "\n",
-    "Adding the two parts, we have the total runtime:\n",
-    "\n",
-    "| Method          | $T = T_1 + T_2$ (one feature) | $T = T_1 + T_2$ (all features) |\n",
-    "|-----------------|-------------------------------|--------------------------------|\n",
-    "| **PDP / d-PDP** | $(c_1 + c_2) N + 2 t_f$       | $D (c_1 + c_2) N + 2 D t_f$    |\n",
-    "| **ALE**         | $2 t_f$                       | $2 D t_f$                      |\n",
-    "| **RHALE**       | $t_f$                         | $t_f$                          |"
-   ]
+   "source": "## Total Runtime\n\nAdding the two parts, we have the total runtime:\n\n| Method          | $T = T_1 + T_2$ (one feature) | $T = T_1 + T_2$ (all features) |\n|-----------------|-------------------------------|--------------------------------|\n| **PDP / d-PDP** | $(c_1 + c_2) N + 2 t_f$       | $D (c_1 + c_2) N + 2 D t_f$    |\n| **ALE**         | $2 t_f$                       | $2 D t_f$                      |\n| **RHALE**       | $t_f$                         | $t_f$                          |\n\n### Binning cost: the role of `K` and `binning_method`\n\nThe table above folds binning into the constants by using `Fixed(nof_bins=20)`. But **ALE and RHALE bin the local effects inside `.fit()`**, and that step has its own cost — a pure-numpy pass over the $N$ local effects, *independent of the model*. With $K$ the number of bins, the per-feature binning cost $C_\\text{bin}$ depends on the `binning_method`:\n\n| `binning_method` | complexity | notes |\n|---|---|---|\n| `Fixed` | $O(N)$ | uniform grid; ALE's only option, RHALE-capable |\n| `Greedy` | $O(K \\cdot N)$ | adaptive one-pass merge; **RHALE default** |\n| `DynamicProgramming` | $O(N + K^2)$ | globally optimal bins |\n\nBecause it touches no model, $C_\\text{bin}$ is negligible against any nonzero $t_f$ — **as long as it stays sub-model-call.** The catch is that it is paid **per feature** ($D \\cdot C_\\text{bin}$), so a slow binner over many features can quietly dominate when $t_f$ is small.\n\nMeasured at $N = 50{,}000$ (per feature): `Fixed` ≈ 1.5 ms, `Greedy` ≈ 8 ms, `DynamicProgramming` ≈ 1.5 ms.\n\n!!! note \"DynamicProgramming used to be the landmine\"\n    `DynamicProgramming` was previously $O(K^3 N)$: at $N = 50{,}000,\\ K = 40$ it cost **≈ 3.3 s per feature** (≈ **66 s** for $D = 20$) — which could dwarf the model itself for fast $t_f$, and even make RHALE slower than PDP. It is now $O(N + K^2)$ (**≈ 1.5 ms**, a ~2000× speedup), so the binning method no longer changes the runtime picture.\n\nMaking binning explicit, the totals for the two accumulation-based methods become:\n\n| Method | $T$ (all features) |\n|---|---|\n| **ALE** | $2 D\\, t_f + D \\cdot O(N)$ |\n| **RHALE** | $t_f + D \\cdot C_\\text{bin}(N, K, \\texttt{binning\\_method})$ |\n\nRHALE still needs only **one** Jacobian pass for all $D$ features, so it stays model-bound: for realistic $t_f$, $C_\\text{bin}$ is milliseconds and any `binning_method` is a fine choice."
   },
   {
    "cell_type": "markdown",

--- a/tests/test_functional_binning.py
+++ b/tests/test_functional_binning.py
@@ -49,13 +49,13 @@ BINNING = [
     ),
     pytest.param(
         effector.axis_partitioning.DynamicProgramming(
-            max_nof_bins=20, min_points_per_bin=10, cat_limit=1
+            max_nof_bins=20, min_points_per_bin=10
         ),
         id="dp-20",
     ),
     pytest.param(
         effector.axis_partitioning.Greedy(
-            init_nof_bins=100, min_points_per_bin=10, discount=0.2, cat_limit=1
+            init_nof_bins=100, min_points_per_bin=10, discount=0.2
         ),
         id="greedy-100",
     ),

--- a/tests/test_unit_axis_partitioning.py
+++ b/tests/test_unit_axis_partitioning.py
@@ -113,7 +113,7 @@ class TestBinEstimation:
         # test Greedy
         min_points = 2
         est = effector.axis_partitioning.Greedy(
-            init_nof_bins=100, discount=0.3, min_points_per_bin=min_points, cat_limit=1
+            init_nof_bins=100, discount=0.3, min_points_per_bin=min_points
         )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
 
@@ -124,7 +124,7 @@ class TestBinEstimation:
         # test DP
         min_points = 2
         est = effector.axis_partitioning.DynamicProgramming(
-            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+            max_nof_bins=10, min_points_per_bin=min_points
         )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
 
@@ -139,14 +139,14 @@ class TestBinEstimation:
 
         min_points = 3
         est = effector.axis_partitioning.Greedy(
-            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points
         )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_greedy)
 
         min_points = 3
         est = effector.axis_partitioning.DynamicProgramming(
-            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+            max_nof_bins=10, min_points_per_bin=min_points
         )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_dp)
@@ -157,14 +157,14 @@ class TestBinEstimation:
 
         min_points = 4
         est = effector.axis_partitioning.Greedy(
-            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points
         )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_greedy)
 
         min_points = 4
         est = effector.axis_partitioning.DynamicProgramming(
-            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+            max_nof_bins=10, min_points_per_bin=min_points
         )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert np.allclose(gt_limits, limits_dp)
@@ -174,14 +174,14 @@ class TestBinEstimation:
 
         min_points = 5
         est = effector.axis_partitioning.Greedy(
-            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points
         )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert limits_greedy is False
 
         min_points = 5
         est = effector.axis_partitioning.DynamicProgramming(
-            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+            max_nof_bins=10, min_points_per_bin=min_points
         )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert limits_dp is False
@@ -193,7 +193,7 @@ class TestBinEstimation:
         # test Greedy
         min_points = 10
         est = effector.axis_partitioning.Greedy(
-            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points, cat_limit=1
+            init_nof_bins=100, discount=1.05, min_points_per_bin=min_points
         )
         limits_greedy = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert (
@@ -245,7 +245,7 @@ class TestBinEstimation:
         # test DP
         min_points = 10
         est = effector.axis_partitioning.DynamicProgramming(
-            max_nof_bins=10, min_points_per_bin=min_points, cat_limit=1
+            max_nof_bins=10, min_points_per_bin=min_points
         )
         limits_dp = est.find_limits(x[:, 0], y_grad[:, 0], axis_limits[:, 0])
         assert (
@@ -355,20 +355,18 @@ class TestConstantEffectMerging:
 
 def _greedy():
     return effector.axis_partitioning.Greedy(
-        init_nof_bins=20, min_points_per_bin=2, discount=0.3, cat_limit=1
+        init_nof_bins=20, min_points_per_bin=2, discount=0.3
     )
 
 
 def _dp():
     return effector.axis_partitioning.DynamicProgramming(
-        max_nof_bins=20, min_points_per_bin=2, discount=0.3, cat_limit=1
+        max_nof_bins=20, min_points_per_bin=2, discount=0.3
     )
 
 
 def _fixed():
-    return effector.axis_partitioning.Fixed(
-        nof_bins=4, min_points_per_bin=2, cat_limit=1
-    )
+    return effector.axis_partitioning.Fixed(nof_bins=4, min_points_per_bin=2)
 
 
 def _case_4pt():
@@ -459,17 +457,19 @@ class TestAxisPartitioningEdgeCases:
         assert _dp().find_limits(x, g, np.array([0.3, 0.3])) is False
 
     def test_adapt_for_categorical_rewrites_bin_count_greedy(self):
+        # Greedy's candidate-bin knob is a method param (init_nof_bins)
         method = effector.axis_partitioning.Greedy(init_nof_bins=20)
         adapted = effector.axis_partitioning.adapt_for_categorical(method, nof_levels=5)
-        assert adapted.method_args["init_nof_bins"] == 4  # nof_levels - 1
+        assert adapted.params["init_nof_bins"] == 4  # nof_levels - 1
         # deepcopy independence: the original is untouched
-        assert method.method_args["init_nof_bins"] == 20
+        assert method.params["init_nof_bins"] == 20
 
     def test_adapt_for_categorical_rewrites_bin_count_dp(self):
+        # DP's candidate-bin knob is a constraint (max_nof_bins)
         method = effector.axis_partitioning.DynamicProgramming(max_nof_bins=20)
         adapted = effector.axis_partitioning.adapt_for_categorical(method, nof_levels=5)
-        assert adapted.method_args["max_nof_bins"] == 4
-        assert method.method_args["max_nof_bins"] == 20
+        assert adapted.constraints.max_nof_bins == 4
+        assert method.constraints.max_nof_bins == 20
 
     def test_axis_limits_none_branch(self):
         # axis_limits=None => xs_min/xs_max derive from data.min()/max().

--- a/tests/test_unit_axis_partitioning.py
+++ b/tests/test_unit_axis_partitioning.py
@@ -585,3 +585,110 @@ class TestNoBinningReason:
         limits = est.find_limits(np.ones(50) * 0.3, np.ones(50), np.array([0.3, 0.3]))
         with pytest.raises(ValueError, match="all points share a single value"):
             utils.raise_if_no_binning(limits, feature=0, binning_method=est)
+
+
+def _inclusive_reference_dp_limits(est, x, y, x_lims):
+    """Recompute DP limits with the ORIGINAL inclusive-boundary cost (np.var +
+    filter_points_in_bin), reusing the class's DP fill + backtracking. Used to
+    cross-check the O(N+K^2) prefix-sum (half-open) cost matrix of Stage 2."""
+    import effector.utils as utils
+
+    est._preprocess_find(x, y, x_lims)
+    K = est.constraints.max_nof_bins
+    discount = est.params["discount"]
+    N = x.shape[0]
+    thres = max(est.constraints.min_points_per_bin, 2)
+    x_min, x_max = est.x_min, est.x_max
+    dx = (x_max - x_min) / K
+    nof = K + 1
+
+    cost = np.full((nof, nof), est.big_M)
+    for i in range(nof):
+        for j in range(i, nof):
+            if i == j:
+                cost[i, j] = 0.0
+                continue
+            start, stop = x_min + i * dx, x_min + j * dx
+            _, yb = utils.filter_points_in_bin(x, y, np.array([start, stop]))
+            if yb.size >= thres:
+                cost[i, j] = np.var(yb) * (stop - start) * (1 - discount * yb.size / N)
+
+    matrix = np.ones((nof, K)) * est.big_M
+    argmatrix = np.ones((nof, K)) * np.nan
+    matrix[:, 0] = cost[0, :]
+    for b in range(1, K):
+        prev = matrix[:, b - 1][:, None] + cost
+        matrix[:, b] = prev.min(axis=0)
+        argmatrix[:, b] = prev.argmin(axis=0)
+    est.method_outputs = {"argmatrix": argmatrix}
+    limits, _ = est._argmatrix_to_limits(K)
+    return limits
+
+
+class TestDPPrefixSumEquivalence:
+    """Stage 2 (prefix-sum, half-open) must match the inclusive-boundary
+    reference on all realistic data; it may differ only when points land exactly
+    on interior grid edges (unreachable for continuous data)."""
+
+    def _DP(self, K, mp):
+        return effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=K, min_points_per_bin=mp
+        )
+
+    def test_matches_inclusive_reference_on_random_data(self):
+        rng = np.random.default_rng(0)
+        compared = 0
+        for _ in range(120):
+            N = int(rng.integers(60, 1500))
+            x = np.sort(rng.uniform(0, 1, N))
+            kind = rng.integers(0, 3)
+            if kind == 0:
+                y = np.sin(rng.uniform(2, 12) * x) + rng.normal(0, 0.2, N)
+            elif kind == 1:
+                y = np.where(x < rng.uniform(0.3, 0.7), 5.0, -5.0)
+            else:
+                y = rng.normal(0, 1, N)
+            K = int(rng.integers(3, 18))
+            mp = int(rng.integers(2, 6))
+            ax = np.array([0.0, 1.0])
+
+            stage2 = self._DP(K, mp).find_limits(x, y, ax)
+            # only cross-check when a full search ran (not collapsed / False)
+            if stage2 is False or stage2.size <= 2:
+                continue
+            ref = _inclusive_reference_dp_limits(self._DP(K, mp), x, y, ax)
+            np.testing.assert_array_equal(stage2, ref)
+            compared += 1
+        assert compared > 40  # the sweep actually exercised full searches
+
+    def test_exact_grid_edge_half_open_behavior(self):
+        # The one place Stage 2 legitimately differs: many points sitting EXACTLY
+        # on interior grid edges (K=4 -> 0.25/0.5/0.75) with contrasting y.
+        # Inclusive boundaries double-count them (-> collapse to [0, 1]); the
+        # half-open cells count them once (-> full split). Unreachable for
+        # continuous data; impossible on the categorical t-0.5 grid. Pinned so
+        # the behavior is explicit, not accidental.
+        x = np.concatenate(
+            [
+                np.full(20, 0.25),
+                np.full(20, 0.5),
+                np.full(20, 0.75),
+                np.linspace(0.01, 0.24, 30),
+                np.linspace(0.76, 0.99, 30),
+            ]
+        )
+        y = np.concatenate(
+            [
+                np.full(20, 100.0),
+                np.full(20, -100.0),
+                np.full(20, 100.0),
+                np.zeros(30),
+                np.zeros(30),
+            ]
+        )
+        ax = np.array([0.0, 1.0])
+        stage2 = self._DP(4, 2).find_limits(x, y, ax)
+        ref = _inclusive_reference_dp_limits(self._DP(4, 2), x, y, ax)
+        np.testing.assert_array_equal(stage2, np.array([0.0, 0.25, 0.5, 0.75, 1.0]))
+        np.testing.assert_array_equal(ref, np.array([0.0, 1.0]))
+        assert not np.array_equal(stage2, ref)

--- a/tests/test_unit_axis_partitioning.py
+++ b/tests/test_unit_axis_partitioning.py
@@ -515,3 +515,73 @@ class TestAxisPartitioningEdgeCases:
         dp = _dp().find_limits(x, g, ax)
         np.testing.assert_array_equal(gr, dp)
         np.testing.assert_array_equal(gr, np.array([0.0, 0.5, 1.0]))
+
+    def test_fixed_min_points_none_no_longer_raises(self):
+        # AP-3: Fixed(min_points_per_bin=None) used to raise TypeError in
+        # _none_valid_binning (`size < None`). Now None == "no minimum" and it
+        # returns the exact uniform grid.
+        x = np.linspace(0.0, 1.0, 100)
+        est = effector.axis_partitioning.Fixed(nof_bins=4, min_points_per_bin=None)
+        limits = est.find_limits(x, None, np.array([0.0, 1.0]))
+        np.testing.assert_allclose(limits, np.linspace(0.0, 1.0, 5))
+        assert est.no_binning_reason is None
+
+
+class TestNoBinningReason:
+    """The `False` outcome carries a machine-readable reason (folded into PR-2)."""
+
+    _Reason = effector.axis_partitioning.NoBinningReason
+
+    def test_greedy_single_unique_reason(self):
+        est = _greedy()
+        assert (
+            est.find_limits(np.ones(50) * 0.3, np.ones(50), np.array([0.3, 0.3]))
+            is False
+        )
+        assert est.no_binning_reason is self._Reason.SINGLE_UNIQUE_VALUE
+
+    def test_dp_single_unique_reason(self):
+        est = _dp()
+        assert (
+            est.find_limits(np.ones(50) * 0.3, np.ones(50), np.array([0.3, 0.3]))
+            is False
+        )
+        assert est.no_binning_reason is self._Reason.SINGLE_UNIQUE_VALUE
+
+    def test_greedy_too_few_points_reason(self):
+        # 4 points, min_points=5 -> data.size < min_points
+        x, g, ax = _case_4pt()
+        est = effector.axis_partitioning.Greedy(init_nof_bins=100, min_points_per_bin=5)
+        assert est.find_limits(x, g, ax) is False
+        assert est.no_binning_reason is self._Reason.TOO_FEW_POINTS
+
+    def test_dp_too_few_points_reason(self):
+        x, g, ax = _case_4pt()
+        est = effector.axis_partitioning.DynamicProgramming(
+            max_nof_bins=10, min_points_per_bin=5
+        )
+        assert est.find_limits(x, g, ax) is False
+        assert est.no_binning_reason is self._Reason.TOO_FEW_POINTS
+
+    def test_fixed_grid_underfilled_reason(self):
+        # 3 points, 4 fixed bins, min 2 per bin -> a bin is under-filled
+        x = np.array([0.05, 0.1, 0.9])
+        est = effector.axis_partitioning.Fixed(nof_bins=4, min_points_per_bin=2)
+        assert est.find_limits(x, None, np.array([0.0, 1.0])) is False
+        assert est.no_binning_reason is self._Reason.FIXED_GRID_UNDERFILLED
+
+    def test_reason_resets_on_success(self):
+        # a failing call then a succeeding call on the same instance: no stale reason
+        est = _fixed()
+        est.find_limits(np.ones(50) * 0.3, None, np.array([0.3, 0.3]))
+        assert est.no_binning_reason is not None
+        est.find_limits(np.linspace(0, 1, 100), None, np.array([0.0, 1.0]))
+        assert est.no_binning_reason is None
+
+    def test_raise_if_no_binning_surfaces_reason(self):
+        import effector.utils as utils
+
+        est = _greedy()
+        limits = est.find_limits(np.ones(50) * 0.3, np.ones(50), np.array([0.3, 0.3]))
+        with pytest.raises(ValueError, match="all points share a single value"):
+            utils.raise_if_no_binning(limits, feature=0, binning_method=est)


### PR DESCRIPTION
## Why this PR exists
PRs #40, #41, #42 are all marked **merged**, but each was merged into its *stacked base branch*, not `main` — so the actual source rework never reached `main`. Today `main` has only the golden tests (#39) and the notebook fix (#43); it's missing the template, contract, constraints/params split, `cat_limit` removal, and both DP efficiency stages.

This PR lands the four source commits on `main` (cherry-picked cleanly — the golden-test tree already matched) and adds the runtime-guide documentation.

## Contents
- **`refactor`** — axis_partitioning as an isolated 1D bin-optimizer: `find_limits` template method, `x`/`y`/`x_lims` vocabulary, documented contract, `no_binning_reason` mechanism.
- **`refactor`** — split `Constraints` (min_points_per_bin, max_nof_bins) from method `params` (discount, init_nof_bins, nof_bins); `adapt_for_categorical` via a `_set_candidate_bin_count` hook; **remove dead `cat_limit`**.
- **`perf`** — hoist DP cost matrix, O(K³N)→O(K²N), byte-identical.
- **`perf`** — prefix-sum DP cost matrix, O(K²N)→O(N+K²); equivalence-verified, one documented half-open edge case.
- **`docs`** — global runtime guide gains a "Binning cost" section (`K`, `binning_method`, per-method complexity, the DP O(N+K²) improvement).

Net: DP ~1800–2200× faster (3298 ms → 1.5 ms at N=50k, K=40); RHALE is model-bound again for any binning.

## Verification
`make test` green (552 passed, 1 skipped); full suite green after #43. Guide `.md` regenerated via `make docs-pages` (no re-execution, no image churn).

## Note on the merged PRs
#40/#41/#42 can be left as-is (their commits are reproduced here) — no need to reopen. After this merges, `main` finally has the shipped rework.