### PR TITLE
Local-effects lifecycle: single-model-touch constitution + regional collapse

### DIFF
--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -410,9 +410,7 @@ class GlobalEffectBase(ABC):
             self._refit(feature)
         return dict(self.feature_effect["feature_" + str(feature)])
 
-    def heter_score(
-        self, feature: int, mask: Optional[np.ndarray] = None
-    ) -> float:
+    def heter_score(self, feature: int, mask: Optional[np.ndarray] = None) -> float:
         """The method-agnostic heterogeneity scalar of the `feature`-th
         feature: the mean of `eval_heter` over a uniform grid
         (`helpers.NOF_INTERNAL_POINTS` points) on the feature's interval — the

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, Tuple, Union
 
@@ -56,6 +57,7 @@ class GlobalEffectBase(ABC):
         model_jac: Optional[Callable] = None,
         *,
         data_effect: Optional[np.ndarray] = None,
+        local_effects: Optional[dict] = None,
         nof_instances: Union[int, str] = 10_000,
         axis_limits: Optional[np.ndarray] = None,
         schema: Optional[Union[ingestion.Schema, dict]] = None,
@@ -106,6 +108,15 @@ class GlobalEffectBase(ABC):
 
         # dict, like {"feature_i": {"quantity_1": value_1, "quantity_2": value_2, ...}} for the i-th
         self.feature_effect: dict = {}
+
+        # step 2 output cache: {"feature_i": <per-instance local effect>} —
+        # computed once (model-touching, `_compute_local_effects`) or injected
+        # here at construction; steps 3-4 (summarize/eval/plot/heter) read it and
+        # never re-touch the model (R: single-model-touch constitution)
+        self.local_effects: dict = dict(local_effects) if local_effects else {}
+        # feature keys whose local effects are cached, so a later model touch on
+        # the cached path can be flagged by the (silent) diagnostic
+        self._sealed: set = set()
 
     @abstractmethod
     def fit(
@@ -162,13 +173,65 @@ class GlobalEffectBase(ABC):
 
     @abstractmethod
     def _eval_unnorm(
-        self, feature: int, x: np.ndarray, heterogeneity: bool = False
+        self,
+        feature: int,
+        x: np.ndarray,
+        heterogeneity: bool = False,
+        params: Optional[dict] = None,
     ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
-        """The method-specific evaluation kernel, over the stored (fitted)
-        state: the *uncentered* mean effect at `x`, and — if `heterogeneity`
-        — also the heterogeneity curve h(x) (a variance-like quantity in the
-        method's own units, independent of any centering)."""
+        """The method-specific evaluation kernel: the *uncentered* mean effect
+        at `x`, and — if `heterogeneity` — also the heterogeneity curve h(x) (a
+        variance-like quantity in the method's own units, independent of any
+        centering).
+
+        `params` selects the payload to evaluate against: `None` reads the
+        stored fitted state (`feature_effect["feature_i"]`); a passed dict (the
+        output of `_summarize`) lets the masked heterogeneity path evaluate a
+        *transient* subregion payload without disturbing the stored one."""
         raise NotImplementedError
+
+    def _compute_local_effects(self, feature: int) -> None:
+        """Step 2 (model-touching): compute the per-instance local effect for
+        `feature` and store it in `self.local_effects["feature_i"]`. The single
+        place the model is queried for the effect. Overridden per method."""
+        raise NotImplementedError
+
+    def _ensure_local_effects(self, feature: int) -> None:
+        """Populate the local-effects cache for `feature` if absent — skipped
+        when the effects were injected at construction. Seals the feature; a
+        later recompute on a sealed feature (a parameter incompatible with the
+        cache) is flagged by the silent diagnostic below."""
+        key = "feature_" + str(feature)
+        if key not in self.local_effects:
+            if key in self._sealed:
+                logging.getLogger("effector").debug(
+                    "%s: recomputing local effects for feature %d after it was "
+                    "sealed — a parameter is incompatible with the cache",
+                    self.method_name,
+                    feature,
+                )
+            self._compute_local_effects(feature)
+        self._sealed.add(key)
+
+    def _summarize(
+        self, feature: int, mask: Optional[np.ndarray] = None, **fit_kwargs
+    ) -> dict:
+        """Step 3 (pure numpy): derive the effect payload for `feature` from the
+        cached local effects restricted to `mask` (`None` = all instances),
+        returning the same shape as the stored `feature_effect["feature_i"]`.
+        Overridden per method."""
+        raise NotImplementedError
+
+    def _replay_fit_kwargs(self, feature: int) -> dict:
+        """The method-specific fit kwargs recorded at the last `fit` (e.g.
+        `binning_method`, `order`, `use_vectorized`), minus centering — what a
+        transient `_summarize` must replay to match the fitted state."""
+        prev = self.fit_args.get("feature_" + str(feature), {})
+        return {
+            k: v
+            for k, v in prev.items()
+            if k not in ("centering", "points_for_centering")
+        }
 
     def _is_cat(self, feature: int) -> bool:
         """Does `feature` behave categorically (ordinal or nominal)?"""
@@ -178,10 +241,14 @@ class GlobalEffectBase(ABC):
         """The observed levels of a discrete feature, ascending."""
         return np.unique(self.data[:, feature])
 
-    def _level_weights(self, feature: int) -> Tuple[np.ndarray, np.ndarray]:
+    def _level_weights(
+        self, feature: int, mask: Optional[np.ndarray] = None
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """(levels, frequencies) of a discrete feature — the weights of every
-        frequency-weighted quantity in method_semantics.md."""
-        levels, counts = np.unique(self.data[:, feature], return_counts=True)
+        frequency-weighted quantity in method_semantics.md. With a `mask` the
+        levels and frequencies are those *within* the masked subregion."""
+        col = self.data[:, feature] if mask is None else self.data[mask, feature]
+        levels, counts = np.unique(col, return_counts=True)
         return levels, counts / counts.sum()
 
     def _level_display(self, feature: int, levels=None):
@@ -300,7 +367,9 @@ class GlobalEffectBase(ABC):
             return utils.mean_1d_linspace(partial_eval, start, stop, nof_points)
         return partial_eval(np.array([start])).item()
 
-    def eval_heter(self, feature: int, xs: np.ndarray) -> np.ndarray:
+    def eval_heter(
+        self, feature: int, xs: np.ndarray, mask: Optional[np.ndarray] = None
+    ) -> np.ndarray:
         """Evaluate the heterogeneity curve h(xs) of the `feature`-th feature.
 
         Notes:
@@ -316,13 +385,21 @@ class GlobalEffectBase(ABC):
         Args:
             feature: index of feature of interest
             xs: the points to evaluate the heterogeneity at, `(T,)`
+            mask: optional boolean `(N,)` selecting a subregion. `None` (default)
+                evaluates over the fitted state; a mask summarizes that subset of
+                the cached local effects on the fly (the regional split search) —
+                pure numpy, no model calls.
 
         Returns:
             the heterogeneity curve h(xs), `(T,)`, non-negative
         """
-        if self.requires_refit(feature, centering=False):
-            self._refit(feature)
-        return self._eval_unnorm(feature, xs, heterogeneity=True)[1]
+        if mask is None:
+            if self.requires_refit(feature, centering=False):
+                self._refit(feature)
+            return self._eval_unnorm(feature, xs, heterogeneity=True)[1]
+        self._ensure_local_effects(feature)
+        params = self._summarize(feature, mask, **self._replay_fit_kwargs(feature))
+        return self._eval_unnorm(feature, xs, heterogeneity=True, params=params)[1]
 
     def payload(self, feature: int) -> dict:
         """The method's raw fitted object for the `feature`-th feature — the
@@ -333,22 +410,31 @@ class GlobalEffectBase(ABC):
             self._refit(feature)
         return dict(self.feature_effect["feature_" + str(feature)])
 
-    def heter_score(self, feature: int) -> float:
+    def heter_score(
+        self, feature: int, mask: Optional[np.ndarray] = None
+    ) -> float:
         """The method-agnostic heterogeneity scalar of the `feature`-th
         feature: the mean of `eval_heter` over a uniform grid
         (`helpers.NOF_INTERNAL_POINTS` points) on the feature's interval — the
         single quantity regional splitting (and the future interaction module)
-        consumes."""
+        consumes.
+
+        With a `mask` (boolean `(N,)`), the score is computed over that
+        subregion from the cached local effects — the entry point the regional
+        split search calls for every candidate, model-free."""
         if self._is_cat(feature):
-            # frequency-weighted over levels (method_semantics.md)
-            levels, weights = self._level_weights(feature)
-            return float(np.average(self.eval_heter(feature, levels), weights=weights))
+            # frequency-weighted over levels (method_semantics.md); with a mask
+            # the levels/frequencies are those within the subregion
+            levels, weights = self._level_weights(feature, mask)
+            return float(
+                np.average(self.eval_heter(feature, levels, mask), weights=weights)
+            )
         xs = np.linspace(
             self.axis_limits[0, feature],
             self.axis_limits[1, feature],
             helpers.NOF_INTERNAL_POINTS,
         )
-        return float(np.mean(self.eval_heter(feature, xs)))
+        return float(np.mean(self.eval_heter(feature, xs, mask)))
 
     def requires_refit(self, feature, centering):
         """Check if refitting is needed."""

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -48,8 +48,13 @@ class ALEBase(GlobalEffectBase):
     def fit(self, features: typing.Union[int, str, list] = "all", **kwargs) -> None:
         raise NotImplementedError
 
-    def _eval_unnorm(self, feature: int, x: np.ndarray, heterogeneity: bool = False):
-        params = self.feature_effect["feature_" + str(feature)]
+    def _eval_unnorm(
+        self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
+    ):
+        # `params` (from `_summarize`) lets the masked heterogeneity path evaluate
+        # a transient subregion payload without disturbing the stored fitted one
+        if params is None:
+            params = self.feature_effect["feature_" + str(feature)]
         if params.get("is_cat"):
             # discrete kernel (method_semantics.md): accumulate in code space —
             # exact at levels, and h(v_j) is the variance of the step *into*
@@ -575,12 +580,54 @@ class RHALE(ALEBase):
             method_name="RHALE",
         )
 
-    def compile(self):
-        """Prepare everything for fitting, i.e., compute the gradients on data points."""
+    def _fill_jacobian(self):
+        """Compute the model Jacobian on the data (step 2 raw material): exact
+        via `model_jac`, else numerically. Runs at most once."""
         if self.data_effect is None and self.model_jac is not None:
             self.data_effect = self.model_jac(self.data)
         elif self.data_effect is None and self.model_jac is None:
             self.data_effect = utils.compute_jacobian_numerically(self.model, self.data)
+
+    def _compute_local_effects(self, feature: int) -> None:
+        """Step 2: RHALE's local effect is the pointwise derivative — a column
+        of the model Jacobian, independent of the binning (so re-binning a
+        subregion needs no model calls)."""
+        if self._is_cat(feature):
+            # ordinal kernel handled by the (combined) `_fit_feature_cat`; not
+            # reached on the continuous split-search path
+            raise NotImplementedError
+        self._fill_jacobian()
+        self.local_effects["feature_" + str(feature)] = self.data_effect[:, feature]
+
+    def _summarize(
+        self,
+        feature: int,
+        mask=None,
+        binning_method: Union[
+            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
+        ] = "dp",
+        order=None,
+    ) -> typing.Dict:
+        """Step 3 (pure numpy): bin the cached per-instance jacobian over the
+        subregion `mask` (None = all) and derive the bin effects/variances."""
+        self._ensure_local_effects(feature)
+        eff = self.local_effects["feature_" + str(feature)]
+        col = self.data[:, feature]
+        if mask is not None:
+            eff = eff[mask]
+            col = col[mask]
+
+        binning = (
+            ap.return_default(binning_method)
+            if isinstance(binning_method, str)
+            else binning_method
+        )
+        limits = binning.find_limits(col, eff, self.axis_limits[:, feature])
+        utils.raise_if_no_binning(limits, feature, binning)
+
+        dale_params = utils.compute_ale_params(col, eff, limits)
+        dale_params["alg_params"] = binning
+        return dale_params
 
     def _fit_feature(
         self,
@@ -594,26 +641,7 @@ class RHALE(ALEBase):
             # ordinal kernel: adjacent-level differences are the discrete
             # derivative; the jacobian (if any) is ignored for this feature
             return self._fit_feature_cat(feature, binning_method, order=order)
-        if self.data_effect is None:
-            self.compile()
-
-        data = self.data
-        data_effect = self.data_effect
-
-        if isinstance(binning_method, str):
-            binning_method = ap.return_default(binning_method)
-        limits = binning_method.find_limits(
-            data[:, feature], self.data_effect[:, feature], self.axis_limits[:, feature]
-        )
-        utils.raise_if_no_binning(limits, feature, binning_method)
-
-        # compute the bin effect
-        dale_params = utils.compute_ale_params(
-            data[:, feature], data_effect[:, feature], limits
-        )
-
-        dale_params["alg_params"] = binning_method
-        return dale_params
+        return self._summarize(feature, None, binning_method=binning_method, order=order)
 
     def fit(
         self,

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -99,13 +99,11 @@ class ALEBase(GlobalEffectBase):
                 "feature — call fit per feature"
             )
 
-    def _fit_feature_cat(
-        self, feature: int, binning_method=None, order=None
-    ) -> typing.Dict:
-        """The discrete (RH)ALE kernel: two-sided adjacent-level differences in
-        code space (method_semantics.md). ALE keeps one bin per transition;
-        RHALE additionally merges adjacent transitions with Greedy/DP —
-        adaptive level grouping."""
+    def _compute_local_effects_cat(self, feature: int, order=None) -> dict:
+        """Step 2 (categorical): two-sided adjacent-level differences in code
+        space — the discrete derivative (method_semantics.md). The levels (and
+        their order) are frozen from the full data, so a subregion re-bins the
+        same per-instance differences without re-querying the model."""
         levels = self._levels(feature)
         if len(levels) < 2:
             raise ValueError(
@@ -117,12 +115,32 @@ class ALEBase(GlobalEffectBase):
         positions, effects, instance_idx = utils.compute_local_effects_categorical(
             self.data, self.model, levels, feature
         )
-        self.data_effect_ale["feature_" + str(feature)] = {
+        prim = {
             "positions": positions,
             "effects": effects,
             "instance_idx": instance_idx,
             "levels": levels,
         }
+        self.local_effects["feature_" + str(feature)] = prim
+        # back-compat mirror (regional ALE reads this until the collapse)
+        self.data_effect_ale["feature_" + str(feature)] = prim
+        return prim
+
+    def _summarize_cat(
+        self, feature: int, mask=None, binning_method=None
+    ) -> typing.Dict:
+        """Step 3 (categorical): bin the cached adjacent-level differences over
+        the subregion `mask` (None = all). ALE keeps one bin per transition;
+        RHALE merges adjacent transitions with Greedy/DP (adaptive grouping)."""
+        self._ensure_local_effects(feature)
+        prim = self.local_effects["feature_" + str(feature)]
+        positions = prim["positions"]
+        effects = prim["effects"]
+        levels = prim["levels"]
+        if mask is not None:
+            keep = mask[prim["instance_idx"]]
+            positions = positions[keep]
+            effects = effects[keep]
 
         if binning_method is None:
             limits = np.arange(len(levels), dtype=float)
@@ -134,13 +152,22 @@ class ALEBase(GlobalEffectBase):
                 positions, effects, np.array([0.0, len(levels) - 1.0])
             )
             utils.raise_if_no_binning(limits, feature, binning)
-        self.bin_limits["feature_" + str(feature)] = limits
+        if mask is None:
+            self.bin_limits["feature_" + str(feature)] = limits
 
         params = utils.compute_ale_params(positions, effects, limits)
         params["alg_params"] = "categorical"
         params["levels"] = levels
         params["is_cat"] = True
         return params
+
+    def _fit_feature_cat(
+        self, feature: int, binning_method=None, order=None
+    ) -> typing.Dict:
+        """The discrete (RH)ALE kernel (compute + summarize), used by the global
+        fit; `_summarize_cat` alone powers the masked split search."""
+        self._compute_local_effects_cat(feature, order)
+        return self._summarize_cat(feature, None, binning_method)
 
     def plot(
         self,
@@ -385,8 +412,9 @@ class ALE(ALEBase):
         frozen at the global Fixed grid and a subregion re-bins these same
         secants rather than re-querying the model."""
         if self._is_cat(feature):
-            # ordinal kernel handled by the (combined) `_fit_feature_cat`
-            raise NotImplementedError
+            order = self.fit_args.get("feature_" + str(feature), {}).get("order")
+            self._compute_local_effects_cat(feature, order)
+            return
         binning_method = self.fit_args.get("feature_" + str(feature), {}).get(
             "binning_method", "fixed"
         )
@@ -410,6 +438,9 @@ class ALE(ALEBase):
     ) -> typing.Dict:
         """Step 3 (pure numpy): re-bin the cached secants over the subregion
         `mask` (None = all) on the frozen global bins → bin effects/variances."""
+        if self._is_cat(feature):
+            # ALE keeps one bin per transition (binning_method=None)
+            return self._summarize_cat(feature, mask, None)
         self._ensure_local_effects(feature)
         prim = self.local_effects["feature_" + str(feature)]
         secants, limits = prim["effects"], prim["limits"]
@@ -431,7 +462,9 @@ class ALE(ALEBase):
                 f"Invalid binning_method: {binning_method!r}; ALE works only with "
                 "the fixed binning method ('fixed' or an ap.Fixed instance)"
             )
