### PR TITLE
Regional ≡ masked global: node eval/plot delegate to the one global effect

### DIFF
--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -1050,3 +1050,51 @@ gated behind a visual color review (the alpha values are the one taste knob).
 categorical dot-interval redesign, A5 stable per-method colors.
 
 ---
+
+## 26. 2026-07-07 — Regional ≡ masked global: the node objects go away (tag: theory+code)  [docs/design.md R11; PRs #47 + regional-masked-delegation; branches `feat/masked-global-eval-plot`, `feat/regional-masked-delegation`]
+
+**The decision (with Vasilis, option (b)):** a regional effect is *not* a
+re-instantiated global object on a data subset (option a); it is **the one
+global object's own summary restricted by a mask**. Deciding argument: for ALE
+(edge-bound secants) and PDP (grid-bound ICE) a node object is either
+model-touching or inject-and-freeze — i.e. (b) with extra machinery; the
+literature estimators (REPID/GADGET) are grouped local effects, i.e. (b).
+Option (a) survives only as a future store/load feature (the `local_effects=`
+constructor kwarg is the deserialization seam) — parked, nothing wired.
+
+**The invariant (now design.md R11):** `axis_limits` is the immutable global
+frame; a mask never mutates stored state; anything region-shaped is transient,
+derived per call via `_effective_limits(feature, mask)`. Its only consumers:
+masked centering constants, the masked plot x-window, degeneracy guards.
+
+**What lands:**
+- `mask=` + `feature_label=` on `eval`/`eval_heter`/`heter_score`/`plot` of all
+  five methods, model-free (constitution extended to eval/plot; one documented
+  exception: PDP `eval(mask=)` off the cached grid recomputes ICE exactly).
+- Regional `eval/eval_heter/_plot` delegate to ONE shared global object;
+  `_create_fe_object`/`_fit_node_effect`/`_extra_fe_kwargs`/`_after_precompute`
+  and `MethodSpec.uses_data_effect` deleted. New contracts: RC7 one-truth
+  (tree heterogeneity == `heter_score(feature, mask)`), RC8 node surfaces
+  model-free.
+- **`binning_scope` knob (Vasilis: "why not both"):** fit kwarg on RHALE/ShapDP
+  only — the range handed to `find_limits` on masked re-binning, `"global"`
+  (default) | `"effective"`; recorded in fit_args and replayed, so split search
+  and display always share it. Default flip to `"effective"` deferred
+  (prototype shows both recover the truth; "effective" packs finer bins into
+  the region).
+- Two real bugs found by the rewire: (1) nan heterogeneity poisoned the
+  partitioner accept test (`nan < thres` is False → bogus splits, even an empty
+  stored node) → BIG_M finite-guard in `_create_heterogeneity_function`;
+  (2) ShapDP single-bin payload → interp1d on one knot → nan spline → constant
+  fallback in `_summarize`.
+
+**Prototype evidence (`scripts/proto_masked_regional.py`, old=main vs new):**
+trees identical everywhere (split search untouched); bike-sharing ALE node
+plots visually identical; PDP node values identical, drawn on the global grid
+(smooth) instead of the node refit's staircase; the old ShapDP empty-node crash
+renders fine on new. Figures in `scripts/proto_masked_figs/`.
+
+**Docs:** design.md R11 (+ R5 de-staled), method_semantics.md "Masked
+evaluation" section (per-method frozen-vs-recomputed table), regional
+quickstart "under the hood" note with the ad-hoc `plot(mask=X[:, 6] > 0.5)`
+example.

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,8 +48,8 @@ to detect refit.
 ## R5 — One method registry
 
 `effector.method_registry` holds the single
-`{canonical_name: (cls, needs_jac, uses_data_effect, display_name)}` table
-plus aliases. `FeatureEffect`, `RegionalEffectBase._create_fe_object`, and
+`{canonical_name: (cls, needs_jac, display_name, ...capabilities)}` table
+plus aliases. `FeatureEffect`, `RegionalEffectBase`, and
 plot titles all read it; per-method if/elif chains are a bug.
 
 ## R6 — String-argument registries
@@ -150,3 +150,38 @@ construction-time defaults; a plot-time `scale_x`/`scale_y` dict overrides,
 checks name/type list lengths against `dim`, canonical type values, scale
 dict shapes (`{"mean","std"}`, `std != 0`), `cat_limit` sanity, and
 `category_names` lengths against the observed levels.
+
+## R11 — Regional ≡ masked global
+
+A regional effect is **not** a re-instantiated global object on a data
+subset; it is the one global object's own summary restricted by a boolean
+mask. Every global `eval`/`eval_heter`/`heter_score`/`plot` accepts
+`mask=` (boolean, shape `(N,)`); `RegionalX.eval/eval_heter/plot(feature,
+node_idx)` delegates to the one fitted global object with the node's mask
+(plus `feature_label=` for the region title). One source of truth: the
+heterogeneity printed in the partition tree **is**
+`global.heter_score(feature, mask)`, and every plotted node band derives
+from `eval_heter(feature, xs, mask)`.
+
+**The invariant.** `axis_limits` is the immutable global frame, fixed at
+construction. A mask never mutates stored state — no axis_limits, no bins,
+no payloads. Anything region-shaped is transient, derived per call via
+`_effective_limits(feature, mask)` = `[min, max]` of the masked column
+(categorical analog: `_level_weights`). Its only consumers: masked
+centering constants, the masked plot x-window, and degeneracy guards
+(empty mask / collapsed interval → `ValueError`).
+
+**Model-free.** Masked surfaces extend the single-model-touch constitution
+to eval/plot: everything is re-summarized from the stored per-instance
+local effects, zero model calls (contract-tested). The one allowed
+exception: PDP `eval(mask=)` at points off the cached grid recomputes ICE
+on `data[mask]` exactly — symmetric with global PDP eval.
+
+**Frame semantics.** Structure frozen on the global frame stays frozen:
+ALE keeps its bin edges, PDP its grid. Bins/levels left empty by the mask
+are interpolated (`fill_nans`) and edge bins extend flat — a region never
+re-touches the model to re-support the frame. RHALE/ShapDP store
+per-instance local effects, so masked calls re-run binning; the
+`binning_scope` fit kwarg (`"global"` default | `"effective"`) selects the
+range handed to `find_limits`, is recorded in `fit_args`, and is replayed
+on every masked call — split search and display always share it.

