### PR TITLE
mask= on all global surfaces: eval/plot within a subregion, model-free

### DIFF
--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -36,6 +36,17 @@ def check_feature_type_supported(
     )
 
 
+def check_binning_scope(binning_scope: str) -> None:
+    """Validate the `binning_scope` fit kwarg of the adaptive-binning methods
+    (RHALE/ShapDP): the x-range handed to the binner when a mask restricts the
+    data — `"global"` = the frozen global frame, `"effective"` = the masked
+    column's own `[min, max]`."""
+    if binning_scope not in ("global", "effective"):
+        raise ValueError(
+            f"binning_scope must be 'global' or 'effective'; got {binning_scope!r}"
+        )
+
+
 class GlobalEffectBase(ABC):
     # the class-level centering default (R3): each subclass declares it once;
     # fit/eval/plot signatures converge on it during the homogenization
@@ -190,6 +201,15 @@ class GlobalEffectBase(ABC):
         *transient* subregion payload without disturbing the stored one."""
         raise NotImplementedError
 
+    def _eval_masked_mean(
+        self, feature: int, x: np.ndarray, params: dict, mask: np.ndarray
+    ) -> np.ndarray:
+        """The uncentered masked mean effect at `x` — default reads the
+        transient payload (pure numpy). PDP overrides it: on the cached grid it
+        reads the payload, off-grid it recomputes ICE on `data[mask]` (the
+        exact-evaluation retouch, symmetric with the global PDP `eval`)."""
+        return self._eval_unnorm(feature, x, heterogeneity=False, params=params)
+
     def _compute_local_effects(self, feature: int) -> None:
         """Step 2 (model-touching): compute the per-instance local effect for
         `feature` and store it in `self.local_effects["feature_i"]`. The single
@@ -232,6 +252,44 @@ class GlobalEffectBase(ABC):
             for k, v in prev.items()
             if k not in ("centering", "points_for_centering")
         }
+
+    def _prep_mask(self, mask) -> Optional[np.ndarray]:
+        """Normalize a user `mask` to a boolean `(N,)` array (`None` passes
+        through). Strictly boolean — an integer index array is rejected rather
+        than silently reinterpreted as truth values."""
+        if mask is None:
+            return None
+        mask = np.asarray(mask)
+        if mask.dtype != bool:
+            raise ValueError(
+                f"mask must be a boolean array of shape ({self.data.shape[0]},); "
+                f"got dtype {mask.dtype}"
+            )
+        if mask.shape != (self.data.shape[0],):
+            raise ValueError(
+                f"mask must have shape ({self.data.shape[0]},); got {mask.shape}"
+            )
+        if not mask.any():
+            raise ValueError("mask selects no instances")
+        return mask
+
+    def _effective_limits(
+        self, feature: int, mask: Optional[np.ndarray] = None
+    ) -> Tuple[float, float]:
+        """The transient x-interval a (feature, mask) pair lives on: the masked
+        column's `[min, max]`; `None` = the immutable global frame. The global
+        `axis_limits` are never mutated by a mask — anything region-shaped is
+        derived per call. Raises on a degenerate masked interval."""
+        if mask is None:
+            return self.axis_limits[0, feature], self.axis_limits[1, feature]
+        col = self.data[mask, feature]
+        lo, hi = float(col.min()), float(col.max())
+        if not lo < hi:
+            raise ValueError(
+                f"Feature {feature} has a degenerate interval [{lo}, {hi}] "
+                f"within the masked subregion"
+            )
+        return lo, hi
 
     def _is_cat(self, feature: int) -> bool:
         """Does `feature` behave categorically (ordinal or nominal)?"""
@@ -339,29 +397,39 @@ class GlobalEffectBase(ABC):
         feature: int,
         method: str = "zero_integral",
         nof_points: int = helpers.NOF_INTERNAL_POINTS,
+        params: Optional[dict] = None,
+        mask: Optional[np.ndarray] = None,
     ) -> float:
         """Compute the normalization constant from the evaluation kernel:
         `zero_integral` = the mean over the feature interval, `zero_start` =
-        the value at its left limit."""
+        the value at its left limit.
+
+        With `params`/`mask` (the masked path), the constant belongs to a
+        *transient* subregion payload: the integral runs over the subregion's
+        effective interval (its own `[min, max]`, not the global frame) and the
+        level weights are those within the mask. Nothing is stored."""
         assert method in ["zero_integral", "zero_start"]
 
         def partial_eval(x):
-            return self._eval_unnorm(feature, x, heterogeneity=False)
+            return self._eval_unnorm(feature, x, heterogeneity=False, params=params)
 
         if self._is_cat(feature):
             # discrete centering (method_semantics.md): zero_integral is the
             # frequency-weighted level mean (order-invariant); zero_start
             # zeroes the first level *in fit order* (a custom `order` makes
             # its first entry the reference level)
-            levels, weights = self._level_weights(feature)
+            levels, weights = self._level_weights(feature, mask)
             if method == "zero_integral":
                 return float(np.average(partial_eval(levels), weights=weights))
-            fitted = self.feature_effect.get("feature_" + str(feature), {})
-            fit_levels = fitted.get("levels", levels)
+            source = (
+                params
+                if params is not None
+                else self.feature_effect.get("feature_" + str(feature), {})
+            )
+            fit_levels = source.get("levels", levels)
             return partial_eval(np.asarray(fit_levels[:1])).item()
 
-        start = self.axis_limits[0, feature]
-        stop = self.axis_limits[1, feature]
+        start, stop = self._effective_limits(feature, mask)
 
         if method == "zero_integral":
             return utils.mean_1d_linspace(partial_eval, start, stop, nof_points)
@@ -393,6 +461,7 @@ class GlobalEffectBase(ABC):
         Returns:
             the heterogeneity curve h(xs), `(T,)`, non-negative
         """
+        mask = self._prep_mask(mask)
         if mask is None:
             if self.requires_refit(feature, centering=False):
                 self._refit(feature)
@@ -492,6 +561,7 @@ class GlobalEffectBase(ABC):
         feature: int,
         xs: np.ndarray,
         centering: Union[None, bool, str] = None,
+        mask: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """Evaluate the mean effect of the `feature`-th feature at positions `xs`.
 
@@ -515,11 +585,32 @@ class GlobalEffectBase(ABC):
                 - `True` or `"zero_integral"`: center around the `y` axis
                 - `"zero_start"`: the effect starts from `y=0`
 
+            mask: optional boolean `(N,)` selecting a subregion. `None`
+                (default) evaluates the fitted state; a mask summarizes that
+                subset of the cached local effects on the fly — the effect
+                *within* the subregion, on the global frame, without model
+                calls. Centering is then computed over the subregion's own
+                interval. Nothing is stored.
+
         Returns:
             the mean effect `y` at the given `xs`, `(T,)`
         """
         centering = self.DEFAULT_CENTERING if centering is None else centering
         centering = helpers.prep_centering(centering)