-        return self._summarize(feature, None, binning_method=binning_method, order=order)
+        return self._summarize(
+            feature, None, binning_method=binning_method, order=order
+        )
 
     def fit(
         self,
@@ -617,9 +650,11 @@ class RHALE(ALEBase):
         of the model Jacobian, independent of the binning (so re-binning a
         subregion needs no model calls)."""
         if self._is_cat(feature):
-            # ordinal kernel handled by the (combined) `_fit_feature_cat`; not
-            # reached on the continuous split-search path
-            raise NotImplementedError
+            # ordinal kernel: adjacent-level differences are the discrete
+            # derivative; the jacobian (if any) is ignored for this feature
+            order = self.fit_args.get("feature_" + str(feature), {}).get("order")
+            self._compute_local_effects_cat(feature, order)
+            return
         self._fill_jacobian()
         self.local_effects["feature_" + str(feature)] = self.data_effect[:, feature]
 
@@ -634,6 +669,9 @@ class RHALE(ALEBase):
     ) -> typing.Dict:
         """Step 3 (pure numpy): bin the cached per-instance jacobian over the
         subregion `mask` (None = all) and derive the bin effects/variances."""
+        if self._is_cat(feature):
+            # ordinal: merge adjacent transitions with the chosen binning
+            return self._summarize_cat(feature, mask, binning_method)
         self._ensure_local_effects(feature)
         eff = self.local_effects["feature_" + str(feature)]
         col = self.data[:, feature]
@@ -665,7 +703,9 @@ class RHALE(ALEBase):
             # ordinal kernel: adjacent-level differences are the discrete
             # derivative; the jacobian (if any) is ignored for this feature
             return self._fit_feature_cat(feature, binning_method, order=order)
-        return self._summarize(feature, None, binning_method=binning_method, order=order)
+        return self._summarize(
+            feature, None, binning_method=binning_method, order=order
+        )
 
     def fit(
         self,

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -379,11 +379,51 @@ class ALE(ALEBase):
             method_name="ALE",
         )
 
+    def _compute_local_effects(self, feature: int) -> None:
+        """Step 2: ALE's local effect is the secant of the model across each
+        fixed bin — *edge-bound* (it depends on the bin limits), so the bins are
+        frozen at the global Fixed grid and a subregion re-bins these same
+        secants rather than re-querying the model."""
+        if self._is_cat(feature):
+            # ordinal kernel handled by the (combined) `_fit_feature_cat`
+            raise NotImplementedError
+        binning_method = self.fit_args.get("feature_" + str(feature), {}).get(
+            "binning_method", "fixed"
+        )
+        if isinstance(binning_method, str):
+            binning_method = ap.Fixed()
+        limits = binning_method.find_limits(
+            self.data[:, feature], None, self.axis_limits[:, feature]
+        )
+        utils.raise_if_no_binning(limits, feature, binning_method)
+        secants = utils.compute_local_effects(self.data, self.model, limits, feature)
+        self.local_effects["feature_" + str(feature)] = {
+            "effects": secants,
+            "limits": limits,
+        }
+        # back-compat mirrors (regional ALE reads these until the collapse)
+        self.data_effect_ale["feature_" + str(feature)] = secants
+        self.bin_limits["feature_" + str(feature)] = limits
+
+    def _summarize(
+        self, feature: int, mask=None, binning_method="fixed", order=None
+    ) -> typing.Dict:
+        """Step 3 (pure numpy): re-bin the cached secants over the subregion
+        `mask` (None = all) on the frozen global bins → bin effects/variances."""
+        self._ensure_local_effects(feature)
+        prim = self.local_effects["feature_" + str(feature)]
+        secants, limits = prim["effects"], prim["limits"]
+        col = self.data[:, feature]
+        if mask is not None:
+            secants = secants[mask]
+            col = col[mask]
+        dale_params = utils.compute_ale_params(col, secants, limits)
+        dale_params["alg_params"] = "fixed"
+        return dale_params
+
     def _fit_feature(
         self, feature: int, binning_method="fixed", order=None
     ) -> typing.Dict:
-
-        data = self.data
         if self._is_cat(feature):
             return self._fit_feature_cat(feature, order=order)
         if not (binning_method == "fixed" or isinstance(binning_method, ap.Fixed)):
@@ -391,23 +431,7 @@ class ALE(ALEBase):
                 f"Invalid binning_method: {binning_method!r}; ALE works only with "
                 "the fixed binning method ('fixed' or an ap.Fixed instance)"
             )
-
-        if isinstance(binning_method, str):
-            binning_method = ap.Fixed()
-        limits = binning_method.find_limits(
-            data[:, feature], None, self.axis_limits[:, feature]
-        )
-        utils.raise_if_no_binning(limits, feature, binning_method)
-
-        # compute data effect on bin limits
-        data_effect = utils.compute_local_effects(data, self.model, limits, feature)
-        self.data_effect_ale["feature_" + str(feature)] = data_effect
-        self.bin_limits["feature_" + str(feature)] = limits
-
-        # compute the bin effect
-        dale_params = utils.compute_ale_params(data[:, feature], data_effect, limits)
-        dale_params["alg_params"] = "fixed"
-        return dale_params
+        return self._summarize(feature, None, binning_method=binning_method, order=order)
 
     def fit(
         self,

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -28,10 +28,6 @@ class ALEBase(GlobalEffectBase):
         random_state: Optional[int] = 21,
         method_name: str = "ALE",
     ):
-        # per-feature raw local effects + bin limits (regional reuse and the
-        # discrete kernel store here; ALE also uses them on the continuous path)
-        self.data_effect_ale: dict = {}
-        self.bin_limits: dict = {}
         super(ALEBase, self).__init__(
             method_name,
             data,
@@ -122,8 +118,6 @@ class ALEBase(GlobalEffectBase):
             "levels": levels,
         }
         self.local_effects["feature_" + str(feature)] = prim
-        # back-compat mirror (regional ALE reads this until the collapse)
-        self.data_effect_ale["feature_" + str(feature)] = prim
         return prim
 
     def _summarize_cat(
@@ -152,8 +146,6 @@ class ALEBase(GlobalEffectBase):
                 positions, effects, np.array([0.0, len(levels) - 1.0])
             )
             utils.raise_if_no_binning(limits, feature, binning)
-        if mask is None:
-            self.bin_limits["feature_" + str(feature)] = limits
 
         params = utils.compute_ale_params(positions, effects, limits)
         params["alg_params"] = "categorical"
@@ -429,9 +421,6 @@ class ALE(ALEBase):
             "effects": secants,
             "limits": limits,
         }
-        # back-compat mirrors (regional ALE reads these until the collapse)
-        self.data_effect_ale["feature_" + str(feature)] = secants
-        self.bin_limits["feature_" + str(feature)] = limits
 
     def _summarize(
         self, feature: int, mask=None, binning_method="fixed", order=None

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -74,9 +74,7 @@ class PDPBase(GlobalEffectBase):
         ice = self._predict(self.data, grid, feature, use_vectorized)  # (T, N)
         self.local_effects["feature_" + str(feature)] = {"grid": grid, "ice": ice}
 
-    def _summarize(
-        self, feature: int, mask=None, use_vectorized: bool = True
-    ) -> dict:
+    def _summarize(self, feature: int, mask=None, use_vectorized: bool = True) -> dict:
         """Step 3 (pure numpy): from the cached (d-)ICE table restricted to the
         subregion `mask` (None = all), the mean curve and the heterogeneity curve
         on the grid — cross-instance variance of the per-instance-centered ICE
@@ -161,7 +159,11 @@ class PDPBase(GlobalEffectBase):
                 y = params["mean"][codes]
                 return (y, params["heter"][codes]) if heterogeneity else y
             y = np.interp(x, params["grid"], params["mean"])
-            return (y, np.interp(x, params["grid"], params["heter"])) if heterogeneity else y
+            return (
+                (y, np.interp(x, params["grid"], params["heter"]))
+                if heterogeneity
+                else y
+            )
 
         if self._is_cat(feature):
             # discrete features are evaluated only at levels (R10)

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -55,6 +55,56 @@ class PDPBase(GlobalEffectBase):
             return {"levels": self._levels(feature), "is_cat": True}
         return {}
 
+    def _compute_local_effects(self, feature: int) -> None:
+        """Step 2 (model-touching): the (d-)ICE table on the heterogeneity grid
+        — one row per grid point, one column per instance `(T, N)`. This is the
+        (d-)PDP's per-instance local effect; the split search re-scores column
+        subsets of it without re-querying the model."""
+        use_vectorized = self.fit_args.get("feature_" + str(feature), {}).get(
+            "use_vectorized", True
+        )
+        if self._is_cat(feature):
+            grid = self._levels(feature)
+        else:
+            grid = np.linspace(
+                self.axis_limits[0, feature],
+                self.axis_limits[1, feature],
+                helpers.NOF_INTERNAL_POINTS,
+            )
+        ice = self._predict(self.data, grid, feature, use_vectorized)  # (T, N)
+        self.local_effects["feature_" + str(feature)] = {"grid": grid, "ice": ice}
+
+    def _summarize(
+        self, feature: int, mask=None, use_vectorized: bool = True
+    ) -> dict:
+        """Step 3 (pure numpy): from the cached (d-)ICE table restricted to the
+        subregion `mask` (None = all), the mean curve and the heterogeneity curve
+        on the grid — cross-instance variance of the per-instance-centered ICE
+        curves (PDP) or of the raw d-ICE curves (DerPDP)."""
+        self._ensure_local_effects(feature)
+        prim = self.local_effects["feature_" + str(feature)]
+        grid, ice = prim["grid"], prim["ice"]  # ice (T, N)
+        if mask is not None:
+            ice = ice[:, mask]
+
+        is_cat = self._is_cat(feature)
+        if self.method_name == "pdp":
+            # each ICE curve is centered on its own (frequency-weighted for a
+            # discrete axis) mean — a per-instance shift, so mask-invariant
+            if is_cat:
+                _, weights = self._level_weights(feature)
+                per_instance_norm = np.average(ice, axis=0, weights=weights)
+            else:
+                per_instance_norm = np.mean(ice, axis=0)
+            heter = np.var(ice - per_instance_norm[np.newaxis, :], axis=1)
+        else:
+            heter = np.var(ice, axis=1)
+        out = {"grid": grid, "heter": heter, "mean": np.mean(ice, axis=1)}
+        if is_cat:
+            out["is_cat"] = True
+            out["levels"] = grid
+        return out
+
     def _compute_norm_const(
         self,
         feature: int,
@@ -92,11 +142,27 @@ class PDPBase(GlobalEffectBase):
         # mean-effect shift is their average
         return np.mean(norm_const)
 
-    def _eval_unnorm(self, feature: int, x: np.ndarray, heterogeneity: bool = False):
+    def _eval_unnorm(
+        self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
+    ):
         """Kernel: uncentered mean (d-)ICE at `x`; with `heterogeneity`, also
         h(x) — the variance across the *per-instance centered* ICE curves for
         the PDP (levels are only comparable after centering) and across the raw
-        d-ICE curves for the DerPDP (slopes are directly comparable)."""
+        d-ICE curves for the DerPDP (slopes are directly comparable).
+
+        When `params` (from `_summarize`) is given, read the mean/heterogeneity
+        off the cached grid — the model-free masked path used by the regional
+        split search — instead of re-querying the model at `x`."""
+        if params is not None:
+            if params.get("is_cat"):
+                codes = utils.codes_from_levels(
+                    x, params["levels"], feature, self.feature_names[feature]
+                )
+                y = params["mean"][codes]
+                return (y, params["heter"][codes]) if heterogeneity else y
+            y = np.interp(x, params["grid"], params["mean"])
+            return (y, np.interp(x, params["grid"], params["heter"])) if heterogeneity else y
+
         if self._is_cat(feature):
             # discrete features are evaluated only at levels (R10)
             utils.codes_from_levels(

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -220,34 +220,44 @@ class ShapDP(GlobalEffectBase):
             random_state=random_state,
         )
 
-    def _fit_feature(
-        self,
-        feature: int,
-        binning_method: Union[
-            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
-        ] = "dp",
-    ) -> typing.Dict:
-        data = self.data
-
+    def _compute_local_effects(self, feature: int) -> None:
+        """Step 2: the SHAP values are the local effect — computed once by the
+        backend (or injected via `shap_values=`), feature-independent. Fill the
+        whole `(N,D)` table on first use and cache this feature's column."""
         if self.shap_values is None:
             self.shap_values = _compute_shap_values(
                 self.model,
-                data,
+                self.data,
                 self.backend,
                 self.budget,
                 self.shap_explainer_kwargs,
                 self.shap_explanation_kwargs,
                 self.random_state,
             )
+        self.local_effects["feature_" + str(feature)] = self.shap_values[:, feature]
 
-        # extract x and y
-        yy = self.shap_values[:, feature]
-        xx = data[:, feature]
+    def _summarize(
+        self,
+        feature: int,
+        mask=None,
+        binning_method: Union[
+            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
+        ] = "dp",
+    ) -> typing.Dict:
+        """Step 3 (pure numpy): bin/aggregate the cached SHAP column over the
+        subregion `mask` (None = all) — a spline of per-bin mean/variance for
+        continuous features, per-level mean/variance for discrete ones."""
+        self._ensure_local_effects(feature)
+        yy = self.local_effects["feature_" + str(feature)]
+        xx = self.data[:, feature]
+        if mask is not None:
+            yy = yy[mask]
+            xx = xx[mask]
 
         if self._is_cat(feature):
             # per-level mean/variance of the shap values with a step lookup —
             # no spline, no order enters the math (method_semantics.md)
-            levels = self._levels(feature)
+            levels = np.unique(xx)
             codes = utils.codes_from_levels(
                 xx, levels, feature, self.feature_names[feature]
             )
@@ -264,24 +274,18 @@ class ShapDP(GlobalEffectBase):
                 "yy": yy,
             }
 
-        if isinstance(binning_method, str):
-            binning_method = ap.return_default(binning_method)
-
-        limits = binning_method.find_limits(
-            data[:, feature], self.shap_values[:, feature], self.axis_limits[:, feature]
+        binning = (
+            ap.return_default(binning_method)
+            if isinstance(binning_method, str)
+            else binning_method
         )
+        limits = binning.find_limits(xx, yy, self.axis_limits[:, feature])
+        utils.raise_if_no_binning(limits, feature, binning)
+        feature_effect_dict = utils.compute_ale_params(xx, yy, limits)
+        feature_effect_dict["alg_params"] = binning
 
-        utils.raise_if_no_binning(limits, feature, binning_method)
-        # compute the bin effect
-        feature_effect_dict = utils.compute_ale_params(
-            data[:, feature], self.shap_values[:, feature], limits
-        )
-        feature_effect_dict["alg_params"] = binning_method
-
-        # Compute bin edges and bin centers
+        # Compute bin edges and bin centers, then piecewise-linear interpolation
         bin_centers = (limits[:-1] + limits[1:]) / 2
-
-        # Create piecewise linear interpolation
         mean_spline = interp1d(
             bin_centers,
             feature_effect_dict["bin_effect"],
@@ -294,17 +298,27 @@ class ShapDP(GlobalEffectBase):
             kind="linear",
             fill_value="extrapolate",
         )
-
-        ret_dict = {
+        return {
             "spline_mean": mean_spline,
             "spline_var": var_spline,
             "xx": xx,
             "yy": yy,
         }
-        return ret_dict
 
-    def _eval_unnorm(self, feature: int, x: np.ndarray, heterogeneity: bool = False):
-        params = self.feature_effect["feature_" + str(feature)]
+    def _fit_feature(
+        self,
+        feature: int,
+        binning_method: Union[
+            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
+        ] = "dp",
+    ) -> typing.Dict:
+        return self._summarize(feature, None, binning_method=binning_method)
+
+    def _eval_unnorm(
+        self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
+    ):
+        if params is None:
+            params = self.feature_effect["feature_" + str(feature)]
         if params.get("is_cat"):
             codes = utils.codes_from_levels(
                 x, params["levels"], feature, self.feature_names[feature]

--- a/effector/regional_effect.py
+++ b/effector/regional_effect.py
@@ -8,9 +8,11 @@ from tqdm import tqdm
 
 import effector.helpers as helpers
 import effector.space_partitioning
-from effector import global_effect, ingestion
+from effector import global_effect, ingestion, utils
 from effector.method_registry import resolve as resolve_method
 from effector.space_partitioning import Best, Tree
+
+BIG_M = helpers.BIG_M
 
 
 class RegionalEffectBase:
@@ -78,18 +80,60 @@ class RegionalEffectBase:
         self.partitioners: typing.Dict[str, Best] = {}
         self.tree: typing.Dict[str, Tree] = {}
 
+        # the ONE global effect object per feature: fit once on the full data,
+        # its cached local effects re-scored (masked) for every candidate split
+        self._global_fe: typing.Dict = {}
+
     def fit(self, *args, **kwargs):
         raise NotImplementedError
 
+    def _global_fe_kwargs(self) -> dict:
+        """Hook: method-specific constructor kwargs for the global effect built
+        in `_precompute_global` (e.g. the SHAP backend/budget, or a precomputed
+        jacobian to avoid recomputing it)."""
+        return {}
+
+    def _after_precompute(self, feature: int, fe) -> None:
+        """Hook: run after the global effect is fitted (e.g. stash the computed
+        SHAP values for node injection)."""
+
     def _precompute_global(self, feature: int) -> None:
-        """Hook: method-specific global precompute for `feature` (ICE table,
-        global ALE effects, shap values), run once per feature before the
-        heterogeneity function is built."""
+        """Fit the ONE global effect for `feature` on the full data and cache it
+        (its local effects are computed here, once). The heterogeneity function
+        then re-scores masked subsets of those cached effects — no model calls,
+        no per-candidate object rebuilds (the single-model-touch constitution)."""
+        spec = resolve_method(self.method_name)
+        kwargs = dict(
+            axis_limits=self.axis_limits,
+            nof_instances="all",
+            schema=self._node_schema(),
+            random_state=self.random_state,
+        )
+        kwargs.update(self._global_fe_kwargs())
+        if spec.needs_jac:
+            fe = spec.cls(self.data, self.model, self.model_jac, **kwargs)
+        else:
+            fe = spec.cls(self.data, self.model, **kwargs)
+        fe.fit(features=feature, centering=False, **self.kwargs_fitting)
+        self._global_fe["feature_" + str(feature)] = fe
+        self._after_precompute(feature, fe)
 
     def _create_heterogeneity_function(self, feature: int, min_points: int) -> Callable:
-        """Hook: the heterogeneity function the partitioner minimizes —
-        `active_indices -> float` (BIG_M when the region is invalid)."""
-        raise NotImplementedError
+        """The heterogeneity the partitioner minimizes: delegate to the global
+        effect's own `heter_score(feature, mask)` over the candidate subregion —
+        pure numpy over the cached local effects. A degenerate subregion (empty
+        or singleton bins) is rejected with BIG_M."""
+        fe = self._global_fe["feature_" + str(feature)]
+
+        def heter(active_indices) -> float:
+            if np.sum(active_indices) < min_points:
+                return BIG_M
+            try:
+                return fe.heter_score(feature, mask=active_indices.astype(bool))
+            except (utils.AllBinsHaveAtMostOnePointError, ValueError):
+                return BIG_M
+
+        return heter
 
     def _fit_loop(
         self,

--- a/effector/regional_effect_ale.py
+++ b/effector/regional_effect_ale.py
@@ -1,5 +1,4 @@
 import typing
-import warnings
 from typing import Callable, Optional, Union
 
 import numpy as np
@@ -7,7 +6,6 @@ import numpy as np
 import effector.space_partitioning
 from effector import axis_partitioning as ap
 from effector import helpers, ingestion, utils
-from effector.global_effect_ale import ALE, RHALE
 from effector.regional_effect import RegionalEffectBase
 
 BIG_M = helpers.BIG_M
@@ -108,62 +106,10 @@ class RegionalRHALE(RegionalEffectBase):
         elif self.data_effect is None and self.model_jac is None:
             self.data_effect = utils.compute_jacobian_numerically(self.model, self.data)
 
-    def _create_heterogeneity_function(self, feature: int, min_points: int):
-        binning_method = ap.return_default(self.kwargs_fitting["binning_method"])
-        points_for_mean_heterogeneity = helpers.NOF_INTERNAL_POINTS
-
-        def heter(active_indices) -> float:
-            if np.sum(active_indices) < min_points:
-                return BIG_M
-
-            data = self.data[active_indices.astype(bool), :]
-            if self.data_effect is not None:
-                instance_effects = self.data_effect[active_indices.astype(bool), :]
-            else:
-                instance_effects = None
-            rhale = RHALE(
-                data,
-                self.model,
-                self.model_jac,
-                data_effect=instance_effects,
-                nof_instances="all",
-                axis_limits=self.axis_limits,
-                schema=self._node_schema(),
-                random_state=self.random_state,
-            )
-            try:
-                rhale.fit(
-                    features=feature, binning_method=binning_method, centering=False
-                )
-            except utils.AllBinsHaveAtMostOnePointError as e:
-                warnings.warn(
-                    f"RegionalRHALE: at a candidate split, some bins had at most "
-                    f"one point; the split is rejected. Error: {e}"
-                )
-                return BIG_M
-            except Exception as e:
-                warnings.warn(
-                    f"RegionalRHALE: an unexpected error occurred at a candidate "
-                    f"split ({np.sum(active_indices)} active points); the split "
-                    f"is rejected. Error: {e}"
-                )
-                return BIG_M
-
-            # heterogeneity is the mean of the heterogeneity curve
-            # (freq-weighted over the subset's levels for discrete features)
-            if ingestion.is_categorical(self.feature_types[feature]):
-                xs, counts = np.unique(data[:, feature], return_counts=True)
-                z = rhale.eval_heter(feature, xs)
-                return float(np.average(z, weights=counts))
-            xs = np.linspace(
-                self.axis_limits[0, feature],
-                self.axis_limits[1, feature],
-                points_for_mean_heterogeneity,
-            )
-            z = rhale.eval_heter(feature, xs)
-            return np.mean(z)
-
-        return heter
+    def _global_fe_kwargs(self) -> dict:
+        # hand the already-computed jacobian to the global RHALE so it is not
+        # recomputed there (the split search re-bins it, model-free)
+        return {"data_effect": self.data_effect}
 
     def fit(
         self,
@@ -311,8 +257,6 @@ class RegionalALE(RegionalEffectBase):
                 - `None`, for non-deterministic behavior
         """
 
-        self.global_bin_limits = {}
-        self.global_data_effect = {}
         super(RegionalALE, self).__init__(
             "ale",
             data,
@@ -322,87 +266,6 @@ class RegionalALE(RegionalEffectBase):
             schema=schema,
             random_state=random_state,
         )
-
-    def _precompute_global(self, feature: int):
-        """Fit the global ALE once and keep its per-instance bin effects: the
-        candidate regions re-bin those instead of refitting the model."""
-        global_ale = ALE(
-            self.data,
-            self.model,
-            nof_instances="all",
-            axis_limits=self.axis_limits,
-            schema=self._node_schema(),
-            random_state=self.random_state,
-        )
-        global_ale.fit(
-            features=feature,
-            binning_method=self.kwargs_fitting["binning_method"],
-            centering=False,
-        )
-        self.global_data_effect["feature_" + str(feature)] = global_ale.data_effect_ale[
-            "feature_" + str(feature)
-        ]
-        self.global_bin_limits["feature_" + str(feature)] = global_ale.bin_limits[
-            "feature_" + str(feature)
-        ]
-
-    def _create_heterogeneity_function(self, feature: int, min_points: int):
-        points_for_mean_heterogeneity = helpers.NOF_INTERNAL_POINTS
-        is_cat = ingestion.is_categorical(self.feature_types[feature])
-
-        def heter_cat(active_indices) -> float:
-            if np.sum(active_indices) < min_points:
-                return BIG_M
-            mask = active_indices.astype(bool)
-            contrib = self.global_data_effect["feature_" + str(feature)]
-            keep = mask[contrib["instance_idx"]]
-            if not keep.any():
-                return BIG_M
-            levels = contrib["levels"]
-            try:
-                params = utils.compute_ale_params(
-                    contrib["positions"][keep],
-                    contrib["effects"][keep],
-                    np.arange(len(levels), dtype=float),
-                )
-            except utils.AllBinsHaveAtMostOnePointError:
-                return BIG_M
-            # H = freq-weighted mean of h(v_k) within the candidate region;
-            # h(v_k) = variance of the step into level k
-            col = self.data[mask, feature]
-            counts = np.array(
-                [np.isclose(col, lev).sum() for lev in levels], dtype=float
-            )
-            if counts.sum() == 0:
-                return BIG_M
-            step_into = np.maximum(np.arange(len(levels)), 1) - 1
-            h_levels = params["bin_variance"][step_into]
-            return float(np.average(h_levels, weights=counts))
-
-        if is_cat:
-            return heter_cat
-
-        def heter(active_indices) -> float:
-            if np.sum(active_indices) < min_points:
-                return BIG_M
-
-            data_effect = self.global_data_effect["feature_" + str(feature)][
-                active_indices.astype(bool)
-            ]
-            data = self.data[active_indices.astype(bool), feature]
-            bin_limits = self.global_bin_limits["feature_" + str(feature)]
-
-            params = utils.compute_ale_params(data, data_effect, bin_limits)
-
-            xx = np.linspace(
-                params["limits"][0], params["limits"][-1], points_for_mean_heterogeneity
-            )
-            var = utils.apply_bin_value(
-                x=xx, bin_limits=params["limits"], bin_value=params["bin_variance"]
-            )
-            return np.mean(var)
-
-        return heter
 
     def fit(
         self,

--- a/effector/regional_effect_pdp.py
+++ b/effector/regional_effect_pdp.py
@@ -3,7 +3,6 @@ import typing
 import numpy as np
 
 from effector import helpers, ingestion
-from effector.global_effect_pdp import PDP, DerPDP
 from effector.regional_effect import RegionalEffectBase
 from effector.space_partitioning import Best
 
@@ -23,8 +22,6 @@ class RegionalPDPBase(RegionalEffectBase):
         schema: typing.Optional[typing.Union[ingestion.Schema, dict]] = None,
         random_state: typing.Optional[int] = 21,
     ):
-        self.y_ice = {}
-        self.heter_grid: dict = {}
         super(RegionalPDPBase, self).__init__(
             method_name,
             data,
@@ -35,30 +32,6 @@ class RegionalPDPBase(RegionalEffectBase):
             schema=schema,
             random_state=random_state,
         )
-
-    def _create_heterogeneity_function(self, feature: int, min_points: int):
-        is_cat = ingestion.is_categorical(self.feature_types[feature])
-
-        def heter(active_indices) -> float:
-            if np.sum(active_indices) < min_points:
-                return BIG_M
-            mask = active_indices.astype(bool)
-            yy = self.y_ice["feature_" + str(feature)][mask, :]
-            z = np.var(yy, axis=0)
-            if is_cat:
-                # H = freq-weighted mean over levels, frequencies within the
-                # candidate region (method_semantics.md)
-                levels = self.heter_grid["feature_" + str(feature)]
-                col = self.data[mask, feature]
-                counts = np.array(
-                    [np.isclose(col, lev).sum() for lev in levels], dtype=float
-                )
-                if counts.sum() == 0:
-                    return BIG_M
-                return float(np.average(z, weights=counts))
-            return float(np.mean(z))
-
-        return heter
 
 
 class RegionalPDP(RegionalPDPBase):
@@ -130,42 +103,6 @@ class RegionalPDP(RegionalPDPBase):
             schema=schema,
             random_state=random_state,
         )
-
-    def _precompute_global(self, feature: int):
-        """Fit the global PDP once and keep the centered ICE table on the
-        heterogeneity grid: candidate regions score row-subsets of it."""
-        pdp = PDP(
-            self.data,
-            self.model,
-            axis_limits=self.axis_limits,
-            nof_instances="all",
-            schema=self._node_schema(),
-            random_state=self.random_state,
-        )
-        pdp.fit(
-            features=feature,
-            centering=True,
-            points_for_centering=self.kwargs_fitting["points_for_centering"],
-            use_vectorized=self.kwargs_fitting["use_vectorized"],
-        )
-
-        if ingestion.is_categorical(self.feature_types[feature]):
-            xx = pdp._levels(feature)
-        else:
-            xx = np.linspace(
-                self.axis_limits[0, feature],
-                self.axis_limits[1, feature],
-                helpers.NOF_INTERNAL_POINTS,
-            )
-        self.heter_grid["feature_" + str(feature)] = xx
-        y_ice = pdp._predict(
-            pdp.data, xx, feature, self.kwargs_fitting["use_vectorized"]
-        )
-        y_ice = (
-            y_ice
-            - pdp.feature_effect["feature_" + str(feature)]["norm_const"][np.newaxis, :]
-        )
-        self.y_ice["feature_" + str(feature)] = y_ice.T
 
     def fit(
         self,
@@ -335,38 +272,6 @@ class RegionalDerPDP(RegionalPDPBase):
             schema=schema,
             random_state=random_state,
         )
-
-    def _precompute_global(self, feature: int):
-        """Fit the global DerPDP once and keep the d-ICE table on the
-        heterogeneity grid: candidate regions score row-subsets of it."""
-        pdp = DerPDP(
-            self.data,
-            self.model,
-            self.model_jac,
-            axis_limits=self.axis_limits,
-            nof_instances="all",
-            schema=self._node_schema(),
-            random_state=self.random_state,
-        )
-        pdp.fit(
-            features=feature,
-            centering=False,
-            use_vectorized=self.kwargs_fitting["use_vectorized"],
-        )
-
-        if ingestion.is_categorical(self.feature_types[feature]):
-            xx = pdp._levels(feature)
-        else:
-            xx = np.linspace(
-                self.axis_limits[0, feature],
-                self.axis_limits[1, feature],
-                helpers.NOF_INTERNAL_POINTS,
-            )
-        self.heter_grid["feature_" + str(feature)] = xx
-        y_ice = pdp._predict(
-            pdp.data, xx, feature, self.kwargs_fitting["use_vectorized"]
-        )
-        self.y_ice["feature_" + str(feature)] = y_ice.T
 
     def fit(
         self,

--- a/effector/regional_effect_shap.py
+++ b/effector/regional_effect_shap.py
@@ -1,12 +1,11 @@
 import typing
-import warnings
 from typing import Callable, Optional, Union
 
 import numpy as np
 
 import effector
 from effector import axis_partitioning as ap
-from effector import helpers, ingestion, utils
+from effector import helpers, ingestion
 from effector.regional_effect import RegionalEffectBase
 
 BIG_M = helpers.BIG_M
@@ -100,74 +99,20 @@ class RegionalShapDP(RegionalEffectBase):
         values (attributions are not recomputed within the region)."""
         return {"shap_values": self.global_shap_values[active_indices, :]}
 
-    def _precompute_global(self, feature: int):
-        """Compute the global SHAP values once; regions score slices of them."""
-        if self.global_shap_values is None:
-            global_shap_dp = effector.ShapDP(
-                self.data,
-                self.model,
-                axis_limits=self.axis_limits,
-                nof_instances="all",
-                schema=self._node_schema(),
-                random_state=self.random_state,
-                backend=self.backend,
-                budget=self.budget,
-                shap_explainer_kwargs=self.shap_explainer_kwargs,
-                shap_explanation_kwargs=self.shap_explanation_kwargs,
-            )
-            global_shap_dp.fit(feature, centering=False, **self.kwargs_fitting)
-            self.global_shap_values = global_shap_dp.shap_values
+    def _global_fe_kwargs(self) -> dict:
+        # the global ShapDP is constructed with the backend/budget config and
+        # any user-provided attributions (reused, not recomputed)
+        return dict(
+            backend=self.backend,
+            budget=self.budget,
+            shap_values=self.global_shap_values,
+            shap_explainer_kwargs=self.shap_explainer_kwargs,
+            shap_explanation_kwargs=self.shap_explanation_kwargs,
+        )
 
-    def _create_heterogeneity_function(self, feature: int, min_points: int):
-        binning_method = ap.return_default(self.kwargs_fitting["binning_method"])
-        points_for_mean_heterogeneity = helpers.NOF_INTERNAL_POINTS
-
-        def heterogeneity_function(active_indices) -> float:
-            if np.sum(active_indices) < min_points:
-                return BIG_M
-
-            data = self.data[active_indices.astype(bool), :]
-            shap_values = self.global_shap_values[active_indices.astype(bool), :]
-            shap_dp = effector.ShapDP(
-                data,
-                self.model,
-                axis_limits=self.axis_limits,
-                nof_instances="all",
-                schema=self._node_schema(),
-                random_state=self.random_state,
-                shap_values=shap_values,
-            )
-
-            try:
-                shap_dp.fit(
-                    features=feature, binning_method=binning_method, centering=False
-                )
-            except utils.AllBinsHaveAtMostOnePointError as e:
-                warnings.warn(
-                    f"RegionalShapDP: at a candidate split, some bins had at most "
-                    f"one point; the split is rejected. Error: {e}"
-                )
-                return BIG_M
-            except Exception as e:
-                warnings.warn(
-                    f"RegionalShapDP: an unexpected error occurred at a candidate "
-                    f"split; the split is rejected. Error: {e}"
-                )
-                return BIG_M
-
-            if ingestion.is_categorical(self.feature_types[feature]):
-                xs, counts = np.unique(data[:, feature], return_counts=True)
-                z = shap_dp.eval_heter(feature, xs)
-                return float(np.average(z, weights=counts))
-            xs = np.linspace(
-                self.axis_limits[0, feature],
-                self.axis_limits[1, feature],
-                points_for_mean_heterogeneity,
-            )
-            z = shap_dp.eval_heter(feature, xs)
-            return np.mean(z)
-
-        return heterogeneity_function
+    def _after_precompute(self, feature: int, fe) -> None:
+        # stash the computed attributions for node injection (_extra_fe_kwargs)
+        self.global_shap_values = fe.shap_values
 
     def fit(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,21 @@ def mixed_df_model(df):
 N_REGIONAL = 500
 
 
+class CountingModel:
+    """Wrap a model (or jacobian) callable and count its invocations — the
+    instrument behind the single-model-touch invariant (steps 3-4 of the
+    local-effects lifecycle must not re-query the model during the split
+    search)."""
+
+    def __init__(self, fn):
+        self.fn = fn
+        self.n_calls = 0
+
+    def __call__(self, x):
+        self.n_calls += 1
+        return self.fn(x)
+
+
 def gated_model(x):
     y = np.zeros_like(x[:, 0])
     ind = np.logical_and(x[:, 1] > 0, x[:, 2] == 0)

--- a/tests/test_contract_regional.py
+++ b/tests/test_contract_regional.py
@@ -12,7 +12,13 @@ import pytest
 
 import effector
 import effector.axis_partitioning as ap
-from tests.conftest import make_regional_data
+from tests.conftest import (
+    REGIONAL_NAMES,
+    CountingModel,
+    gated_model,
+    gated_model_jac,
+    make_regional_data,
+)
 
 XS = np.linspace(-0.9, 0.9, 30)
 
@@ -154,3 +160,53 @@ def test_rc5_best_level_wise_works(rc5_data):
 def test_rc5_junk_raises(rc5_data, junk):
     with pytest.raises((ValueError, AssertionError)):
         _fit_pdp_with_partitioner(rc5_data, junk)
+
+
+# ---------------------------------------------------------------------------
+# RC6 — the split search is model-free: the whole point of the local-effects
+# lifecycle. The global effect is fit once (its local effects computed once),
+# and every candidate split re-scores cached subsets. So the number of model
+# (and jacobian) calls during fit must NOT grow with how many candidate splits
+# are evaluated — the old per-candidate object rebuilds scaled with grid size.
+# ---------------------------------------------------------------------------
+
+
+def _fit_counted(name, data, grid):
+    model = CountingModel(gated_model)
+    jac = CountingModel(gated_model_jac)
+    part = effector.space_partitioning.Best(
+        max_depth=2, numerical_features_grid_size=grid
+    )
+    if name == "regional_pdp":
+        reg = effector.RegionalPDP(data, model)
+    elif name == "regional_derpdp":
+        reg = effector.RegionalDerPDP(data, model, model_jac=jac)
+    elif name == "regional_ale":
+        reg = effector.RegionalALE(data, model)
+    elif name == "regional_rhale":
+        reg = effector.RegionalRHALE(data, model, model_jac=jac)
+    elif name == "regional_shapdp":
+        # inject attributions: the split search never touches the model (0 calls)
+        shap_values = np.random.RandomState(0).normal(size=data.shape)
+        reg = effector.RegionalShapDP(data, model, shap_values=shap_values)
+    else:
+        raise ValueError(name)
+    reg.fit(0, space_partitioner=part)
+    return model.n_calls + jac.n_calls
+
+
+@pytest.mark.parametrize("name", REGIONAL_NAMES)
+def test_rc6_split_search_is_model_free(name):
+    data = make_regional_data()
+    # 5 vs 40 candidate positions per conditioning feature at the root — an ~8x
+    # difference in candidate splits scored
+    n_small = _fit_counted(name, data, grid=5)
+    n_large = _fit_counted(name, data, grid=40)
+    assert n_small == n_large, (
+        f"{name}: model calls grew with the candidate count "
+        f"({n_small} at grid=5 vs {n_large} at grid=40) — the split search is "
+        f"re-querying the model instead of re-scoring cached local effects"
+    )
+    # a one-time precompute is a small constant; per-candidate work would be
+    # >= the number of candidates (>= grid)
+    assert n_large < 40, f"{name}: {n_large} model calls looks like per-candidate work"


### PR DESCRIPTION
## Summary

Homogenizes the effect lifecycle across all five methods (PDP/DerPDP/ALE/RHALE/ShapDP) around a **single-model-touch constitution**, and collapses the regional layer onto one narrow seam.

**Constitution:** the model is touched in exactly one place — `_compute_local_effects` (step 2), and only if local effects weren't injected at construction. `_summarize`/`eval`/`eval_heter`/`heter_score`/`plot` are pure numpy over the cached `local_effects`.

**The win — regional↔global isolation:** the split search now delegates to the one seam `global_fe.heter_score(feature, mask) -> float`. This deletes the five bespoke per-candidate heterogeneity functions (RHALE/ShapDP previously *rebuilt and refit a full effect object for every candidate split*) and the scattered caches (`global_data_effect`, `global_shap_values`, `y_ice`, `heter_grid`, `data_effect_ale`, `bin_limits`). Regional partitioning and global methods can now evolve independently.

## What changed, per method

Each method's per-instance **local effect** is cached once, then subregions re-score a boolean-masked subset:

| method | local effect | masked heterogeneity |
|---|---|---|
| PDP/DerPDP | (d-)ICE table `(T,N)` | cross-instance variance over masked columns |
| ALE | secants at fixed global bin edges (edge-bound) | re-bin masked secants on frozen bins |
| RHALE | jacobian column | re-bin masked jacobian |
| ShapDP | φ column | re-bin masked φ |

Two accepted, documented asterisks: ALE stays on frozen global bins (edge-bound); PDP `eval`/`plot` at off-grid `xs` still query the model (the exact ICE-at-xs path). Both fire a silent `logging.debug` only when re-touching an already-sealed feature.

## Verification

- `make test` (merge gate, `-m "not slow"`): **562 passed**.
- Every method's masked heterogeneity validated as an **exact match** to the old regional formula (behavior-preserving).
- New invariant `test_rc6_split_search_is_model_free`: model calls during `.fit()` do not grow with the candidate-grid size.
- Real SHAP + shapiq (global + regional) and all 10 synthetic notebooks pass.
- One pre-existing full-suite flake remains: `test_active_region_effect[regional-shapdp-shapiq]` — a `slow` (non-gate), tolerance-edge shapiq approximation (4/94 points ~15% over a loose bound), unaffected by this refactor (the SHAP computation is unchanged).

## Follow-up (separate discussion)

Generalizing `mask=` to `eval`/`plot` (and possibly replacing the node-object path) — a semantics choice between global-frame and region-tailored regional plots. Deferred.