--- a/docs/docs/quickstart/global_and_regional_effects.md
+++ b/docs/docs/quickstart/global_and_regional_effects.md
@@ -316,4 +316,35 @@ To print the partition tree, we will use `.summary()` method of the regional eff
     📊 **PDP and SHAP-DP go further**  
     They reveal another key factor: **temperature**. The impact of `hour` on bike rentals differs on non-working days depending on whether it’s hot or cold.  
 
+---
+
+## Under the hood: a regional effect is a masked global effect
+
+???+ Note "Regional plots are global-frame views"
+
+    A regional node is **not** a new effect fitted from scratch on a data subset.
+    `effector` fits the global effect **once** (one pass over the model) and every
+    node plot is that same object's summary restricted to the node's instances:
+    the axis limits, the PDP grid, and the ALE bin edges stay on the global frame,
+    while means, heterogeneity bands, and centering are re-computed from the
+    node's instances only — with **zero extra model calls**. The heterogeneity
+    printed in the partition tree and the band drawn in the node plot come from
+    the same computation.
+
+You can use the same mechanism ad hoc, with any condition you like, without
+fitting a regional object at all — every global method's `eval` and `plot`
+accept a boolean `mask` over the instances:
+
+```python
+pdp = effector.PDP(X, model)
+pdp.fit(feature=3)
+
+# the effect of `hour`, only over working days
+pdp.plot(feature=3, mask=X[:, 6] > 0.5, feature_label="hr | workingday")
+```
+
+`RegionalPDP.plot(feature, node_idx)` does exactly this, with the node's mask
+and label. See *The design contract* (R11) and *Method semantics* for what is
+re-computed versus frozen per method.
+
     ✔️ This makes sense—temperature matters for sightseeing, but not for commuting.

--- a/docs/method_semantics.md
+++ b/docs/method_semantics.md
@@ -28,6 +28,42 @@ their natural numeric order. Nominal levels are indexed by an order $\pi$: decla
   per-level jittered dots. Nominal → same bars at positions $1..K$ with level labels as
   ticks; bar order follows $\pi$; PDP/ShapDP may reorder for display (`order="effect"`).
 
+## Masked evaluation (regional ≡ masked global)
+
+`eval`/`eval_heter`/`heter_score`/`plot` all accept `mask=` — a boolean array
+over the $N$ instances — and return the method's own summary restricted to the
+selected instances. This is exactly what a regional node is (design contract
+R11): `RegionalX.plot(feature, node_idx)` = `globalX.plot(feature,
+mask=node_mask)`. Masked calls are model-free — they re-summarize the stored
+per-instance local effects (one exception below). Per method, what re-runs and
+what stays frozen:
+
+- **PDP / DerPDP** — the grid is frozen (global frame). Masked mean and
+  variance are re-averaged over the masked *columns* of the cached ICE (d-ICE)
+  table; centering constants are recomputed per masked instance. The one
+  allowed model touch: `eval(mask=)` at points off the cached grid recomputes
+  ICE on `data[mask]` exactly; heterogeneity and plot always interpolate from
+  the cached grid.
+- **ALE** — bin edges are frozen (the edge-bound secants cannot be recomputed
+  without touching the model). Masked per-bin means/variances are re-averaged
+  from the stored per-instance effects; bins left empty by the mask are
+  interpolated (`fill_nans`) and edge bins extend flat.
+- **RHALE / ShapDP** — the stored local effects are per-instance (jacobian
+  values / SHAP values), so a masked call re-runs binning on the masked data.
+  The `binning_scope` fit kwarg selects the range handed to the binner:
+  `"global"` (default) = the global `axis_limits` interval, `"effective"` =
+  the masked column's `[min, max]`. It is recorded at fit and replayed on
+  every masked call, so the split search's `heter_score(mask)` and every
+  masked eval/plot share the same scope.
+- **Categorical features** keep the parent's level frame: means/variances are
+  re-aggregated per level within the mask, level weights $w_k$ become the
+  within-mask frequencies, and levels absent from the region are interpolated
+  (ALE transitions) or dropped from the bars.
+
+Masked plots window the x-axis to the effective interval, so node plots look
+"zoomed" by default. A degenerate mask (empty, or collapsing the feature to a
+point) raises `ValueError`.
+
 ## PDP
 
 ICE curve: $\hat f^{(i)}(x) = f(x,\, x^{(i)}_c)$.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,7 +5,7 @@ nav:
   - Quickstart: quickstart.md
   - API Docs: api_docs.md
   - Design:
-      - The design contract (R1-R10): design.md
+      - The design contract (R1-R11): design.md
       - Method semantics by feature type: method_semantics.md
   - Guides: guides.md
   - Examples: examples.md

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -295,18 +295,31 @@ class ShapDP(GlobalEffectBase):
 
         # Compute bin edges and bin centers, then piecewise-linear interpolation
         bin_centers = (limits[:-1] + limits[1:]) / 2
-        mean_spline = interp1d(
-            bin_centers,
-            feature_effect_dict["bin_effect"],
-            kind="linear",
-            fill_value="extrapolate",
-        )
-        var_spline = interp1d(
-            bin_centers,
-            feature_effect_dict["bin_variance"],
-            kind="linear",
-            fill_value="extrapolate",
-        )
+        if len(bin_centers) == 1:
+            # a single bin (e.g. an unstructured φ that the adaptive binning
+            # rightly refuses to split): interp1d on one knot divides by a
+            # zero span and returns nan everywhere — use the constant instead
+            mean_val = float(feature_effect_dict["bin_effect"][0])
+            var_val = float(feature_effect_dict["bin_variance"][0])
+
+            def mean_spline(x, _v=mean_val):
+                return np.full(np.shape(x), _v)
+
+            def var_spline(x, _v=var_val):
+                return np.full(np.shape(x), _v)
+        else:
+            mean_spline = interp1d(
+                bin_centers,
+                feature_effect_dict["bin_effect"],
+                kind="linear",
+                fill_value="extrapolate",
+            )
+            var_spline = interp1d(
+                bin_centers,
+                feature_effect_dict["bin_variance"],
+                kind="linear",
+                fill_value="extrapolate",
+            )
         return {
             "spline_mean": mean_spline,
             "spline_var": var_spline,

--- a/effector/method_registry.py
+++ b/effector/method_registry.py
@@ -2,8 +2,7 @@
 
 Every piece of per-method knowledge that used to live in scattered if/elif
 chains — which class implements a method, whether it consumes the model
-jacobian, whether it carries a precomputed `data_effect`, and how it is
-displayed — is written here once.
+jacobian, and how it is displayed — is written here once.
 """
 
 from collections import namedtuple
@@ -17,7 +16,6 @@ MethodSpec = namedtuple(
     [
         "cls",
         "needs_jac",
-        "uses_data_effect",
         "display_name",
         "supported_feature_types",
         "cat_strategy",
@@ -25,13 +23,12 @@ MethodSpec = namedtuple(
 )
 
 
-def _spec(cls, needs_jac, uses_data_effect, display_name):
+def _spec(cls, needs_jac, display_name):
     # capability fields are read from the class attributes (single source of
     # truth — a contract test pins the agreement)
     return MethodSpec(
         cls,
         needs_jac,
-        uses_data_effect,
         display_name,
         cls.SUPPORTED_FEATURE_TYPES,
         cls.CAT_STRATEGY,
@@ -39,11 +36,11 @@ def _spec(cls, needs_jac, uses_data_effect, display_name):
 
 
 METHODS = {
-    "pdp": _spec(PDP, False, False, "PDP"),
-    "derpdp": _spec(DerPDP, True, False, "d-PDP"),
-    "ale": _spec(ALE, False, False, "ALE"),
-    "rhale": _spec(RHALE, True, True, "RHALE"),
-    "shapdp": _spec(ShapDP, False, False, "SHAP-DP"),
+    "pdp": _spec(PDP, False, "PDP"),
+    "derpdp": _spec(DerPDP, True, "d-PDP"),
+    "ale": _spec(ALE, False, "ALE"),
+    "rhale": _spec(RHALE, True, "RHALE"),
+    "shapdp": _spec(ShapDP, False, "SHAP-DP"),
 }
 
 ALIASES = {

--- a/effector/regional_effect.py
+++ b/effector/regional_effect.py
@@ -80,9 +80,10 @@ class RegionalEffectBase:
         self.partitioners: typing.Dict[str, Best] = {}
         self.tree: typing.Dict[str, Tree] = {}
 
-        # the ONE global effect object per feature: fit once on the full data,
-        # its cached local effects re-scored (masked) for every candidate split
-        self._global_fe: typing.Dict = {}
+        # the ONE global effect object (regional ≡ masked global): constructed
+        # once, fitted per feature; the split search AND the node eval/plot are
+        # its own masked summaries — pure numpy over its cached local effects
+        self._global_fe = None
 
     def fit(self, *args, **kwargs):
         raise NotImplementedError
@@ -93,45 +94,56 @@ class RegionalEffectBase:
         jacobian to avoid recomputing it)."""
         return {}
 
-    def _after_precompute(self, feature: int, fe) -> None:
-        """Hook: run after the global effect is fitted (e.g. stash the computed
-        SHAP values for node injection)."""
-
     def _precompute_global(self, feature: int) -> None:
-        """Fit the ONE global effect for `feature` on the full data and cache it
-        (its local effects are computed here, once). The heterogeneity function
-        then re-scores masked subsets of those cached effects — no model calls,
-        no per-candidate object rebuilds (the single-model-touch constitution)."""
-        spec = resolve_method(self.method_name)
-        kwargs = dict(
-            axis_limits=self.axis_limits,
-            nof_instances="all",
-            schema=self._node_schema(),
-            random_state=self.random_state,
-        )
-        kwargs.update(self._global_fe_kwargs())
-        if spec.needs_jac:
-            fe = spec.cls(self.data, self.model, self.model_jac, **kwargs)
-        else:
-            fe = spec.cls(self.data, self.model, **kwargs)
-        fe.fit(features=feature, centering=False, **self.kwargs_fitting)
-        self._global_fe["feature_" + str(feature)] = fe
-        self._after_precompute(feature, fe)
+        """Fit the ONE global effect for `feature` on the full data (its local
+        effects are computed here, once; the shared object also reuses
+        feature-independent raw material — jacobian, shap values — across
+        features). Every regional question afterwards is a masked re-summary of
+        those cached effects — no model calls, no per-candidate or per-node
+        object rebuilds (the single-model-touch constitution)."""
+        if self._global_fe is None:
+            spec = resolve_method(self.method_name)
+            kwargs = dict(
+                axis_limits=self.axis_limits,
+                nof_instances="all",
+                schema=self._node_schema(),
+                random_state=self.random_state,
+            )
+            kwargs.update(self._global_fe_kwargs())
+            if spec.needs_jac:
+                self._global_fe = spec.cls(
+                    self.data, self.model, self.model_jac, **kwargs
+                )
+            else:
+                self._global_fe = spec.cls(self.data, self.model, **kwargs)
+            # category_names (a value->name map) is resolved by the parent's
+            # ingest; inherit it by value — the schema-side list format is
+            # positional over *observed* levels, so it can't survive an
+            # unlucky subsample
+            if self.feature_metadata.category_names is not None:
+                self._global_fe.feature_metadata = dataclasses.replace(
+                    self._global_fe.feature_metadata,
+                    category_names=self.feature_metadata.category_names,
+                )
+        self._global_fe.fit(features=feature, centering=False, **self.kwargs_fitting)
 
     def _create_heterogeneity_function(self, feature: int, min_points: int) -> Callable:
         """The heterogeneity the partitioner minimizes: delegate to the global
         effect's own `heter_score(feature, mask)` over the candidate subregion —
         pure numpy over the cached local effects. A degenerate subregion (empty
         or singleton bins) is rejected with BIG_M."""
-        fe = self._global_fe["feature_" + str(feature)]
+        fe = self._global_fe
 
         def heter(active_indices) -> float:
             if np.sum(active_indices) < min_points:
                 return BIG_M
             try:
-                return fe.heter_score(feature, mask=active_indices.astype(bool))
+                score = fe.heter_score(feature, mask=active_indices.astype(bool))
             except (utils.AllBinsHaveAtMostOnePointError, ValueError):
                 return BIG_M
+            # a nan score would poison the accept test (nan < thres is False,
+            # so a nonsense split with an empty child would be *accepted*)
+            return score if np.isfinite(score) else BIG_M
 
         return heter
 
@@ -218,17 +230,11 @@ class RegionalEffectBase:
             centering = resolve_method(self.method_name).cls.DEFAULT_CENTERING
         return helpers.prep_centering(centering)
 
-    def _extra_fe_kwargs(self, active_indices: np.ndarray) -> dict:
-        """Hook: method-specific constructor kwargs for a node's fe object."""
-        return {}
-
-    def _node_schema(self, feature_names: Optional[list] = None) -> ingestion.Schema:
-        """The parent's resolved metadata as an explicit schema for internally
-        built effect objects — types must never be re-inferred from a subset."""
+    def _node_schema(self) -> ingestion.Schema:
+        """The parent's resolved metadata as an explicit schema for the
+        internally built global effect — types must never be re-inferred."""
         return ingestion.Schema(
-            feature_names=(
-                self.feature_names if feature_names is None else feature_names
-            ),
+            feature_names=self.feature_names,
             feature_types=self.feature_types,
             cat_limit=self.cat_limit,
             target_name=self.target_name,
@@ -236,7 +242,9 @@ class RegionalEffectBase:
             scale_y=self.scale_y,
         )
 
-    def _create_fe_object(self, feature, node_idx, scale_x_list):
+    def _node_mask(self, feature: int, node_idx: int):
+        """The `(node, boolean mask)` of a fitted tree node — the ONLY thing
+        that distinguishes the node's effect from the global one."""
         feature_tree = self.tree["feature_{}".format(feature)]
         if feature_tree is None:
             raise ValueError("Feature {} has no splits".format(feature))
@@ -246,47 +254,8 @@ class RegionalEffectBase:
                     node_idx, feature, len(feature_tree.nodes)
                 )
             )