+        mask = self._prep_mask(mask)
+
+        if mask is not None:
+            if not self._is_cat(feature):
+                self._effective_limits(feature, mask)  # degeneracy guard
+            self._ensure_local_effects(feature)
+            params = self._summarize(feature, mask, **self._replay_fit_kwargs(feature))
+            y = self._eval_masked_mean(feature, xs, params, mask)
+            if centering is not False:
+                norm_const = self._compute_norm_const(
+                    feature, method=centering, params=params, mask=mask
+                )
+                y = y - self._mean_norm_const(norm_const)
+            return y
 
         if self.requires_refit(feature, centering):
             self._refit(feature, centering)

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -9,7 +9,7 @@ import effector.helpers as helpers
 import effector.utils as utils
 import effector.visualization as vis
 from effector import ingestion
-from effector.global_effect import GlobalEffectBase
+from effector.global_effect import GlobalEffectBase, check_binning_scope
 
 
 class ALEBase(GlobalEffectBase):
@@ -173,6 +173,8 @@ class ALEBase(GlobalEffectBase):
         dy_limits: Optional[List] = None,
         show_only_aggregated: bool = False,
         show_plot: bool = True,
+        mask: Optional[np.ndarray] = None,
+        feature_label: Optional[str] = None,
     ):
         """
         Plot the (RH)ALE feature effect of feature `feature`.
@@ -214,6 +216,12 @@ class ALEBase(GlobalEffectBase):
 
             show_only_aggregated: if True, only the main ale plot will be shown
             show_plot: if True, the plot will be shown
+            mask: optional boolean `(N,)` selecting a subregion — plot the
+                effect *within* it (re-binned from the cached local effects,
+                no model calls) with the x-axis windowed to the subregion's
+                own interval
+            feature_label: optional display name for the feature axis (e.g. a
+                regional node's name), overriding `feature_names[feature]`
         """
         heterogeneity = helpers.prep_confidence_interval(heterogeneity)
         centering = helpers.prep_centering(centering)
@@ -221,12 +229,36 @@ class ALEBase(GlobalEffectBase):
             scale_x, self.scale_x_list[feature] if self.scale_x_list else None
         )
         scale_y = helpers.resolve_scale(scale_y, self.scale_y)
+        mask = self._prep_mask(mask)
+        feature_names = list(self.feature_names)
+        if feature_label is not None:
+            feature_names[feature] = feature_label
 
-        # fit the feature if needed (the eval below reuses the stored state)
-        self.eval(
-            feature, np.array([self.axis_limits[0, feature]]), centering=centering
-        )
-        params = self.feature_effect["feature_" + str(feature)]
+        if mask is None:
+            # fit the feature if needed (the eval below reuses the stored state)
+            self.eval(
+                feature, np.array([self.axis_limits[0, feature]]), centering=centering
+            )
+            params = self.feature_effect["feature_" + str(feature)]
+            x_window = None
+        else:
+            # transient subregion payload from the cached local effects —
+            # pure numpy, nothing stored (the masked-plot path)
+            self._ensure_local_effects(feature)
+            params = self._summarize(feature, mask, **self._replay_fit_kwargs(feature))
+            x_window = (
+                None if params.get("is_cat") else self._effective_limits(feature, mask)
+            )
+
+        def centered_eval(xs):
+            if mask is None:
+                return self.eval(feature, xs, centering=centering)
+            y = self._eval_unnorm(feature, xs, params=params)
+            if centering is not False:
+                y = y - self._compute_norm_const(
+                    feature, method=centering, params=params, mask=mask
+                )
+            return y
 
         # the accumulated curve is piecewise linear between bin limits, so
         # evaluating exactly at the limits draws it exactly (no resampling).
@@ -235,10 +267,11 @@ class ALEBase(GlobalEffectBase):
         # would reject, so only build this grid for continuous features.
         if not params.get("is_cat"):
             x = np.asarray(params["limits"], dtype=float)
-            y = self.eval(feature, x, centering=centering)
+            y = centered_eval(x)
 
         if show_avg_output:
-            avg_output = helpers.prep_avg_output(self.data, self.model, None, scale_y)
+            data = self.data if mask is None else self.data[mask]
+            avg_output = helpers.prep_avg_output(data, self.model, None, scale_y)
         else:
             avg_output = None
 
@@ -251,9 +284,9 @@ class ALEBase(GlobalEffectBase):
             # bars = accumulated per-level values (in fit order); whiskers =
             # the variance of the step into each level (method_semantics.md)
             levels, labels = self._level_display(feature, params["levels"])
-            y_levels = self.eval(feature, levels, centering=centering)
+            y_levels = centered_eval(levels)
             variances = (
-                self._eval_unnorm(feature, levels, heterogeneity=True)[1]
+                self._eval_unnorm(feature, levels, heterogeneity=True, params=params)[1]
                 if heterogeneity is not False
                 else None
             )
@@ -274,7 +307,7 @@ class ALEBase(GlobalEffectBase):
                 scale_x=scale_x,
                 scale_y=scale_y,
                 avg_output=avg_output,
-                feature_names=self.feature_names,
+                feature_names=feature_names,
                 target_name=self.target_name,
                 y_limits=y_limits,
                 connect_line=True,  # (RH)ALE bars accumulate: show the step path
@@ -293,12 +326,13 @@ class ALEBase(GlobalEffectBase):
             scale_y=scale_y,
             title=title,
             avg_output=avg_output,
-            feature_names=self.feature_names,
+            feature_names=feature_names,
             target_name=self.target_name,
             y_limits=y_limits,
             dy_limits=dy_limits,
             show_only_aggregated=show_only_aggregated,
             show_plot=show_plot,
+            x_limits=x_window,
         )
 
 
@@ -655,11 +689,18 @@ class RHALE(ALEBase):
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
         order=None,
+        binning_scope: str = "global",
     ) -> typing.Dict:
         """Step 3 (pure numpy): bin the cached per-instance jacobian over the
-        subregion `mask` (None = all) and derive the bin effects/variances."""
+        subregion `mask` (None = all) and derive the bin effects/variances.
+
+        `binning_scope` (masked only): the x-range handed to the binner —
+        `"global"` keeps the frozen global frame (one frame for the split
+        search and every node), `"effective"` packs the bins into the masked
+        column's own `[min, max]` (finer subregion resolution)."""
         if self._is_cat(feature):
             # ordinal: merge adjacent transitions with the chosen binning
+            # (code-space bins — binning_scope does not apply)
             return self._summarize_cat(feature, mask, binning_method)
         self._ensure_local_effects(feature)
         eff = self.local_effects["feature_" + str(feature)]
@@ -673,7 +714,11 @@ class RHALE(ALEBase):
             if isinstance(binning_method, str)
             else binning_method
         )
-        limits = binning.find_limits(col, eff, self.axis_limits[:, feature])
+        if mask is not None and binning_scope == "effective":
+            limits_range = np.asarray(self._effective_limits(feature, mask))
+        else:
+            limits_range = self.axis_limits[:, feature]
+        limits = binning.find_limits(col, eff, limits_range)
         utils.raise_if_no_binning(limits, feature, binning)
 
         dale_params = utils.compute_ale_params(col, eff, limits)
@@ -687,13 +732,18 @@ class RHALE(ALEBase):
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
         order=None,
+        binning_scope: str = "global",
     ) -> typing.Dict:
         if self._is_cat(feature):
             # ordinal kernel: adjacent-level differences are the discrete
             # derivative; the jacobian (if any) is ignored for this feature
             return self._fit_feature_cat(feature, binning_method, order=order)
         return self._summarize(
-            feature, None, binning_method=binning_method, order=order
+            feature,
+            None,
+            binning_method=binning_method,
+            order=order,
+            binning_scope=binning_scope,
         )
 
     def fit(
@@ -706,6 +756,7 @@ class RHALE(ALEBase):
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
         order: typing.Union[None, str, list] = None,
+        binning_scope: str = "global",
     ) -> None:
         """Fit the model.
 
@@ -745,10 +796,24 @@ class RHALE(ALEBase):
 
                 Changing `order` requires calling `fit` again; `eval`/`plot`
                 reuse the fitted order.
+
+            binning_scope: the x-range the binner covers when a *masked*
+                summary re-bins a subregion (`eval`/`eval_heter`/`plot`/
+                `heter_score` with `mask=`; the regional split search)
+
+                - `"global"` (default): the frozen global `axis_limits` — one
+                  frame for every subregion, directly comparable
+                - `"effective"`: the masked column's own `[min, max]` — bins
+                  packed into the subregion, finer resolution
+
+                Recorded at fit and replayed by every masked call, so the
+                split search and the display always share the same scope.
+                Ignored when no mask is involved.
         """
         # validation is the resolver's job (R6): one table, one error message
         binning_method = ap.return_default(binning_method)
         self._validate_order_arg(features, order)
+        check_binning_scope(binning_scope)
 
         self._fit_loop(
             features,
@@ -756,4 +821,5 @@ class RHALE(ALEBase):
             points_for_centering,
             binning_method=binning_method,
             order=order,
+            binning_scope=binning_scope,
         )

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -44,7 +44,7 @@ class PDPBase(GlobalEffectBase):
         if self.method_name == "pdp":
             y = method(self.model, None, data, xx, feature, False)
         else:
-            y = method(self.model, self.model_jac, self.data, xx, feature, True)
+            y = method(self.model, self.model_jac, data, xx, feature, True)
         return y
 
     def _fit_feature(self, feature: int, use_vectorized: bool = True) -> dict:
@@ -108,11 +108,34 @@ class PDPBase(GlobalEffectBase):
         feature: int,
         method: str = "zero_integral",
         nof_points: int = helpers.NOF_INTERNAL_POINTS,
+        params: Optional[dict] = None,
+        mask: Optional[np.ndarray] = None,
     ):
         """(d-)PDP overrides the base: its normalization constant is
         *per-instance* — each ICE curve is centered on its own — so an
-        `(N,)` array is stored instead of a scalar."""
+        `(N,)` array is stored instead of a scalar.
+
+        The masked path is model-free: the constants come from the cached ICE
+        table's masked columns, integrated over the subregion's effective
+        interval (linear interpolation between grid rows)."""
         assert method in ["zero_integral", "zero_start"]
+        if mask is not None:
+            prim = self.local_effects["feature_" + str(feature)]
+            grid, ice = prim["grid"], prim["ice"][:, mask]
+            if self._is_cat(feature):
+                # weights of the levels *within* the mask, aligned to the grid
+                # (= the globally observed levels); absent levels weigh zero
+                levels, weights = self._level_weights(feature, mask)
+                if method == "zero_integral":
+                    w = np.zeros(len(grid))
+                    w[np.searchsorted(grid, levels)] = weights
+                    return np.average(ice, axis=0, weights=w)
+                return ice[np.searchsorted(grid, levels[0])]
+            lo, hi = self._effective_limits(feature, mask)
+            if method == "zero_integral":
+                xs = np.linspace(lo, hi, nof_points)
+                return np.mean(_interp_columns(grid, ice, xs), axis=0)
+            return _interp_columns(grid, ice, np.array([lo]))[0]
         use_vectorized = self.fit_args.get("feature_" + str(feature), {}).get(
             "use_vectorized", True
         )
@@ -197,6 +220,25 @@ class PDPBase(GlobalEffectBase):
             y_var = np.var(y_ice, axis=1)
         return y_mean, y_var
 
+    def _eval_masked_mean(
+        self, feature: int, x: np.ndarray, params: dict, mask: np.ndarray
+    ) -> np.ndarray:
+        """Masked mean (d-)ICE: read the cached-grid payload when `x` lies on
+        it (levels are always on it), otherwise recompute ICE on `data[mask]`
+        at `x` — the exact-evaluation retouch, symmetric with the global
+        (d-)PDP `eval` (the one model-touching exception of the masked path)."""
+        if params.get("is_cat"):
+            return self._eval_unnorm(feature, x, params=params)
+        grid = params["grid"]
+        on_grid = np.isclose(x[:, None], grid[None, :]).any(axis=1).all()
+        if on_grid:
+            return self._eval_unnorm(feature, x, params=params)
+        use_vectorized = self.fit_args.get("feature_" + str(feature), {}).get(
+            "use_vectorized", True
+        )
+        y_ice = self._predict(self.data[mask], x, feature, use_vectorized)
+        return np.mean(y_ice, axis=1)
+
     def fit(
         self,
         features: Union[int, str, list] = "all",
@@ -244,6 +286,8 @@ class PDPBase(GlobalEffectBase):
         y_limits: Optional[List] = None,
         use_vectorized: bool = True,
         show_plot: bool = True,
+        mask: Optional[np.ndarray] = None,
+        feature_label: Optional[str] = None,
     ):
         heterogeneity = helpers.prep_confidence_interval(heterogeneity)
         centering = helpers.prep_centering(centering)
@@ -251,27 +295,57 @@ class PDPBase(GlobalEffectBase):
             scale_x, self.scale_x_list[feature] if self.scale_x_list else None
         )
         scale_y = helpers.resolve_scale(scale_y, self.scale_y)
+        mask = self._prep_mask(mask)
+        feature_names = list(self.feature_names)
+        if feature_label is not None:
+            feature_names[feature] = feature_label
 
         is_cat = self._is_cat(feature)
-        x = (
-            self._levels(feature)
-            if is_cat
-            else np.linspace(
-                self.axis_limits[0, feature], self.axis_limits[1, feature], nof_points
+        if mask is None:
+            x = (
+                self._levels(feature)
+                if is_cat
+                else np.linspace(
+                    self.axis_limits[0, feature],
+                    self.axis_limits[1, feature],
+                    nof_points,
+                )
             )
-        )
 
-        # the ICE table is the method's own object: computed by the kernel and
-        # centered with the stored per-instance norms (payload state)
-        if self.requires_refit(feature, centering):
-            self._refit(feature, centering)
-        yy = self._predict(self.data, x, feature, use_vectorized)
-        if centering is not False:
-            norm_consts = self.feature_effect["feature_" + str(feature)]["norm_const"]
-            yy = yy - norm_consts[np.newaxis, :]
+            # the ICE table is the method's own object: computed by the kernel
+            # and centered with the stored per-instance norms (payload state)
+            if self.requires_refit(feature, centering):
+                self._refit(feature, centering)
+            yy = self._predict(self.data, x, feature, use_vectorized)
+            if centering is not False:
+                norm_consts = self.feature_effect["feature_" + str(feature)][
+                    "norm_const"
+                ]
+                yy = yy - norm_consts[np.newaxis, :]
+        else:
+            # masked branch: the cached ICE table's masked columns at grid
+            # resolution — no model calls; `nof_points` does not apply. The x
+            # arrays are cropped to the subregion's effective interval, so the
+            # figure windows itself to the region.
+            self._ensure_local_effects(feature)
+            prim = self.local_effects["feature_" + str(feature)]
+            grid, ice_m = prim["grid"], prim["ice"][:, mask]
+            if is_cat:
+                x = grid
+                yy = ice_m
+            else:
+                lo, hi = self._effective_limits(feature, mask)
+                x = np.concatenate([[lo], grid[(grid > lo) & (grid < hi)], [hi]])
+                yy = _interp_columns(grid, ice_m, x)
+            if centering is not False:
+                norm_consts = self._compute_norm_const(
+                    feature, method=centering, mask=mask
+                )
+                yy = yy - norm_consts[np.newaxis, :]
 
         if show_avg_output:
-            avg_output = helpers.prep_avg_output(self.data, self.model, None, scale_y)
+            data = self.data if mask is None else self.data[mask]
+            avg_output = helpers.prep_avg_output(data, self.model, None, scale_y)
         else:
             avg_output = None
 
@@ -294,18 +368,24 @@ class PDPBase(GlobalEffectBase):
                     scale_x=scale_x,
                     scale_y=scale_y,
                     avg_output=avg_output,
-                    feature_names=self.feature_names,
+                    feature_names=feature_names,
                     target_name=self.target_name,
                     nof_ice=nof_ice,
                     y_limits=y_limits,
                     show_plot=show_plot,
                     random_state=self.random_state,
                 )
-            variances = (
-                self._eval_unnorm(feature, x, heterogeneity=True)[1]
-                if heterogeneity is not False
-                else None
-            )
+            if heterogeneity is not False:
+                params = (
+                    self._summarize(feature, mask, **self._replay_fit_kwargs(feature))
+                    if mask is not None
+                    else None
+                )
+                variances = self._eval_unnorm(
+                    feature, x, heterogeneity=True, params=params
+                )[1]
+            else:
+                variances = None
             return vis.plot_categorical_effect(
                 levels,
                 yy.mean(axis=1),
@@ -317,7 +397,7 @@ class PDPBase(GlobalEffectBase):
                 scale_x=scale_x,
                 scale_y=scale_y,
                 avg_output=avg_output,
-                feature_names=self.feature_names,
+                feature_names=feature_names,
                 target_name=self.target_name,
                 y_limits=y_limits,
                 show_plot=show_plot,
@@ -345,7 +425,7 @@ class PDPBase(GlobalEffectBase):
             scale_x=scale_x,
             scale_y=scale_y,
             avg_output=avg_output,
-            feature_names=self.feature_names,
+            feature_names=feature_names,
             target_name=self.target_name,
             is_derivative=self.IS_DERIVATIVE,
             nof_ice=nof_ice,
@@ -468,6 +548,8 @@ class PDP(PDPBase):
         y_limits: Optional[List] = None,
         use_vectorized: bool = True,
         show_plot: bool = True,
+        mask: Optional[np.ndarray] = None,
+        feature_label: Optional[str] = None,
     ):
         """
         Plot the feature effect.