-
         node = feature_tree.get_node_by_idx(node_idx)
-        name = feature_tree.set_display_name(node.name, scale_x_list)
-        mask = node.info["active_indices"].astype(bool)
-        data = self.data[mask, :]
-        feature_names = copy.deepcopy(self.feature_names)
-        feature_names[feature] = name
-
-        spec = resolve_method(self.method_name)
-        kwargs = dict(
-            nof_instances="all",
-            schema=self._node_schema(feature_names),
-            random_state=self.random_state,
-        )
-        if spec.uses_data_effect:
-            kwargs["data_effect"] = (
-                self.data_effect[mask, :] if self.data_effect is not None else None
-            )
-        kwargs.update(self._extra_fe_kwargs(mask))
-
-        if spec.needs_jac:
-            fe = spec.cls(data, self.model, self.model_jac, **kwargs)
-        else:
-            fe = spec.cls(data, self.model, **kwargs)
-        # a node's data is a subset, so category_names (a value->name map) can't
-        # be re-derived from it; inherit the parent's resolved map by value
-        if self.feature_metadata.category_names is not None:
-            fe.feature_metadata = dataclasses.replace(
-                fe.feature_metadata,
-                category_names=self.feature_metadata.category_names,
-            )
-        return fe
-
-    def _fit_node_effect(self, feature, node_idx, centering, scale_x_list=None):
-        """Build the node's fe object and fit it with the *stored* fit kwargs
-        (B1: eval/plot must refit with what the user chose at fit time)."""
-        fe = self._create_fe_object(feature, node_idx, scale_x_list)
-        fit_kwargs = copy.deepcopy(self.kwargs_fitting)
-        fit_kwargs["centering"] = centering
-        fe.fit(features=feature, **fit_kwargs)
-        return fe
+        return node, node.info["active_indices"].astype(bool)
 
     def eval(
         self,
@@ -328,10 +297,11 @@ class RegionalEffectBase:
         self.refit(feature)
         centering = self._resolve_centering(centering)
 
-        fe = self._fit_node_effect(feature, node_idx, centering)
-        y = fe.eval(feature, xs, centering=centering)
+        _, mask = self._node_mask(feature, node_idx)
+        fe = self._global_fe
+        y = fe.eval(feature, xs, centering=centering, mask=mask)
         if heterogeneity:
-            return y, fe.eval_heter(feature, xs)
+            return y, fe.eval_heter(feature, xs, mask=mask)
         return y
 
     def eval_heter(self, feature: int, node_idx: int, xs: np.ndarray) -> np.ndarray:
@@ -349,21 +319,28 @@ class RegionalEffectBase:
             the heterogeneity curve `h` at the given `xs`, `(T,)`
         """
         self.refit(feature)
-        fe = self._fit_node_effect(feature, node_idx, centering=False)
-        return fe.eval_heter(feature, xs)
+        _, mask = self._node_mask(feature, node_idx)
+        return self._global_fe.eval_heter(feature, xs, mask=mask)
 
     def _plot(self, feature, node_idx, scale_x_list, plot_kwargs):
-        """Fit the node's fe object with the stored fit kwargs (B1) and
-        delegate to its plot — the return rule is the global one's (R7)."""
+        """Delegate to the ONE global effect's masked plot — the node's effect
+        drawn from the cached local effects on the global frame, x-windowed to
+        the node's own interval; the return rule is the global one's (R7)."""
         self.refit(feature)
         plot_kwargs["centering"] = self._resolve_centering(plot_kwargs["centering"])
         scale_x_list = helpers.resolve_scale(scale_x_list, self.scale_x_list)
 
-        fe = self._fit_node_effect(
-            feature, node_idx, plot_kwargs["centering"], scale_x_list
-        )
+        node, mask = self._node_mask(feature, node_idx)
+        feature_tree = self.tree["feature_{}".format(feature)]
+        label = feature_tree.set_display_name(node.name, scale_x_list)
         scale_x = scale_x_list[feature] if scale_x_list is not None else None
-        return fe.plot(feature=feature, scale_x=scale_x, **plot_kwargs)
+        return self._global_fe.plot(
+            feature=feature,
+            scale_x=scale_x,
+            mask=mask,
+            feature_label=label,
+            **plot_kwargs,
+        )
 
     def summary(
         self,

--- a/effector/regional_effect_ale.py
+++ b/effector/regional_effect_ale.py
@@ -124,6 +124,7 @@ class RegionalRHALE(RegionalEffectBase):
             ap.Agglomerative,
             ap.Quantile,
         ] = "dp",
+        binning_scope: str = "global",
     ):
         """
         Find subregions by minimizing the RHALE-based heterogeneity.
@@ -145,6 +146,14 @@ class RegionalRHALE(RegionalEffectBase):
                   For custom parameters initialize a `axis_partitioning.DynamicProgramming` object
                 - Use `"fixed"` for using a Fixed binning solution with the default parameters.
                   For custom parameters initialize a `axis_partitioning.Fixed` object
+
+            binning_scope: the x-range the binner covers when a subregion is
+                re-binned (the split search and the node eval/plot alike)
+
+                - `"global"` (default): the frozen global `axis_limits` — one
+                  frame for every subregion, directly comparable
+                - `"effective"`: each subregion's own `[min, max]` — bins
+                  packed into the subregion, finer resolution
         """
         if self.data_effect is None:
             self.compile()
@@ -154,7 +163,10 @@ class RegionalRHALE(RegionalEffectBase):
             "candidate_conditioning_features": candidate_conditioning_features,
             "space_partitioner": space_partitioner,
         }
-        self.kwargs_fitting = {"binning_method": binning_method}
+        self.kwargs_fitting = {
+            "binning_method": binning_method,
+            "binning_scope": binning_scope,
+        }
 
         self._fit_loop(features, candidate_conditioning_features, space_partitioner)
 

--- a/effector/regional_effect_shap.py
+++ b/effector/regional_effect_shap.py
@@ -94,14 +94,10 @@ class RegionalShapDP(RegionalEffectBase):
             random_state=random_state,
         )
 
-    def _extra_fe_kwargs(self, active_indices: np.ndarray) -> dict:
-        """A node's ShapDP reuses the region's slice of the *global* shap
-        values (attributions are not recomputed within the region)."""
-        return {"shap_values": self.global_shap_values[active_indices, :]}
-
     def _global_fe_kwargs(self) -> dict:
-        # the global ShapDP is constructed with the backend/budget config and
-        # any user-provided attributions (reused, not recomputed)
+        # the ONE global ShapDP is constructed with the backend/budget config
+        # and any user-provided attributions; it computes (and caches) the φ
+        # table once, and every regional question is a masked re-summary of it
         return dict(
             backend=self.backend,
             budget=self.budget,
@@ -109,10 +105,6 @@ class RegionalShapDP(RegionalEffectBase):
             shap_explainer_kwargs=self.shap_explainer_kwargs,
             shap_explanation_kwargs=self.shap_explanation_kwargs,
         )