@@ -507,6 +589,12 @@ class PDP(PDPBase):
                 - If set to a tuple, the limits are manually set
 
             use_vectorized: whether to use the vectorized version of the PDP computation
+            mask: optional boolean `(N,)` selecting a subregion — plot the PDP/
+                ICE *within* it from the cached ICE table (grid resolution;
+                `nof_points` does not apply), model-free, with the x-axis
+                windowed to the subregion's own interval
+            feature_label: optional display name for the feature axis (e.g. a
+                regional node's name), overriding `feature_names[feature]`
         """
         ret = self._plot(
             feature,
@@ -520,6 +608,8 @@ class PDP(PDPBase):
             y_limits,
             use_vectorized,
             show_plot,
+            mask,
+            feature_label,
         )
 
         if not show_plot:
@@ -644,6 +734,8 @@ class DerPDP(PDPBase):
         y_limits: Optional[List] = None,
         use_vectorized: bool = True,
         show_plot: bool = True,
+        mask: Optional[np.ndarray] = None,
+        feature_label: Optional[str] = None,
     ):
         """
         Plot the feature effect.
@@ -684,6 +776,12 @@ class DerPDP(PDPBase):
 
             use_vectorized: whether to use the vectorized version of the PDP computation
             show_plot: whether to show the plot
+            mask: optional boolean `(N,)` selecting a subregion — plot the
+                d-PDP/d-ICE *within* it from the cached d-ICE table (grid
+                resolution; `nof_points` does not apply), model-free, with the
+                x-axis windowed to the subregion's own interval
+            feature_label: optional display name for the feature axis (e.g. a
+                regional node's name), overriding `feature_names[feature]`
         """
         ret = self._plot(
             feature,
@@ -697,11 +795,25 @@ class DerPDP(PDPBase):
             y_limits,
             use_vectorized,
             show_plot,
+            mask,
+            feature_label,
         )
 
         if not show_plot:
             fig, ax = ret
             return fig, ax
+
+
+def _interp_columns(grid: np.ndarray, table: np.ndarray, xs: np.ndarray) -> np.ndarray:
+    """Linear interpolation of each column of `table` `(T, N)` at positions
+    `xs` `(M,)` → `(M, N)`. Outside `grid` the edge rows extend flat (the
+    masked path's flat-edge-extension convention)."""
+    xs = np.asarray(xs, dtype=float)
+    idx = np.clip(np.searchsorted(grid, xs, side="right") - 1, 0, len(grid) - 2)
+    x0, x1 = grid[idx], grid[idx + 1]
+    w = np.where(x1 > x0, (xs - x0) / (x1 - x0), 0.0)
+    w = np.clip(w, 0.0, 1.0)
+    return table[idx] * (1 - w)[:, None] + table[idx + 1] * w[:, None]
 
 
 def ice_non_vectorized(

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -6,7 +6,7 @@ import numpy as np
 import effector.helpers as helpers
 import effector.visualization as vis
 from effector import ingestion
-from effector.global_effect import GlobalEffectBase
+from effector.global_effect import GlobalEffectBase, check_binning_scope
 
 try:
     import shap
@@ -243,10 +243,15 @@ class ShapDP(GlobalEffectBase):
         binning_method: Union[
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
+        binning_scope: str = "global",
     ) -> typing.Dict:
         """Step 3 (pure numpy): bin/aggregate the cached SHAP column over the
         subregion `mask` (None = all) — a spline of per-bin mean/variance for
-        continuous features, per-level mean/variance for discrete ones."""
+        continuous features, per-level mean/variance for discrete ones.
+
+        `binning_scope` (masked only): `"global"` bins over the frozen global
+        frame, `"effective"` packs the bins into the masked column's own
+        `[min, max]` (see `fit`)."""
         self._ensure_local_effects(feature)
         yy = self.local_effects["feature_" + str(feature)]
         xx = self.data[:, feature]
@@ -279,7 +284,11 @@ class ShapDP(GlobalEffectBase):
             if isinstance(binning_method, str)
             else binning_method
         )
-        limits = binning.find_limits(xx, yy, self.axis_limits[:, feature])
+        if mask is not None and binning_scope == "effective":
+            limits_range = np.asarray(self._effective_limits(feature, mask))
+        else:
+            limits_range = self.axis_limits[:, feature]
+        limits = binning.find_limits(xx, yy, limits_range)
         utils.raise_if_no_binning(limits, feature, binning)
         feature_effect_dict = utils.compute_ale_params(xx, yy, limits)
         feature_effect_dict["alg_params"] = binning
@@ -311,8 +320,11 @@ class ShapDP(GlobalEffectBase):
         binning_method: Union[
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
+        binning_scope: str = "global",
     ) -> typing.Dict:
-        return self._summarize(feature, None, binning_method=binning_method)
+        return self._summarize(
+            feature, None, binning_method=binning_method, binning_scope=binning_scope
+        )
 
     def _eval_unnorm(
         self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
@@ -344,6 +356,7 @@ class ShapDP(GlobalEffectBase):
         binning_method: Union[
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
+        binning_scope: str = "global",
     ) -> None:
         r"""Fit the SHAP Dependence Plot to the data.
 
@@ -369,12 +382,26 @@ class ShapDP(GlobalEffectBase):
                 - If set to "greedy", the greedy binning method will be used.
                 - If set to "fixed", the fixed binning method will be used.
 
+            binning_scope: the x-range the binner covers when a *masked*
+                summary re-bins a subregion (`eval`/`eval_heter`/`plot`/
+                `heter_score` with `mask=`; the regional split search)
+
+                - `"global"` (default): the frozen global `axis_limits` — one
+                  frame for every subregion, directly comparable
+                - `"effective"`: the masked column's own `[min, max]` — bins
+                  packed into the subregion, finer resolution
+
+                Recorded at fit and replayed by every masked call, so the
+                split search and the display always share the same scope.
+                Ignored when no mask is involved.
         """
+        check_binning_scope(binning_scope)
         self._fit_loop(
             features,
             centering,
             points_for_centering,
             binning_method=binning_method,
+            binning_scope=binning_scope,
         )
 
     def plot(
@@ -390,6 +417,8 @@ class ShapDP(GlobalEffectBase):
         y_limits: Optional[List] = None,
         only_shap_values: bool = False,
         show_plot: bool = True,
+        mask: Optional[np.ndarray] = None,
+        feature_label: Optional[str] = None,
     ) -> Union[Tuple, None]:
         """
         Plot the SHAP Dependence Plot (SDP) of the s-th feature.
@@ -416,6 +445,12 @@ class ShapDP(GlobalEffectBase):
             y_limits: limits of the y-axis
             only_shap_values: whether to plot only the shap values
             show_plot: whether to show the plot
+            mask: optional boolean `(N,)` selecting a subregion — plot the
+                SHAP-DP *within* it (the masked φ re-binned/re-splined from the
+                cached attributions, no model calls), with the x-axis windowed
+                to the subregion's own interval
+            feature_label: optional display name for the feature axis (e.g. a
+                regional node's name), overriding `feature_names[feature]`
         """
         heterogeneity = helpers.prep_confidence_interval(heterogeneity)
         centering = helpers.prep_centering(centering)
@@ -423,16 +458,46 @@ class ShapDP(GlobalEffectBase):
             scale_x, self.scale_x_list[feature] if self.scale_x_list else None
         )
         scale_y = helpers.resolve_scale(scale_y, self.scale_y)
+        mask = self._prep_mask(mask)
+        feature_names = list(self.feature_names)
+        if feature_label is not None:
+            feature_names[feature] = feature_label
+
+        if mask is not None:
+            # transient subregion payload from the cached attributions —
+            # pure numpy, nothing stored (the masked-plot path)
+            if not self._is_cat(feature):
+                self._effective_limits(feature, mask)  # degeneracy guard
+            self._ensure_local_effects(feature)
+            m_params = self._summarize(
+                feature, mask, **self._replay_fit_kwargs(feature)
+            )
+            m_norm = (
+                self._compute_norm_const(
+                    feature, method=centering, params=m_params, mask=mask
+                )
+                if centering is not False
+                else 0.0
+            )
 
         params_key = "feature_" + str(feature)
         if self._is_cat(feature):
-            # fit if needed, then draw per-level bars (+ the shap cloud)
-            self.eval(feature, self._levels(feature)[:1], centering=centering)
-            params = self.feature_effect[params_key]
-            levels, labels = self._level_display(feature)
-            y_levels = self.eval(feature, levels, centering=centering)
+            if mask is not None:
+                # the masked payload's frame: the levels observed *within* the
+                # subregion (its φ were re-binned per level by _summarize)
+                params = m_params
+                levels, labels = self._level_display(feature, params["levels"])
+                y_levels = self._eval_unnorm(feature, levels, params=params) - m_norm
+                data = self.data[mask]
+            else:
+                # fit if needed, then draw per-level bars (+ the shap cloud)
+                self.eval(feature, self._levels(feature)[:1], centering=centering)
+                params = self.feature_effect[params_key]
+                levels, labels = self._level_display(feature)
+                y_levels = self.eval(feature, levels, centering=centering)
+                data = self.data
             avg_output = (
-                helpers.prep_avg_output(self.data, self.model, None, scale_y)
+                helpers.prep_avg_output(data, self.model, None, scale_y)
                 if show_avg_output
                 else None
             )
@@ -440,7 +505,7 @@ class ShapDP(GlobalEffectBase):
             if heterogeneity == "shap_values":
                 yy = params["yy"]
                 if centering is not False:
-                    yy = yy - params["norm_const"]
+                    yy = yy - (m_norm if mask is not None else params["norm_const"])
                 return vis.plot_shap_categorical(
                     levels,
                     y_levels,
@@ -452,7 +517,7 @@ class ShapDP(GlobalEffectBase):
                     scale_x=scale_x,
                     scale_y=scale_y,
                     avg_output=avg_output,
-                    feature_names=self.feature_names,
+                    feature_names=feature_names,
                     target_name=self.target_name,
                     nof_shap_values=nof_shap_values,
                     y_limits=y_limits,
@@ -460,7 +525,7 @@ class ShapDP(GlobalEffectBase):
                     random_state=self.random_state,
                 )
             variances = (
-                self._eval_unnorm(feature, levels, heterogeneity=True)[1]
+                self._eval_unnorm(feature, levels, heterogeneity=True, params=params)[1]
                 if heterogeneity is not False
                 else None
             )
@@ -475,43 +540,67 @@ class ShapDP(GlobalEffectBase):
                 scale_x=scale_x,
                 scale_y=scale_y,
                 avg_output=avg_output,
-                feature_names=self.feature_names,
+                feature_names=feature_names,
                 target_name=self.target_name,
                 y_limits=y_limits,
                 show_plot=show_plot,
             )
 
-        x = np.linspace(
-            self.axis_limits[0, feature], self.axis_limits[1, feature], nof_points
-        )
+        if mask is not None:
+            # the masked payload's frame: x spans the subregion's effective
+            # interval, the cloud is the masked φ (already filtered by
+            # _summarize) — model-free
+            lo, hi = self._effective_limits(feature, mask)
+            x = np.linspace(lo, hi, nof_points)
+            y = self._eval_unnorm(feature, x, params=m_params)
+            if centering is not False:
+                y = y - m_norm
+            y_std = (
+                np.sqrt(np.maximum(m_params["spline_var"](x), 0.0))
+                if heterogeneity == "std"
+                else None
+            )
+            _, ind = helpers.prep_nof_instances(
+                nof_shap_values, len(m_params["yy"]), self.random_state
+            )
+            yy = m_params["yy"][ind] if heterogeneity == "shap_values" else None
+            if yy is not None and centering is not False:
+                yy = yy - m_norm
+            xx = m_params["xx"][ind] if heterogeneity == "shap_values" else None
+            data = self.data[mask]
+        else:
+            x = np.linspace(
+                self.axis_limits[0, feature], self.axis_limits[1, feature], nof_points
+            )
 
-        # get the SHAP curve
-        y = self.eval(feature, x, centering=centering)
-        y_std = (
-            np.sqrt(self.feature_effect["feature_" + str(feature)]["spline_var"](x))
-            if heterogeneity == "std"
-            else None
-        )
+            # get the SHAP curve
+            y = self.eval(feature, x, centering=centering)
+            y_std = (
+                np.sqrt(self.feature_effect["feature_" + str(feature)]["spline_var"](x))
+                if heterogeneity == "std"
+                else None
+            )
 
-        # get some SHAP values
-        _, ind = helpers.prep_nof_instances(
-            nof_shap_values, self.data.shape[0], self.random_state
-        )
-        yy = (
-            self.feature_effect["feature_" + str(feature)]["yy"][ind]
-            if heterogeneity == "shap_values"
-            else None
-        )
-        if yy is not None and centering is not False:
-            yy = yy - self.feature_effect["feature_" + str(feature)]["norm_const"]
-        xx = (
-            self.feature_effect["feature_" + str(feature)]["xx"][ind]
-            if heterogeneity == "shap_values"
-            else None
-        )
+            # get some SHAP values
+            _, ind = helpers.prep_nof_instances(
+                nof_shap_values, self.data.shape[0], self.random_state
+            )
+            yy = (
+                self.feature_effect["feature_" + str(feature)]["yy"][ind]
+                if heterogeneity == "shap_values"
+                else None
+            )
+            if yy is not None and centering is not False:
+                yy = yy - self.feature_effect["feature_" + str(feature)]["norm_const"]
+            xx = (
+                self.feature_effect["feature_" + str(feature)]["xx"][ind]
+                if heterogeneity == "shap_values"
+                else None
+            )
+            data = self.data
 
         if show_avg_output:
-            avg_output = helpers.prep_avg_output(self.data, self.model, None, scale_y)
+            avg_output = helpers.prep_avg_output(data, self.model, None, scale_y)
         else:
             avg_output = None
 
@@ -526,7 +615,7 @@ class ShapDP(GlobalEffectBase):
             scale_x=scale_x,
             scale_y=scale_y,
             avg_output=avg_output,
-            feature_names=self.feature_names,
+            feature_names=feature_names,
             target_name=self.target_name,
             y_limits=y_limits,
             only_shap_values=only_shap_values,

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -96,12 +96,14 @@ def ale_plot(
     dy_limits: typing.Union[None, tuple] = None,
     show_only_aggregated: bool = False,
     show_plot: bool = True,
+    x_limits: typing.Union[None, tuple] = None,
 ):
     """Draw the (RH)ALE mean effect (top axis) and the bin-effects bar plot
     (bottom axis, with sqrt(bin_variance) error bars if `heterogeneity`).
 
     `x`/`y` is the mean-effect curve; `bin_effect`/`bin_variance`/`limits`/`dx`
-    is the stored bin payload.
+    is the stored bin payload. `x_limits` (raw feature units) windows the
+    shared x-axis — the masked/subregion zoom.
     """
     x = _scale_x(x, scale_x)
     y = _scale_y(y, scale_y)
@@ -153,6 +155,11 @@ def ale_plot(
             label="dy_dx",
         )
         _decorate_ax(ax2, xlabel=x_name, ylabel="dy/dx", y_limits=dy_limits)
+
+    if x_limits is not None:
+        # window the (shared) x-axis to the caller's interval, e.g. a
+        # subregion's effective range
+        ax1.set_xlim(*_scale_x(np.asarray(x_limits, dtype=float), scale_x))
 
     return _finalize(fig, axes, show_plot)
 

--- a/tests/test_contract_masked.py
+++ b/tests/test_contract_masked.py
@@ -1,0 +1,354 @@
+"""Contract layer, the masked global surface (regional ≡ masked global).
+
+A mask is the ONLY thing that differentiates a regional question from a global
+one: `eval`/`eval_heter`/`heter_score`/`plot` with `mask=` summarize the cached
+local effects over the subregion, on the global frame, without model calls.
+The rules pinned here:
+
+  - M1  mask of all-ones ≡ mask=None (eval / eval_heter / heter_score / plot),
+        continuous and categorical features of interest;
+  - M2  masked calls after the local-effects cache is sealed make ZERO model
+        calls — the single-model-touch constitution extended to eval/plot.
+        The one documented exception: (d-)PDP `eval` at off-grid `xs`
+        recomputes ICE on `data[mask]` (the exact-evaluation retouch);
+  - M3  invalid masks fail loudly: wrong dtype/shape, empty, or a degenerate
+        masked interval;
+  - M4  masked centering is computed over the subregion's own effective
+        interval (zero_integral / zero_start semantics within the region);
+  - M5  `binning_scope` ("global"/"effective") exists on RHALE/ShapDP only,
+        is validated, and controls the x-range of the masked re-binning;
+  - M6  masked plots return (fig, ax), window the x-axis to the effective
+        interval, and honor `feature_label`.
+"""
+
+import inspect
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import effector
+from effector import helpers
+from tests.conftest import (
+    GLOBAL_NAMES,
+    CountingModel,
+    analytic_shap_values,
+    linear_model,
+    linear_model_jac,
+    make_global,
+    make_global_data,
+)
+
+XS = np.linspace(-0.8, 0.8, 40)
+
+
+def params(names=GLOBAL_NAMES):
+    return [pytest.param(name, id=name) for name in names]
+
+
+def half_mask(data):
+    """A mask correlated with feature 0 — a genuinely restrictive subregion."""
+    return data[:, 0] < 0.3
+
+
+# ---------------------------------------------------------------------------
+# categorical mirror: ordinal FOI (feature 1), so RHALE participates too;
+# DerPDP is continuous-only and sits the categorical tests out
+# ---------------------------------------------------------------------------
+
+CAT_NAMES = ["pdp", "ale", "rhale", "shapdp"]
+CAT_SCHEMA = {"feature_types": ["continuous", "ordinal", "continuous"]}
+
+
+def cat_model(x):
+    return (
+        2.0 * x[:, 0]
+        + 1.5 * (x[:, 1] == 1)
+        - 0.5 * (x[:, 1] == 2)
+        + (x[:, 1] == 1) * (x[:, 2] > 0)
+    )
+
+
+def cat_model_jac(x):
+    j = np.zeros_like(x)
+    j[:, 0] = 2.0
+    return j
+
+
+def make_cat_data(n=200, seed=3):
+    rng = np.random.default_rng(seed)
+    return np.stack(
+        [
+            rng.uniform(-1, 1, n),
+            rng.integers(0, 3, n).astype(float),
+            rng.uniform(-1, 1, n),
+        ],
+        axis=1,
+    )
+
+
+def make_cat_global(name, data):
+    """The 4 cat-capable methods on the categorical mirror. ShapDP gets
+    deterministic (seeded, not meaningful) attributions — the masked contract
+    tests determinism and model-freedom, not SHAP correctness."""
+    if name == "pdp":
+        return effector.PDP(data, cat_model, schema=CAT_SCHEMA)
+    if name == "ale":
+        return effector.ALE(data, cat_model, schema=CAT_SCHEMA)
+    if name == "rhale":
+        return effector.RHALE(data, cat_model, cat_model_jac, schema=CAT_SCHEMA)
+    if name == "shapdp":
+        rng = np.random.default_rng(7)
+        return effector.ShapDP(
+            data,
+            cat_model,
+            schema=CAT_SCHEMA,
+            shap_values=rng.normal(size=data.shape),
+        )
+    raise ValueError(name)
+
+
+# ---------------------------------------------------------------------------
+# M1 — all-ones mask ≡ no mask
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params())
+def test_m1_ones_mask_equals_none_continuous(name, global_data):
+    m = make_global(name, global_data)
+    m.fit(features=0)
+    ones = np.ones(m.data.shape[0], dtype=bool)
+    for centering in [False, "zero_integral", "zero_start"]:
+        np.testing.assert_allclose(
+            m.eval(0, XS, centering=centering, mask=ones),
+            m.eval(0, XS, centering=centering),
+            atol=1e-8,
+        )
+    np.testing.assert_allclose(
+        m.eval_heter(0, XS, mask=ones), m.eval_heter(0, XS), atol=1e-8
+    )
+    np.testing.assert_allclose(m.heter_score(0, mask=ones), m.heter_score(0), atol=1e-8)
+
+
+@pytest.mark.parametrize("name", params(CAT_NAMES))
+def test_m1_ones_mask_equals_none_categorical(name):
+    data = make_cat_data()
+    m = make_cat_global(name, data)
+    m.fit(features=1)
+    ones = np.ones(m.data.shape[0], dtype=bool)
+    levels = np.unique(data[:, 1])
+    for centering in [False, "zero_integral"]:
+        np.testing.assert_allclose(
+            m.eval(1, levels, centering=centering, mask=ones),
+            m.eval(1, levels, centering=centering),
+            atol=1e-8,
+        )
+    np.testing.assert_allclose(
+        m.eval_heter(1, levels, mask=ones), m.eval_heter(1, levels), atol=1e-8
+    )
+    np.testing.assert_allclose(m.heter_score(1, mask=ones), m.heter_score(1), atol=1e-8)
+
+
+@pytest.mark.parametrize("name", params())
+def test_m1_masked_eval_deterministic(name, global_data):
+    """Two identical masked calls agree — the transient payload is
+    reproducible and never contaminates stored state."""
+    m = make_global(name, global_data)
+    m.fit(features=0)
+    mask = half_mask(m.data)
+    y_stored_before = m.eval(0, XS, centering="zero_integral")
+    y1 = m.eval(0, XS, centering="zero_integral", mask=mask)
+    y2 = m.eval(0, XS, centering="zero_integral", mask=mask)
+    np.testing.assert_allclose(y1, y2, atol=1e-12)
+    # stored state untouched by the masked calls
+    np.testing.assert_allclose(
+        m.eval(0, XS, centering="zero_integral"), y_stored_before, atol=1e-12
+    )
+
+
+# ---------------------------------------------------------------------------
+# M2 — the constitution on the masked surface: zero model calls
+# ---------------------------------------------------------------------------
+
+
+def make_counting(name, data):
+    """A global object whose model/jacobian invocations are counted."""
+    model = CountingModel(linear_model)
+    jac = CountingModel(linear_model_jac)
+    if name == "pdp":
+        obj = effector.PDP(data, model)
+    elif name == "derpdp":
+        obj = effector.DerPDP(data, model, jac)
+    elif name == "ale":
+        obj = effector.ALE(data, model)
+    elif name == "rhale":
+        obj = effector.RHALE(data, model, jac)
+    elif name == "shapdp":
+        obj = effector.ShapDP(data, model, shap_values=analytic_shap_values(data))
+    else:
+        raise ValueError(name)
+    return obj, model, jac
+
+
+@pytest.mark.parametrize("name", params())
+def test_m2_masked_surface_is_model_free(name):
+    data = make_global_data()
+    obj, model, jac = make_counting(name, data)
+    obj.fit(features=0)
+    mask = half_mask(obj.data)
+    grid = np.linspace(
+        obj.axis_limits[0, 0], obj.axis_limits[1, 0], helpers.NOF_INTERNAL_POINTS
+    )
+    # warmup: the first masked call may compute+seal the local effects (the
+    # one model touch of the lifecycle, e.g. PDP's lazily cached ICE table)
+    obj.eval_heter(0, grid, mask=mask)
+    n0 = model.n_calls + jac.n_calls
+    obj.eval(0, grid, centering="zero_integral", mask=mask)
+    obj.eval(0, grid, centering="zero_start", mask=mask)
+    obj.eval_heter(0, grid, mask=mask)
+    obj.heter_score(0, mask=mask)
+    obj.plot(0, show_plot=False, mask=mask)
+    assert model.n_calls + jac.n_calls == n0
+    plt.close("all")
+
+
+@pytest.mark.parametrize("name", params(["pdp", "derpdp"]))
+def test_m2_pdp_offgrid_masked_eval_recomputes(name):
+    """The documented exception: (d-)PDP masked `eval` at off-grid `xs` is the
+    exact-evaluation retouch — it DOES query the model, on `data[mask]`."""
+    data = make_global_data()
+    obj, model, jac = make_counting(name, data)
+    obj.fit(features=0)
+    mask = half_mask(obj.data)
+    obj.eval_heter(0, XS, mask=mask)  # seal
+    n0 = model.n_calls + jac.n_calls
+    obj.eval(0, np.array([0.1234, 0.4321]), centering=False, mask=mask)
+    assert model.n_calls + jac.n_calls > n0
+
+
+# ---------------------------------------------------------------------------
+# M3 — invalid masks fail loudly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params())
+def test_m3_invalid_masks_raise(name, global_data):
+    m = make_global(name, global_data)
+    m.fit(features=0)
+    n = m.data.shape[0]
+    with pytest.raises(ValueError):
+        m.eval(0, XS, mask=np.zeros(n, dtype=bool))  # empty
+    with pytest.raises(ValueError):
+        m.eval(0, XS, mask=np.ones(n, dtype=float))  # not boolean
+    with pytest.raises(ValueError):
+        m.eval(0, XS, mask=np.ones(n + 1, dtype=bool))  # wrong shape
+    single = np.zeros(n, dtype=bool)
+    single[0] = True
+    with pytest.raises(ValueError):
+        m.eval(0, XS, mask=single)  # degenerate masked interval
+
+
+# ---------------------------------------------------------------------------
+# M4 — masked centering lives on the subregion's effective interval
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params())
+def test_m4_masked_zero_integral_on_effective_interval(name, global_data):
+    m = make_global(name, global_data)
+    m.fit(features=0)
+    mask = half_mask(m.data)
+    lo, hi = m.data[mask, 0].min(), m.data[mask, 0].max()
+    xs = np.linspace(lo, hi, 1000)
+    y = m.eval(0, xs, centering="zero_integral", mask=mask)
+    np.testing.assert_allclose(np.mean(y), 0.0, atol=2e-2)
+
+
+@pytest.mark.parametrize("name", params())
+def test_m4_masked_zero_start_at_effective_start(name, global_data):
+    m = make_global(name, global_data)
+    m.fit(features=0)
+    mask = half_mask(m.data)
+    lo = m.data[mask, 0].min()
+    y = m.eval(0, np.array([lo]), centering="zero_start", mask=mask)
+    np.testing.assert_allclose(y, 0.0, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# M5 — binning_scope: RHALE/ShapDP only, validated, honored
+# ---------------------------------------------------------------------------
+
+
+def test_m5_binning_scope_signature():
+    for cls in [effector.RHALE, effector.ShapDP]:
+        assert "binning_scope" in inspect.signature(cls.fit).parameters
+    for cls in [effector.ALE, effector.PDP, effector.DerPDP]:
+        assert "binning_scope" not in inspect.signature(cls.fit).parameters
+
+
+@pytest.mark.parametrize("name", params(["rhale", "shapdp"]))
+def test_m5_binning_scope_validated(name, global_data):
+    m = make_global(name, global_data)
+    with pytest.raises(ValueError):
+        m.fit(features=0, binning_scope="bogus")
+
+
+@pytest.mark.parametrize("name", params(["rhale", "shapdp"]))
+def test_m5_binning_scope_controls_masked_bins(name, global_data):
+    mask = half_mask(global_data)
+    lo, hi = global_data[mask, 0].min(), global_data[mask, 0].max()
+
+    m_eff = make_global(name, global_data)
+    m_eff.fit(features=0, binning_scope="effective")
+    p_eff = m_eff._summarize(0, mask, **m_eff._replay_fit_kwargs(0))
+
+    m_glob = make_global(name, global_data)
+    m_glob.fit(features=0)  # default: "global"
+    p_glob = m_glob._summarize(0, mask, **m_glob._replay_fit_kwargs(0))
+
+    def limits_of(p):
+        if "limits" in p:
+            return np.asarray(p["limits"], dtype=float)
+        # ShapDP keeps the spline, not the limits: read the spline knots' span
+        return np.asarray(p["spline_mean"].x, dtype=float)
+
+    # the mask (x0 < 0.3) shares the global LEFT edge, so the scopes separate
+    # on the right: effective bins stop at the masked max, global bins keep
+    # covering the full axis (ShapDP knots are bin centers — compare vs hi)
+    eff = limits_of(p_eff)
+    glob = limits_of(p_glob)
+    assert eff[0] >= lo - 1e-12 and eff[-1] <= hi + 1e-12
+    assert glob[-1] > hi
+
+
+# ---------------------------------------------------------------------------
+# M6 — masked plot: (fig, ax), effective x-window, feature_label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", params())
+def test_m6_masked_plot_window_and_label(name, global_data):
+    m = make_global(name, global_data)
+    m.fit(features=0)
+    mask = half_mask(m.data)
+    lo, hi = m.data[mask, 0].min(), m.data[mask, 0].max()
+    ret = m.plot(0, show_plot=False, mask=mask, feature_label="x_0 | region")
+    assert isinstance(ret, tuple) and len(ret) == 2
+    fig, ax = ret
+    assert isinstance(fig, plt.Figure)
+    ax_main = ax[0] if isinstance(ax, tuple) else ax
+    xlo, xhi = ax_main.get_xlim()
+    pad = 0.1 * (hi - lo)
+    assert xlo >= lo - pad and xhi <= hi + pad
+    labeled = ax[-1] if isinstance(ax, tuple) else ax
+    assert labeled.get_xlabel() == "x_0 | region"
+
+
+@pytest.mark.parametrize("name", params(CAT_NAMES))
+def test_m6_masked_plot_categorical_smoke(name):
+    data = make_cat_data()
+    m = make_cat_global(name, data)
+    m.fit(features=1)
+    mask = data[:, 2] > 0
+    ret = m.plot(1, show_plot=False, mask=mask)
+    assert isinstance(ret, tuple) and len(ret) == 2


### PR DESCRIPTION
## What

Extends `mask=` from `eval_heter`/`heter_score` to **all** global surfaces — `eval` and `plot` — so "the effect within a subregion" is a first-class, model-free primitive of every global effect object:

```python
pdp = effector.PDP(X, model)
pdp.plot(0, mask=X[:, 1] > 0)                  # PDP/ICE within the region, no model calls
ale.eval(0, xs, centering=True, mask=mask)     # masked mean effect, centered on the region
```

This is step 1 of the regional ≡ masked-global decision (see follow-up PR): a regional method is the global object's own summary restricted by a mask — not a re-instantiated object on a data subset.

## Semantics

- **The global frame is immutable.** `axis_limits`, bins, grids, and stored payloads are never mutated by a mask; masked results are transient, derived per call (`_effective_limits` is the one derived concept: the masked column's `[min, max]`).
- **Masked centering** integrates over the subregion's own effective interval; level weights are those within the mask.
- **Masked plots** window the x-axis to the effective interval and accept `feature_label=` (the hook the regional node plots will use).
- **Model-free by constitution**, with one documented exception: (d-)PDP `eval` at off-grid `xs` recomputes ICE on `data[mask]` — the same exact-evaluation retouch the global PDP `eval` already has.
- **`binning_scope`** (`"global"` default | `"effective"`) on `RHALE.fit`/`ShapDP.fit` only: the x-range handed to the adaptive binner when a mask re-bins a subregion. Recorded in `fit_args` and replayed, so the regional split search and every masked display always share the same scope.

## Tests

New contract file `tests/test_contract_masked.py` (M1–M6, 50 tests): all-ones mask ≡ no mask (continuous + categorical, all 5 methods); zero model calls on the masked surface after sealing (CountingModel), with the PDP off-grid exception asserted explicitly; loud failures for invalid/degenerate masks; masked centering semantics on the effective interval; `binning_scope` signature/validation/behavior; masked plot window + `feature_label`.

Also fixes a latent wart: `PDPBase._predict` ignored its `data` argument on the derivative branch.