-
-    def _after_precompute(self, feature: int, fe) -> None:
-        # stash the computed attributions for node injection (_extra_fe_kwargs)
-        self.global_shap_values = fe.shap_values
 
     def fit(
         self,
@@ -123,6 +115,7 @@ class RegionalShapDP(RegionalEffectBase):
         binning_method: Union[
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
+        binning_scope: str = "global",
     ):
         """
         Fit the regional SHAP.
@@ -138,6 +131,14 @@ class RegionalShapDP(RegionalEffectBase):
                 - If set to "greedy", the greedy space partitioner will be used.
 
             binning_method: the binning method to use
+
+            binning_scope: the x-range the binner covers when a subregion is
+                re-binned (the split search and the node eval/plot alike)
+
+                - `"global"` (default): the frozen global `axis_limits` — one
+                  frame for every subregion, directly comparable
+                - `"effective"`: each subregion's own `[min, max]` — bins
+                  packed into the subregion, finer resolution
 
             budget: Budget to use for the approximation. Defaults to 512.
                 - Increasing the budget improves the approximation at the cost of slower computation.
@@ -174,6 +175,7 @@ class RegionalShapDP(RegionalEffectBase):
         }
         self.kwargs_fitting = {
             "binning_method": binning_method,
+            "binning_scope": binning_scope,
         }
 
         self._fit_loop(features, candidate_conditioning_features, space_partitioner)

--- a/scripts/proto_masked_regional.py
+++ b/scripts/proto_masked_regional.py
@@ -1,0 +1,168 @@
+"""Side-by-side prototype: OLD node-object regional plots vs NEW masked-global
+regional plots (PR feat/regional-masked-delegation), plus the binning_scope
+global-vs-effective comparison for RHALE.
+
+Run twice:
+    PYTHONPATH=<old-worktree> python scripts/proto_masked_regional.py old <outdir>
+    PYTHONPATH=<repo>         python scripts/proto_masked_regional.py new <outdir>
+
+Part A: synthetic gated model (fast gate).
+Part B: bike sharing + lightgbm (once, the expensive real-data look).
+Part C (new only): RHALE binning_scope "global" vs "effective".
+"""
+
+import os
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+import effector
+
+MODE = sys.argv[1]  # "old" | "new"
+OUT = sys.argv[2]
+os.makedirs(OUT, exist_ok=True)
+print("effector from:", effector.__file__)
+
+
+def save(ret, fname):
+    if ret is None:
+        return
+    fig = ret[0]
+    fig.suptitle(fname.replace(".png", f" [{MODE}]"), fontsize=9)
+    fig.savefig(os.path.join(OUT, f"{MODE}_{fname}"), dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------- Part A ----
+def gated(x):
+    y = np.zeros_like(x[:, 0])
+    ind = np.logical_and(x[:, 1] > 0, x[:, 2] == 0)
+    y[ind] = 5 * x[ind, 0]
+    return y
+
+
+def gated_jac(x):
+    j = np.zeros_like(x)
+    ind = np.logical_and(x[:, 1] > 0, x[:, 2] == 0)
+    j[ind, 0] = 5
+    return j
+
+
+rng = np.random.default_rng(21)
+N = 1000
+X = np.stack(
+    [
+        rng.uniform(-1, 1, N),
+        rng.uniform(-1, 1, N),
+        rng.integers(0, 2, N).astype(float),
+    ],
+    axis=1,
+)
+
+# small noise keeps DP binning away from the single-bin/zero-variance corner,
+# where ShapDP's spline goes nan (pre-existing kernel wart, logged separately)
+phi = rng.normal(0, 0.05, X.shape)
+ind = np.logical_and(X[:, 1] > 0, X[:, 2] == 0)
+phi[ind, 0] += 5 * X[ind, 0]
+
+REGIONALS = {
+    "pdp": lambda: effector.RegionalPDP(X, gated, nof_instances="all"),
+    "ale": lambda: effector.RegionalALE(X, gated, nof_instances="all"),
+    "rhale": lambda: effector.RegionalRHALE(
+        X, gated, gated_jac, nof_instances="all"
+    ),
+    "shapdp": lambda: effector.RegionalShapDP(
+        X, gated, nof_instances="all", shap_values=phi
+    ),
+}
+
+for name, make in REGIONALS.items():
+    reg = make()
+    reg.fit(0, space_partitioner=effector.space_partitioning.Best(max_depth=2))
+    tree = reg.tree["feature_0"]
+    print(f"[A:{name}] nodes={len(tree.nodes)}")
+    for node_idx in range(1, min(len(tree.nodes), 5)):
+        try:
+            ret = reg.plot(feature=0, node_idx=node_idx, show_plot=False)
+        except Exception as e:  # noqa: BLE001 — comparison probe, keep going
+            print(f"  node {node_idx} CRASH: {type(e).__name__}: {e}")
+            continue
+        save(ret, f"A_{name}_node{node_idx}.png")
+
+# ---------------------------------------------------------------- Part C ----
+if MODE == "new":
+    for scope in ["global", "effective"]:
+        # condition on x0 itself via a correlated conditioning feature: build
+        # data where x1 correlates with x0, so subregions restrict the x0 range
+        rng2 = np.random.default_rng(7)
+        Xc = np.stack(
+            [rng2.uniform(-1, 1, N), np.zeros(N), rng2.uniform(-1, 1, N)], axis=1
+        )
+        Xc[:, 1] = np.clip(Xc[:, 0] + rng2.normal(0, 0.3, N), -1, 1)
+
+        def corr_model(x):
+            return x[:, 0] ** 2 * (x[:, 1] > 0) + x[:, 2]
+
+        def corr_jac(x):
+            j = np.zeros_like(x)
+            j[:, 0] = 2 * x[:, 0] * (x[:, 1] > 0)
+            j[:, 2] = 1.0
+            return j
+
+        reg = effector.RegionalRHALE(Xc, corr_model, corr_jac, nof_instances="all")
+        reg.fit(0, binning_scope=scope)
+        tree = reg.tree["feature_0"]
+        print(f"[C:rhale:{scope}] nodes={len(tree.nodes)}")
+        for node_idx in range(1, min(len(tree.nodes), 3)):
+            ret = reg.plot(feature=0, node_idx=node_idx, show_plot=False)
+            save(ret, f"C_rhale_scope-{scope}_node{node_idx}.png")
+
+# ---------------------------------------------------------------- Part B ----
+if os.environ.get("PROTO_REAL", "0") == "1":
+    from lightgbm import LGBMRegressor
+
+    bike = effector.datasets.BikeSharing(pcg_train=0.8)
+    Xtr, ytr = bike.x_train, bike.y_train
+    model_lgbm = LGBMRegressor(n_estimators=100, verbose=-1, random_state=21)
+    model_lgbm.fit(Xtr, ytr)
+
+    def bike_model(x):
+        return model_lgbm.predict(x)
+
+    schema = {
+        "feature_names": bike.feature_names,
+        "target_name": bike.target_name,
+        "scale_x_list": [
+            {"mean": mu, "std": std}
+            for mu, std in zip(bike.x_train_mu, bike.x_train_std)
+        ],
+        "scale_y": {"mean": bike.y_train_mu, "std": bike.y_train_std},
+    }
+    HR = 3  # the classic bike-sharing FOI: hour
+
+    for name, ctor in [
+        ("pdp", effector.RegionalPDP),
+        ("ale", effector.RegionalALE),
+    ]:
+        reg = ctor(Xtr, bike_model, nof_instances=5000, schema=schema)
+        reg.fit(
+            HR,
+            space_partitioner=effector.space_partitioning.Best(max_depth=1),
+            candidate_conditioning_features=[6, 8],  # workingday, temp
+        )
+        tree = reg.tree[f"feature_{HR}"]
+        print(f"[B:{name}] nodes={len(tree.nodes)}")
+        for node_idx in range(1, min(len(tree.nodes), 3)):
+            ret = reg.plot(
+                feature=HR,
+                node_idx=node_idx,
+                show_plot=False,
+                scale_x_list=schema["scale_x_list"],
+            )
+            save(ret, f"B_bike_{name}_hr_node{node_idx}.png")
+
+print("done ->", OUT)

--- a/tests/test_contract_ingestion.py
+++ b/tests/test_contract_ingestion.py
@@ -159,10 +159,10 @@ def test_r10_schema_object_equals_dict():
 def test_r10_regional_node_inherits_types():
     reg = make_regional("regional_pdp", make_regional_data())
     reg.fit(0, space_partitioner=effector.space_partitioning.Best(max_depth=2))
-    node_fe = reg._create_fe_object(0, 1, None)
-    # node subsets must NOT re-infer: parent's types verbatim
-    assert node_fe.feature_types == reg.feature_types
-    assert node_fe.cat_limit == reg.cat_limit
+    # the ONE internally built global effect (all node eval/plot delegate to
+    # its masked summaries) must NOT re-infer: parent's types verbatim
+    assert reg._global_fe.feature_types == reg.feature_types
+    assert reg._global_fe.cat_limit == reg.cat_limit
 
 
 def test_r10_facade_submethods_inherit_types():

--- a/tests/test_contract_regional.py
+++ b/tests/test_contract_regional.py
@@ -210,3 +210,77 @@ def test_rc6_split_search_is_model_free(name):
     # a one-time precompute is a small constant; per-candidate work would be
     # >= the number of candidates (>= grid)
     assert n_large < 40, f"{name}: {n_large} model calls looks like per-candidate work"
+
+
+# ---------------------------------------------------------------------------
+# RC7 — one truth (regional ≡ masked global): the heterogeneity number that
+# CHOSE each split is byte-identical to the one the node's surfaces report —
+# the tree summary, heter_score(mask) and the plotted band share one source.
+# ---------------------------------------------------------------------------
+
+
+def test_rc7_tree_heterogeneity_equals_masked_heter_score(fitted_regional):
+    name, reg = fitted_regional
+    fe = reg._global_fe
+    tree = reg.tree["feature_0"]
+    for node in tree.nodes:
+        mask = node.info["active_indices"].astype(bool)
+        np.testing.assert_allclose(
+            node.info["heterogeneity"],
+            fe.heter_score(0, mask=mask),
+            atol=1e-10,
+            err_msg=f"{name}, node {node.idx}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# RC8 — the constitution on the node surfaces: after fit, eval/eval_heter/plot
+# on any node are masked re-summaries of the cached local effects — ZERO model
+# calls. (The one exception, PDP eval at off-grid xs, is pinned in the masked
+# contract layer, test_contract_masked.py::test_m2.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", REGIONAL_NAMES)
+def test_rc8_node_surfaces_are_model_free(name):
+    from effector import helpers
+
+    data = make_regional_data()
+    model = CountingModel(gated_model)
+    jac = CountingModel(gated_model_jac)
+    if name == "regional_pdp":
+        reg = effector.RegionalPDP(data, model)
+    elif name == "regional_derpdp":
+        reg = effector.RegionalDerPDP(data, model, model_jac=jac)
+    elif name == "regional_ale":
+        reg = effector.RegionalALE(data, model)
+    elif name == "regional_rhale":
+        reg = effector.RegionalRHALE(data, model, model_jac=jac)
+    elif name == "regional_shapdp":
+        # structured (gate-aware) attributions so the fitted tree is real; the
+        # small noise keeps DP binning off the single-bin/zero-variance corner
+        # where ShapDP's spline goes nan (pre-existing kernel wart)
+        rng = np.random.default_rng(0)
+        shap_values = rng.normal(0, 0.05, data.shape)
+        ind = np.logical_and(data[:, 1] > 0, data[:, 2] == 0)
+        shap_values[ind, 0] += 5 * data[ind, 0]
+        reg = effector.RegionalShapDP(data, model, shap_values=shap_values)
+    else:
+        raise ValueError(name)
+    reg.fit(0, space_partitioner=effector.space_partitioning.Best(max_depth=2))
+
+    n0 = model.n_calls + jac.n_calls
+    # xs on the (d-)PDP cache grid so no method takes its exact-retouch path
+    grid = np.linspace(
+        reg.axis_limits[0, 0], reg.axis_limits[1, 0], helpers.NOF_INTERNAL_POINTS
+    )
+    tree = reg.tree["feature_0"]
+    for node_idx in range(len(tree.nodes)):
+        reg.eval(0, node_idx, grid, centering=True)
+        reg.eval_heter(0, node_idx, grid)
+        reg.plot(feature=0, node_idx=node_idx, show_plot=False)
+    plt.close("all")
+    assert model.n_calls + jac.n_calls == n0, (
+        f"{name}: node eval/plot re-queried the model "
+        f"({model.n_calls + jac.n_calls - n0} extra calls)"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "effector"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Second half of the regional≡masked-global work (first half: #47). A regional node is no longer a re-instantiated global object on a data subset — it is the one fitted global object's own summary restricted by the node's mask.

## What changes

- `RegionalEffectBase.eval / eval_heter / _plot` delegate to `self._global_fe` — ONE shared global object per feature (φ/jacobian reused across features), called with `mask=node.info["active_indices"]` and `feature_label=` for the region title.
- Deleted: `_create_fe_object`, `_fit_node_effect`, `_extra_fe_kwargs`, `_after_precompute` (base + shap), and `MethodSpec.uses_data_effect` (its one consumer died with them).
- `binning_scope` (`"global"` default | `"effective"`) exposed on `RegionalRHALE.fit` / `RegionalShapDP.fit`, flowing into the one global fe; recorded in fit_args and replayed, so split search and node display always share the same scope.
- `category_names` inherited by-value onto the one global fe (ingestion test rewritten against the masked path).

## New contracts

- **RC7 one-truth**: the heterogeneity printed in the partition tree `==` `global_fe.heter_score(feature, mask)` exactly; the plotted band derives from `eval_heter(mask)`.
- **RC8 model-free nodes**: after `RegionalX.fit`, node `eval/eval_heter/plot` make **zero** model calls (CountingModel) — new behavior; the old node objects re-touched the model for ALE/PDP.

## Two real bugs found by the rewire

1. **nan poisoned the split search**: a nan heterogeneity made the accept test `heter_drop_pcg < thres` silently False → bogus splits, even an *empty* stored node → BIG_M finite-guard in `_create_heterogeneity_function`.
2. **ShapDP single-bin payload** → `interp1d` on one knot → nan spline → constant-spline fallback in `ShapDP._summarize`.

## Prototype evidence (`scripts/proto_masked_regional.py`, old = main, new = this branch)

- Trees identical everywhere (split search untouched): synthetic pdp 5 / ale 7 / rhale 7 / shapdp 7 nodes; bike-sharing pdp 3 / ale 3.
- Bike-sharing ALE node plots visually identical old-vs-new; PDP node values identical, now drawn on the global grid (smooth piecewise-linear) instead of the node refit's staircase.
- The old ShapDP empty-node crash (`zero-size array to reduction`) reproduces on main and renders fine here (bug 1 above).
- `binning_scope` A/B: both scopes recover the true dy/dx on the restricted range; `"effective"` packs finer bins into the region. Default stays `"global"`; flip is a parked one-word decision.
- Figures: `scripts/proto_masked_figs/` (regenerate: `PROTO_REAL=1 python scripts/proto_masked_regional.py {old,new} scripts/proto_masked_figs`, old side via `PYTHONPATH=<main worktree>`).

## Docs

- `design.md` **R11** (regional ≡ masked global; the `axis_limits` immutability invariant; model-free rule + the one PDP off-grid exception; frozen-frame semantics) + de-staled R5.
- `method_semantics.md`: "Masked evaluation" section — per method, what re-runs vs stays frozen.
- Regional quickstart: "under the hood" note + ad-hoc `pdp.plot(feature=3, mask=X[:, 6] > 0.5)` example.
- LOGBOOK #26.

## Tests

`make test` 622 passed; `make test-all` 639 passed, 1 skipped (including the usually-flaky `regional-shapdp-shapiq`). Lint clean.