### PR TITLE
Two-block lifecycle constitution (R14): frame-gated caches, centering as a summary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,10 +126,64 @@ make docs-serve  # preview the docs locally
 
 ## Design contract
 
-Code changes must follow the core rules (R1–R9) in
+Code changes must follow the core rules (R1–R14) in
 [docs/design.md](docs/design.md) — lifecycle, heterogeneity surface, centering
-vocabulary, registries, plot/constructor/error contracts. The
-`tests/test_contract_*.py` layer enforces most of them mechanically.
+vocabulary, registries, plot/constructor/error contracts, and the two-block
+lifecycle constitution (R14: every effect object is two caches and one config,
+owned entirely by `GlobalEffectBase`). The `tests/test_contract_*.py` layer
+enforces most of them mechanically — `tests/test_contract_lifecycle.py` pins
+the exact model-call budget of every lifecycle step, so an extra model touch
+or a lost cache hit is a failing test, not a slow regression.
+
+---
+
+## Writing a new effect method
+
+A method is a **frame declaration plus three pure kernels** — nothing else.
+The base class owns all caching, retriggering, masking, centering, and the
+regional machinery; a subclass that checks a cache is a bug by definition.
+
+1. **Answer the one semantic question: what is your frame?** The frame is the
+   discretization your local effect is defined on — the config parameters
+   whose change makes your cached local effects meaningless. ALE's is its
+   fixed bin grid, categorical (RH)ALE's is the level order; RHALE and ShapDP
+   have none (their local effects are instance-anchored). Declare it in
+   `_frame_from_config(feature) -> tuple` of primitives. The base compares it
+   on every access and recomputes/bumps the epoch when it changes — that is
+   the entire invalidation story, and you never write any of it.
+
+2. **Implement the three kernels** (all independently testable with plain
+   numpy arrays):
+
+   - `_compute_local(feature, frame) -> dict` — the ONLY kernel that may call
+     the model. Return `{"frame": frame, ...instance-aligned arrays}` so any
+     boolean `(N,)` mask can slice your local effects in one expression.
+     Feature-independent raw material (a jacobian, a SHAP table) is computed
+     once per object and shared across features.
+   - `_summarize(feature, mask=None, **config) -> dict` — pure numpy: derive
+     the payload (whatever `eval`/`plot` read) from the cached local effects
+     restricted to `mask`.
+   - `_eval_payload(feature, params, x, heterogeneity=False)` — pure reader:
+     the uncentered mean effect (and h(x)) read off a payload. Same payload +
+     same x → same answer; no model, no state.
+
+3. **Expose the public surface as thin declarations**: `fit` calls
+   `self._fit_loop(features, centering, **your_config)`; `plot` reads
+   `self._summary(feature, mask)` / `self._centering_const(...)` and draws.
+   With that, `eval`, `eval_heter`, `heter_score`, `importance`,
+   `find_regions`, the `mask=` surfaces and the `Partition` sugar all work
+   without another line of code.
+
+4. **Copy [`tests/toy_method.py`](tests/toy_method.py)** — the ~60-line
+   reference implementation the contract suite itself runs — as your starting
+   point, and register the method in `effector/method_registry.py`; the
+   contract tests parametrize over the registry and referee compliance.
+
+5. **If your method doesn't fit the mold**, override a *named hook* — never
+   bypass the gates. Legal override points: `_eval_mean` (exact evaluation
+   off the payload, like (d-)PDP), `_importance` (a method-canonical scalar,
+   like ShapDP's mean |φ|), `_compute_norm_const` / `_mean_norm_const` (a
+   non-scalar centering constant, like PDP's per-instance array).
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -289,6 +289,6 @@ is zero model calls, pinned by counting-model contract tests.
 kernel that may touch the model), `_summarize` (numpy in, payload dict out),
 `_eval_payload` (payload + xs in, numbers out) — and contains **no cache,
 retrigger, or mask logic, ever**. Methods that don't fit the mold override a
-named hook (`_eval_masked_mean`, `_importance`, the norm-const shape) — they
+named hook (`_eval_mean`, `_importance`, the norm-const shape) — they
 never bypass the gates. `tests/toy_method.py` is the reference implementation
 and the contract suite's guinea pig.

--- a/docs/design.md
+++ b/docs/design.md
@@ -7,11 +7,15 @@ enforce most of them mechanically.
 
 ## R1 — Lifecycle
 
-`fit` does the hard work once and stores everything under
-`feature_effect["feature_{i}"]`. `eval(feature, xs, centering=<class default>)`
-returns the **mean effect only — one return type, always** — and never
-recomputes unless `requires_refit`. `plot` is a thin wrapper over `eval` /
-stored state plus one `vis.*` call: the plot layer draws, it does not compute.
+Construction ingests and nothing else. `fit(features, **config)` *declares the
+method configuration* (binning, order, scope, default centering — the kwargs
+`eval`/`plot` deliberately do not accept) and eagerly warms the two caches
+(R14); nothing `fit` does is unavailable lazily — every query silently ensures
+what it needs through the same gates, and fit-then-query equals
+never-fit-just-query byte for byte. `eval(feature, xs, centering=<class
+default>)` returns the **mean effect only — one return type, always**. `plot`
+is a thin wrapper over the same summaries plus one `vis.*` call: the plot
+layer draws, it does not compute.
 
 ## R2 — Heterogeneity semantics
 
@@ -19,7 +23,7 @@ Heterogeneity does **not** go through `eval`; it has its own surface, an
 aggregation ladder with one consumer per level:
 
 - **`payload(feature)` → dict** — the method's honest raw object (ICE table,
-  per-bin variances, shap cloud) from stored state.
+  per-bin variances, shap cloud): the all-ones summary (R14).
 - **`eval_heter(feature, xs)` → `(T,)`** — the heterogeneity curve h(xs).
   h is the *variance* of the method's own per-instance effect object
   (PDP: centered ICE levels; DerPDP: d-ICE slopes; (RH)ALE: per-bin slope
@@ -41,10 +45,14 @@ aggregation ladder with one consumer per level:
 
 ## R4 — State schema
 
-`feature_effect["feature_{i}"]` always contains `norm_const: float | None`
-(`None` means "not centered" — never a sentinel value) plus the
-method-specific payload; `fit_args["feature_{i}"]` records the kwargs needed
-to detect refit.
+An effect object holds exactly two caches and one config (R14): the
+local-effects store `_local[feature]` (frame-carrying, model-derived), the
+summaries memo `_summaries` (payloads *and* centering constants, keyed by
+`(feature, epoch, mask_key[, mode])`), and `fit_args["feature_{i}"]` (the
+declared config). There is no separate "fitted state": the fitted payload *is*
+the all-ones entry of the memo, and `payload(feature)` returns it. Centering
+constants are summaries — always derived from the local effects on demand,
+never stored as fitted state and never a refit trigger.
 
 ## R5 — One method registry
 
@@ -210,10 +218,11 @@ clustering, subgroup discovery, a user `groupby`) plug in with zero changes
 elsewhere, so `Partition` must not structurally assume a tree — hierarchy is
 optional display metadata (`parent_idx`).
 
-**Invisible memos are not state.** Performance caches (the masked-summary memo)
-are allowed inside the effect because they are semantically transparent — keyed
-by fit epoch, so a refit invalidates them, and they never change an answer, only
-its latency. A cache is not API surface; a stored partition would be.
+**Invisible memos are not state.** Performance caches (the summaries memo,
+R14) are allowed inside the effect because they are semantically transparent —
+keyed by the feature's epoch, so a frame or config change makes stale entries
+unreachable, and they never change an answer, only its latency. A cache is not
+API surface; a stored partition would be.
 
 ## R13 — Importance
 
@@ -233,3 +242,53 @@ the *dispersion* would be ~0 for a linear model). `importances(mask=None) ->
 cannot explain. effector never sees `y`, so loss/permutation importance is out of
 scope by construction — importance here is a property of the fitted effect, not
 of a held-out error.
+
+## R14 — Two-block lifecycle
+
+The engine has exactly two caches, owned entirely by `GlobalEffectBase`.
+
+**Cache (a) — local effects** (the only model-touching block). One entry per
+feature, `{"frame": tuple, ...instance-aligned arrays}`, plus shared raw
+material computed once per object (`_jac`, `_shap`, `_y_pred`). Every array is
+instance-aligned, so a boolean `(N,)` mask slices it in one expression. The
+*frame* is the discretization the method's local effect is defined on:
+
+| method | local effect | frame |
+|---|---|---|
+| PDP / DerPDP | (d-)ICE columns, one per x-position | `()` — the position store only grows |
+| ALE (continuous) | per-instance bin secants | `("fixed", nof_bins, min_points)` |
+| (RH)ALE (categorical) | adjacent-level differences | `("order", (levels…))` |
+| RHALE (continuous) | jacobian column | `()` (view of the shared table) |
+| ShapDP | shap column | `()` (view of the shared table) |
+
+**The one retrigger rule.** Recompute a local-effects entry iff it is absent or
+its stored frame differs from the frame derived from the current config
+(tuple equality, checked on every access). Same frame → the cache only grows
+(PDP positions are appended, missing-only, no invalidation — growth is
+additive). Frame change → replace the entry and bump the feature's **epoch**.
+
+**Cache (b) — summaries** (pure numpy, LRU-bounded). Entries are payloads,
+keyed `(feature, epoch, mask_key)`, and centering constants, keyed
+`(feature, epoch, mask_key, mode)`. `mask_key` normalizes `None` and all-ones
+to a single key (rule M1) — that equivalence lives in exactly one function.
+The epoch bumps on frame replacement **or** config change (a refit with new
+binning/scope), so stale summaries become *unreachable*: staleness is handled
+by key structure, never by deletion logic.
+
+**Model-touch inventory.** The model is called in exactly three situations:
+(i) filling cache (a), once per frame; (ii) (d-)PDP evaluation at a
+never-before-seen position — the missing columns only, cached forever (the
+masked off-grid variant instead recomputes transiently on `data[mask]` and
+caches nothing — partial-N columns cannot enter an instance-aligned cache);
+(iii) `_y_pred`, once. Everything else — masked/regional surfaces,
+`heter_score`, `importance`, centering constants, repeated evals and plots —
+is zero model calls, pinned by counting-model contract tests.
+
+**Subclass contract.** A method implements a frame declaration
+(`_frame_from_config`) and three pure kernels — `_compute_local` (the only
+kernel that may touch the model), `_summarize` (numpy in, payload dict out),
+`_eval_payload` (payload + xs in, numbers out) — and contains **no cache,
+retrigger, or mask logic, ever**. Methods that don't fit the mold override a
+named hook (`_eval_masked_mean`, `_importance`, the norm-const shape) — they
+never bypass the gates. `tests/toy_method.py` is the reference implementation
+and the contract suite's guinea pig.

--- a/docs/method_semantics.md
+++ b/docs/method_semantics.md
@@ -19,7 +19,9 @@ their natural numeric order. Nominal levels are indexed by an order $\pi$: decla
   `zero_integral` subtracts $c = \frac{1}{30}\sum_{j=1}^{30}\hat\mu(x_j)$ (uniform grid)
   for continuous, $c = \sum_k w_k\, \hat\mu(v_k)$ (frequency-weighted level mean) for
   discrete. `zero_start` subtracts $c=\hat\mu(a)$ for continuous, $c=\hat\mu(v_1)$ for
-  discrete (reference level = 0, as in dummy coding).
+  discrete (reference level = 0, as in dummy coding). Constants are always
+  derived from the cached local effects (design contract R14) — computing one,
+  globally or masked, never touches the model.
 - **heter_score**: $H = \frac{1}{30}\sum_{j=1}^{30} h(x_j)$ (uniform grid) for continuous;
   $H = \sum_k w_k\, h(v_k)$ (frequency-weighted) for discrete. H is what
   `find_regions` consumes.
@@ -38,12 +40,14 @@ selected instances. This is exactly what a region is (design contract R11):
 they re-summarize the stored per-instance local effects (one exception below).
 Per method, what re-runs and what stays frozen:
 
-- **PDP / DerPDP** — the grid is frozen (global frame). Masked mean and
-  variance are re-averaged over the masked *columns* of the cached ICE (d-ICE)
-  table; centering constants are recomputed per masked instance. The one
-  allowed model touch: `eval(mask=)` at points off the cached grid recomputes
-  ICE on `data[mask]` exactly; heterogeneity and plot always interpolate from
-  the cached grid.
+- **PDP / DerPDP** — the canonical grid is frozen (global frame); the position
+  store only grows as new x-positions are evaluated. Masked mean and variance
+  are re-averaged over the masked *columns* of the cached ICE (d-ICE) table;
+  centering constants are derived from those cached columns — per instance,
+  global and masked alike. The one allowed model touch: `eval(mask=)` at
+  points off the cached positions recomputes ICE on `data[mask]` exactly
+  (transient, never cached); heterogeneity and plot always interpolate from
+  the canonical grid.
 - **ALE** — bin edges are frozen (the edge-bound secants cannot be recomputed
   without touching the model). Masked per-bin means/variances are re-averaged
   from the stored per-instance effects; bins left empty by the mask are

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -1,4 +1,25 @@
-import logging
+"""The global-effect engine: the two-block lifecycle (design contract R14).
+
+Every effect object holds exactly two caches and one config, all owned here:
+
+- **Cache (a) — local effects** (`self._local`): the model-touching material,
+  one frame-carrying entry per feature. Recomputed iff absent or the stored
+  frame differs from the frame derived from the current config; a frame change
+  replaces the entry and bumps the feature's epoch.
+- **Cache (b) — summaries** (`self._summaries`): everything derived from (a)
+  in pure numpy — payloads and centering constants — memoized by
+  `(feature, epoch, mask_key[, mode])`. Stale entries become unreachable when
+  the epoch bumps (frame or config change); they are never served.
+- **Config** (`self.fit_args`): the method settings `fit()` declares (binning,
+  order, scope, default centering) — the kwargs `eval`/`plot` deliberately do
+  not accept.
+
+Subclasses implement a frame declaration (`_frame_from_config`) and three pure
+kernels — `_compute_local` (the only kernel that may touch the model),
+`_summarize` (numpy in, payload dict out), `_eval_payload` (payload + xs in,
+numbers out) — and contain no cache, retrigger, or mask logic.
+"""
+
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -16,6 +37,10 @@ HINT_RHALE_NOMINAL = (
     " No derivative exists for nominal features and grouping over an "
     "arbitrary order is not meaningful; use ALE or PDP instead."
 )
+
+# the shared mask-key sentinel: `mask=None` and an all-ones mask are the same
+# summary (rule M1) — that equivalence lives in `_mask_key` and nowhere else
+_ALL = b"ALL"
 
 
 def check_feature_type_supported(
@@ -50,8 +75,7 @@ def check_binning_scope(binning_scope: str) -> None:
 
 
 class GlobalEffectBase(ABC):
-    # the class-level centering default (R3): each subclass declares it once;
-    # fit/eval/plot signatures converge on it during the homogenization
+    # the class-level centering default (R3): each subclass declares it once
     DEFAULT_CENTERING: Union[bool, str] = False
 
     # capability contract per feature type (method_semantics.md): which of
@@ -62,6 +86,8 @@ class GlobalEffectBase(ABC):
     )
     CAT_STRATEGY: Optional[str] = None
 
+    _SUMMARIES_MAX = 512
+
     def __init__(
         self,
         method_name: str,
@@ -70,15 +96,12 @@ class GlobalEffectBase(ABC):
         model_jac: Optional[Callable] = None,
         *,
         data_effect: Optional[np.ndarray] = None,
-        local_effects: Optional[dict] = None,
         nof_instances: Union[int, str] = 10_000,
         axis_limits: Optional[np.ndarray] = None,
         schema: Optional[Union[ingestion.Schema, dict]] = None,
         random_state: Optional[int] = 21,
     ) -> None:
-        """
-        Constructor for the FeatureEffectBase class.
-        """
+        """Constructor: ingest and nothing else (R1) — no model calls happen here."""
         self.method_name = method_name.lower()
         self.random_state = random_state
 
@@ -113,176 +136,181 @@ class GlobalEffectBase(ABC):
         self.scale_x_list: Optional[list] = ing.meta.scale_x_list
         self.scale_y: Optional[dict] = ing.meta.scale_y
 
-        # state variable
+        # state flag mirror (kept for introspection; the caches are the truth)
         self.is_fitted: np.ndarray = np.ones([self.dim]) < 0
 
-        # parameters used when fitting the feature effect
+        # the declared config (R14): set by fit(), read by the summary gate
         self.fit_args: dict = {}
 
-        # dict, like {"feature_i": {"quantity_1": value_1, "quantity_2": value_2, ...}} for the i-th
-        self.feature_effect: dict = {}
+        # cache (a) — local effects: {feature: {"frame": tuple, ...arrays}}
+        self._local: dict = {}
+        # per-feature epoch: bumped on frame replacement or config change
+        self._epoch: dict = {}
+        # cache (b) — summaries: payloads (f, epoch, mask_key) and centering
+        # constants (f, epoch, mask_key, mode), LRU-bounded
+        self._summaries: "OrderedDict" = OrderedDict()
+        # model(data) predictions, computed once, first time an average output
+        # is needed (global or masked)
+        self._y_pred: Optional[np.ndarray] = None
 
-        # step 2 output cache: {"feature_i": <per-instance local effect>} —
-        # computed once (model-touching, `_compute_local_effects`) or injected
-        # here at construction; steps 3-4 (summarize/eval/plot/heter) read it and
-        # never re-touch the model (R: single-model-touch constitution)
-        self.local_effects: dict = dict(local_effects) if local_effects else {}
-        # feature keys whose local effects are cached, so a later model touch on
-        # the cached path can be flagged by the (silent) diagnostic
-        self._sealed: set = set()
-
-        # Invisible performance memo (R12): masked summaries are pure functions
-        # of (feature, fitted state, mask). Keyed by (feature, fit_epoch,
-        # mask.tobytes()) so a refit — which bumps the epoch — invalidates it.
-        # A cache is not API state; the partition it accelerates is the value.
-        self._masked_cache: "OrderedDict" = OrderedDict()
-        self._fit_epoch: dict = {}  # "feature_i" -> int, bumped on (re)fit/recompute
-        self._MASKED_CACHE_MAX = 512
-
-    @abstractmethod
-    def fit(
-        self,
-        features: Union[int, str, list] = "all",
-        centering: Union[bool, str] = False,
-        **kwargs,
-    ) -> None:
-        """Fit, i.e., compute the quantities that are necessary for evaluating and plotting the feature effect, for the given features.
-
-        Args:
-            features: the features to fit. If set to "all", all the features will be fitted.
-            centering: whether to center the feature effect plot
-
-                    - If `centering` is `False`, the plot is not centered
-                    - If `centering` is `True` or `zero_integral`, the plot is centered around the `y` axis.
-                    - If `centering` is `zero_start`, the plot starts from zero.
-        """
-        raise NotImplementedError
+    # ------------------------------------------------------------------
+    # the three subclass kernels + the frame declaration (R14)
+    # ------------------------------------------------------------------
+    def _frame_from_config(self, feature: int) -> tuple:
+        """The frame tuple this feature's local effects depend on, derived from
+        the declared config. `()` means the local effects are instance-anchored
+        (never invalidated; PDP's position store only grows)."""
+        return ()
 
     @abstractmethod
-    def plot(
-        self,
-        feature: int,
-        heterogeneity: Union[bool, str] = False,
-        centering: Union[bool, str] = False,
-        **kwargs,
-    ) -> None:
-        """
-
-        Parameters
-        ----------
-        feature: index of the feature to plot
-        heterogeneity: whether to plot the heterogeneity measures
-
-            - If `heterogeneity=False`, the plot shows only the mean effect
-            - If `heterogeneity=True`, the plot additionally shows the heterogeneity with the default visualization, e.g., ICE plots for PDPs
-            - If `heterogeneity=<str>`, the plot shows the heterogeneity using the specified method
-
-        centering: whether to center the PDP
-
-                - If `centering` is `False`, the PDP not centered
-                - If `centering` is `True` or `zero_integral`, the PDP is centered around the `y` axis.
-                - If `centering` is `zero_start`, the PDP starts from `y=0`.
-        **kwargs: all other plot-specific arguments
-        """
+    def _compute_local(self, feature: int, frame: tuple) -> dict:
+        """The one model-touching kernel: compute the per-instance local
+        effects of `feature` under `frame` and return the cache-(a) entry —
+        a dict that includes `"frame": frame` plus instance-aligned arrays."""
         raise NotImplementedError
-
-    @abstractmethod
-    def _fit_feature(self, feature: int, **kwargs) -> dict:
-        """Compute and return the method-specific payload for one feature
-        (everything `eval`/`plot` need, except the normalization constant)."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def _eval_unnorm(
-        self,
-        feature: int,
-        x: np.ndarray,
-        heterogeneity: bool = False,
-        params: Optional[dict] = None,
-    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
-        """The method-specific evaluation kernel: the *uncentered* mean effect
-        at `x`, and — if `heterogeneity` — also the heterogeneity curve h(x) (a
-        variance-like quantity in the method's own units, independent of any
-        centering).
-
-        `params` selects the payload to evaluate against: `None` reads the
-        stored fitted state (`feature_effect["feature_i"]`); a passed dict (the
-        output of `_summarize`) lets the masked heterogeneity path evaluate a
-        *transient* subregion payload without disturbing the stored one."""
-        raise NotImplementedError
-
-    def _eval_masked_mean(
-        self, feature: int, x: np.ndarray, params: dict, mask: np.ndarray
-    ) -> np.ndarray:
-        """The uncentered masked mean effect at `x` — default reads the
-        transient payload (pure numpy). PDP overrides it: on the cached grid it
-        reads the payload, off-grid it recomputes ICE on `data[mask]` (the
-        exact-evaluation retouch, symmetric with the global PDP `eval`)."""
-        return self._eval_unnorm(feature, x, heterogeneity=False, params=params)
-
-    def _compute_local_effects(self, feature: int) -> None:
-        """Step 2 (model-touching): compute the per-instance local effect for
-        `feature` and store it in `self.local_effects["feature_i"]`. The single
-        place the model is queried for the effect. Overridden per method."""
-        raise NotImplementedError
-
-    def _ensure_local_effects(self, feature: int) -> None:
-        """Populate the local-effects cache for `feature` if absent — skipped
-        when the effects were injected at construction. Seals the feature; a
-        later recompute on a sealed feature (a parameter incompatible with the
-        cache) is flagged by the silent diagnostic below."""
-        key = "feature_" + str(feature)
-        if key not in self.local_effects:
-            if key in self._sealed:
-                logging.getLogger("effector").debug(
-                    "%s: recomputing local effects for feature %d after it was "
-                    "sealed — a parameter is incompatible with the cache",
-                    self.method_name,
-                    feature,
-                )
-            self._compute_local_effects(feature)
-            # local effects changed -> stale masked summaries must not be served
-            self._fit_epoch[key] = self._fit_epoch.get(key, 0) + 1
-        self._sealed.add(key)
 
     def _summarize(
-        self, feature: int, mask: Optional[np.ndarray] = None, **fit_kwargs
+        self, feature: int, mask: Optional[np.ndarray] = None, **config
     ) -> dict:
-        """Step 3 (pure numpy): derive the effect payload for `feature` from the
-        cached local effects restricted to `mask` (`None` = all instances),
-        returning the same shape as the stored `feature_effect["feature_i"]`.
-        Overridden per method."""
+        """Pure-numpy kernel: derive the payload for `feature` from the cached
+        local effects restricted to `mask` (`None` = all instances), under the
+        declared `config`. Overridden per method; must not touch the model."""
         raise NotImplementedError
 
-    def _replay_fit_kwargs(self, feature: int) -> dict:
-        """The method-specific fit kwargs recorded at the last `fit` (e.g.
-        `binning_method`, `order`, `use_vectorized`), minus centering — what a
-        transient `_summarize` must replay to match the fitted state."""
-        prev = self.fit_args.get("feature_" + str(feature), {})
-        return {
-            k: v
-            for k, v in prev.items()
-            if k not in ("centering", "points_for_centering")
-        }
+    @abstractmethod
+    def _eval_payload(
+        self,
+        feature: int,
+        params: dict,
+        x: np.ndarray,
+        heterogeneity: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        """Pure reader kernel: the *uncentered* mean effect at `x` read off the
+        payload `params`, and — if `heterogeneity` — also the heterogeneity
+        curve h(x). Same payload + same x → same answer; no model, no state."""
+        raise NotImplementedError
 
-    def _masked_params(self, feature: int, mask: np.ndarray) -> dict:
-        """Bounded-LRU memo around the masked `_summarize` (with replayed fit
-        kwargs). Semantically transparent: same (feature, fitted state, mask) ->
-        same payload as calling `_summarize` directly, only faster on repeats
-        (the split search re-proposes identical candidate masks; a plot after a
-        search hits the exact node masks). The `_fit_epoch` term in the key means
-        a refit invalidates stale entries. Callers must have ensured local
-        effects first. Treat the return value as read-only."""
-        key = (feature, self._fit_epoch.get(f"feature_{feature}", 0), mask.tobytes())
-        cached = self._masked_cache.get(key)
-        if cached is not None:
-            self._masked_cache.move_to_end(key)
-            return cached
-        params = self._summarize(feature, mask, **self._replay_fit_kwargs(feature))
-        self._masked_cache[key] = params
-        if len(self._masked_cache) > self._MASKED_CACHE_MAX:
-            self._masked_cache.popitem(last=False)
-        return params
+    # ------------------------------------------------------------------
+    # the two gates (all queries go through these; nothing else checks caches)
+    # ------------------------------------------------------------------
+    def _config(self, feature: int) -> dict:
+        """The declared method config for `feature` (fit_args minus centering)."""
+        prev = self.fit_args.get("feature_" + str(feature), {})
+        return {k: v for k, v in prev.items() if k != "centering"}
+
+    def _bump_epoch(self, feature: int) -> None:
+        self._epoch[feature] = self._epoch.get(feature, 0) + 1
+
+    def _ensure_local(self, feature: int) -> dict:
+        """Gate to cache (a). The one retrigger rule (R14): recompute iff the
+        entry is absent or its stored frame differs from the frame derived from
+        the current config. A replacement bumps the epoch. Every query passes
+        through here, so the capability matrix is enforced once, for all of
+        them."""
+        self._check_feature_type_supported(feature)
+        want = self._frame_from_config(feature)
+        entry = self._local.get(feature)
+        if entry is None or entry["frame"] != want:
+            self._local[feature] = self._compute_local(feature, want)
+            self._bump_epoch(feature)
+        return self._local[feature]
+
+    @staticmethod
+    def _mask_key(mask: Optional[np.ndarray]) -> bytes:
+        """`None` and all-ones normalize to one key (M1) — the single place
+        that equivalence lives. `mask` must already be prepped."""
+        if mask is None or mask.all():
+            return _ALL
+        return mask.tobytes()
+
+    def _memo(self, key, builder):
+        hit = self._summaries.get(key)
+        if hit is not None:
+            self._summaries.move_to_end(key)
+            return hit
+        val = builder()
+        self._summaries[key] = val
+        if len(self._summaries) > self._SUMMARIES_MAX:
+            self._summaries.popitem(last=False)
+        return val
+
+    def _summary(self, feature: int, mask: Optional[np.ndarray] = None) -> dict:
+        """Gate to cache (b): the payload of (feature, mask) under the current
+        epoch — memoized, recomputed from (a) on a miss. Treat as read-only."""
+        self._ensure_local(feature)
+        key = (feature, self._epoch.get(feature, 0), self._mask_key(mask))
+        return self._memo(
+            key, lambda: self._summarize(feature, mask, **self._config(feature))
+        )
+
+    def _centering_const(self, feature: int, mask: Optional[np.ndarray], mode: str):
+        """The centering constant of (feature, mask, mode) — a summary like any
+        other (R14): derived from the payload, memoized, zero model calls."""
+        params = self._summary(feature, mask)
+        key = (feature, self._epoch.get(feature, 0), self._mask_key(mask), mode)
+        return self._memo(
+            key, lambda: self._compute_norm_const(feature, mode, params, mask)
+        )
+
+    # ------------------------------------------------------------------
+    # shared derivations (pure numpy on top of the gates)
+    # ------------------------------------------------------------------
+    def _eval_mean(
+        self, feature: int, x: np.ndarray, params: dict, mask: Optional[np.ndarray]
+    ) -> np.ndarray:
+        """The uncentered mean effect at `x` — default reads the payload.
+        (d-)PDP overrides it: exact ICE columns from the growing position store
+        (global), or the transient `data[mask]` retouch off the cached
+        positions (masked) — the one documented model-touching exception."""
+        return self._eval_payload(feature, params, x)
+
+    def _compute_norm_const(
+        self,
+        feature: int,
+        method: str,
+        params: dict,
+        mask: Optional[np.ndarray] = None,
+    ) -> float:
+        """Derive the centering constant from the payload: `zero_integral` =
+        the mean over the (effective) feature interval, `zero_start` = the
+        value at its left limit. Pure numpy; (d-)PDP overrides it with the
+        per-instance variant read off the cached ICE columns."""
+        assert method in ["zero_integral", "zero_start"]
+
+        def partial_eval(x):
+            return self._eval_payload(feature, params, x)
+
+        if self._is_cat(feature):
+            # discrete centering (method_semantics.md): zero_integral is the
+            # frequency-weighted level mean (order-invariant); zero_start
+            # zeroes the first level *in fit order* (a custom `order` makes
+            # its first entry the reference level)
+            levels, weights = self._level_weights(feature, mask)
+            if method == "zero_integral":
+                return float(np.average(partial_eval(levels), weights=weights))
+            fit_levels = params.get("levels", levels)
+            return partial_eval(np.asarray(fit_levels[:1])).item()
+
+        start, stop = self._effective_limits(feature, mask)
+        if method == "zero_integral":
+            return utils.mean_1d_linspace(
+                partial_eval, start, stop, helpers.NOF_INTERNAL_POINTS
+            )
+        return partial_eval(np.array([start])).item()
+
+    def _mean_norm_const(self, norm_const):
+        """The scalar amount the centered mean effect subtracts. It is a scalar
+        for most methods (ALE/RHALE/ShapDP), so the value is returned as is;
+        PDP overrides this because its constant is a per-instance array."""
+        return norm_const
+
+    def _avg_output(self, mask: Optional[np.ndarray], scale_y: Optional[dict]) -> float:
+        """The (masked) average model output for plots — from the `_y_pred`
+        cache, computed once per object (the plot layer never calls the model)."""
+        if self._y_pred is None:
+            self._y_pred = np.asarray(self.model(self.data))
+        y = self._y_pred if mask is None else self._y_pred[mask]
+        return helpers.prep_avg_output(None, None, float(np.mean(y)), scale_y)
 
     def _prep_mask(self, mask) -> Optional[np.ndarray]:
         """Normalize a user `mask` to a boolean `(N,)` array (`None` passes
@@ -394,79 +422,117 @@ class GlobalEffectBase(ABC):
             self.feature_names[feature],
         )
 
+    # ------------------------------------------------------------------
+    # fit: declare the config + warm the caches (R1/R14)
+    # ------------------------------------------------------------------
+    @abstractmethod
+    def fit(
+        self,
+        features: Union[int, str, list] = "all",
+        centering: Union[bool, str] = False,
+        **kwargs,
+    ) -> None:
+        """Declare the method configuration for the given features and warm the
+        caches. Nothing fit does is unavailable lazily: any `eval`/`plot` on an
+        unfitted feature silently computes what it needs with the defaults.
+
+        Args:
+            features: the features to fit. If set to "all", all the features will be fitted.
+            centering: the default centering mode this feature is queried with
+
+                    - If `centering` is `False`, effects are not centered
+                    - If `centering` is `True` or `zero_integral`, the effect is centered around the `y` axis.
+                    - If `centering` is `zero_start`, the effect starts from zero.
+        """
+        raise NotImplementedError
+
     def _fit_loop(
         self,
         features: Union[int, str, list],
         centering: Union[bool, str],
-        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         **fit_feature_kwargs,
     ) -> None:
-        """The one fit skeleton every method shares (R1): normalize inputs,
-        compute the per-feature payload, then the normalization constant."""
+        """The one fit skeleton every method shares (R1): record the declared
+        config, bump the epoch (the config may have changed — old summaries
+        must become unreachable), then warm cache (a) and the all-ones payload
+        (plus the centering constant, if a mode was declared)."""
         features = helpers.prep_features(features, self.dim)
         centering = helpers.prep_centering(centering)
         for s in features:
             self._check_feature_type_supported(s)
-            key = "feature_" + str(s)
-            self.fit_args[key] = {
+            self.fit_args["feature_" + str(s)] = {
                 "centering": centering,
-                "points_for_centering": points_for_centering,
                 **fit_feature_kwargs,
             }
-            self.feature_effect[key] = self._fit_feature(s, **fit_feature_kwargs)
-            self.feature_effect[key]["norm_const"] = (
-                self._compute_norm_const(
-                    s, method=centering, nof_points=points_for_centering
-                )
-                if centering is not False
-                else None
-            )
+            self._bump_epoch(s)
+            self._ensure_local(s)
+            self._summary(s, None)
+            if centering is not False:
+                self._centering_const(s, None, centering)
             self.is_fitted[s] = True
-            # fitted state (fit_args/payload) changed -> invalidate masked memo
-            self._fit_epoch[key] = self._fit_epoch.get(key, 0) + 1
 
-    def _compute_norm_const(
+    # ------------------------------------------------------------------
+    # public queries (R1/R2/R11/R13) — thin wrappers over the two gates
+    # ------------------------------------------------------------------
+    def eval(
         self,
         feature: int,
-        method: str = "zero_integral",
-        nof_points: int = helpers.NOF_INTERNAL_POINTS,
-        params: Optional[dict] = None,
+        xs: np.ndarray,
+        centering: Union[None, bool, str] = None,
         mask: Optional[np.ndarray] = None,
-    ) -> float:
-        """Compute the normalization constant from the evaluation kernel:
-        `zero_integral` = the mean over the feature interval, `zero_start` =
-        the value at its left limit.
+    ) -> np.ndarray:
+        """Evaluate the mean effect of the `feature`-th feature at positions `xs`.
 
-        With `params`/`mask` (the masked path), the constant belongs to a
-        *transient* subregion payload: the integral runs over the subregion's
-        effective interval (its own `[min, max]`, not the global frame) and the
-        level weights are those within the mask. Nothing is stored."""
-        assert method in ["zero_integral", "zero_start"]
+        Notes:
+            This is the one evaluation method of every effect class (R1): it
+            always returns the mean effect as a single `(T,)` array.
+            Heterogeneity lives on its own surface — `eval_heter(feature, xs)`
+            for the curve, `heter_score(feature)` for the scalar, and
+            `payload(feature)` for the method's raw object.
 
-        def partial_eval(x):
-            return self._eval_unnorm(feature, x, heterogeneity=False, params=params)
+        Args:
+            feature: index of feature of interest
+            xs: the points along the s-th axis to evaluate the effect at
 
-        if self._is_cat(feature):
-            # discrete centering (method_semantics.md): zero_integral is the
-            # frequency-weighted level mean (order-invariant); zero_start
-            # zeroes the first level *in fit order* (a custom `order` makes
-            # its first entry the reference level)
-            levels, weights = self._level_weights(feature, mask)
-            if method == "zero_integral":
-                return float(np.average(partial_eval(levels), weights=weights))
-            source = (
-                params
-                if params is not None
-                else self.feature_effect.get("feature_" + str(feature), {})
+              - `np.ndarray` of shape `(T, )`
+
+            centering: whether to center the effect
+
+                - `None` (default) uses the class default (`DEFAULT_CENTERING`)
+                - `False`: no centering
+                - `True` or `"zero_integral"`: center around the `y` axis
+                - `"zero_start"`: the effect starts from `y=0`
+
+            mask: optional boolean `(N,)` selecting a subregion. `None`
+                (default) evaluates over all instances; a mask summarizes that
+                subset of the cached local effects on the fly — the effect
+                *within* the subregion, on the global frame, without model
+                calls. Centering is then computed over the subregion's own
+                interval. Nothing is stored.
+
+        Returns:
+            the mean effect `y` at the given `xs`, `(T,)`
+        """
+        centering = self.DEFAULT_CENTERING if centering is None else centering
+        centering = helpers.prep_centering(centering)
+        mask = self._prep_mask(mask)
+
+        if not self._is_cat(feature):
+            if mask is not None:
+                self._effective_limits(feature, mask)  # degeneracy guard
+            elif not self.axis_limits[0, feature] < self.axis_limits[1, feature]:
+                raise ValueError(
+                    f"Feature {feature} has a degenerate axis interval "
+                    f"[{self.axis_limits[0, feature]}, {self.axis_limits[1, feature]}]"
+                )
+
+        params = self._summary(feature, mask)
+        y = self._eval_mean(feature, xs, params, mask)
+        if centering is not False:
+            y = y - self._mean_norm_const(
+                self._centering_const(feature, mask, centering)
             )
-            fit_levels = source.get("levels", levels)
-            return partial_eval(np.asarray(fit_levels[:1])).item()
-
-        start, stop = self._effective_limits(feature, mask)
-
-        if method == "zero_integral":
-            return utils.mean_1d_linspace(partial_eval, start, stop, nof_points)
-        return partial_eval(np.array([start])).item()
+        return y
 
     def eval_heter(
         self, feature: int, xs: np.ndarray, mask: Optional[np.ndarray] = None
@@ -487,7 +553,7 @@ class GlobalEffectBase(ABC):
             feature: index of feature of interest
             xs: the points to evaluate the heterogeneity at, `(T,)`
             mask: optional boolean `(N,)` selecting a subregion. `None` (default)
-                evaluates over the fitted state; a mask summarizes that subset of
+                evaluates over all instances; a mask summarizes that subset of
                 the cached local effects on the fly (the regional split search) —
                 pure numpy, no model calls.
 
@@ -495,22 +561,15 @@ class GlobalEffectBase(ABC):
             the heterogeneity curve h(xs), `(T,)`, non-negative
         """
         mask = self._prep_mask(mask)
-        if mask is None:
-            if self.requires_refit(feature, centering=False):
-                self._refit(feature)
-            return self._eval_unnorm(feature, xs, heterogeneity=True)[1]
-        self._ensure_local_effects(feature)
-        params = self._masked_params(feature, mask)
-        return self._eval_unnorm(feature, xs, heterogeneity=True, params=params)[1]
+        params = self._summary(feature, mask)
+        return self._eval_payload(feature, params, xs, heterogeneity=True)[1]
 
     def payload(self, feature: int) -> dict:
         """The method's raw fitted object for the `feature`-th feature — the
         honest method-specific state behind `eval`/`eval_heter` (bin effects
         and variances for (RH)ALE, splines and shap values for ShapDP, the
-        normalization constants for PDP)."""
-        if self.requires_refit(feature, centering=False):
-            self._refit(feature)
-        return dict(self.feature_effect["feature_" + str(feature)])
+        grid summaries for (d-)PDP): the all-ones summary (R14)."""
+        return dict(self._summary(feature, None))
 
     def heter_score(self, feature: int, mask: Optional[np.ndarray] = None) -> float:
         """The method-agnostic heterogeneity scalar of the `feature`-th
@@ -525,7 +584,8 @@ class GlobalEffectBase(ABC):
         if self._is_cat(feature):
             # frequency-weighted over levels (method_semantics.md); with a mask
             # the levels/frequencies are those within the subregion
-            levels, weights = self._level_weights(feature, mask)
+            mask_p = self._prep_mask(mask)
+            levels, weights = self._level_weights(feature, mask_p)
             return float(
                 np.average(self.eval_heter(feature, levels, mask), weights=weights)
             )
@@ -565,9 +625,7 @@ class GlobalEffectBase(ABC):
         from effector import space_partitioning  # lazy: one-way dep guard
 
         self._check_feature_type_supported(feature)
-        if self.requires_refit(feature, centering=False):
-            self._refit(feature)
-        self._ensure_local_effects(feature)
+        self._ensure_local(feature)
 
         if isinstance(finder, str):
             finder = space_partitioning.return_default(finder)
@@ -606,10 +664,10 @@ class GlobalEffectBase(ABC):
         self._check_feature_type_supported(feature)
         mask = self._prep_mask(mask)
         if mask is None:
-            # route through the masked (cached) path so PDP/DerPDP read the
-            # cached ICE instead of re-predicting; all-ones ≡ None (M1)
+            # all-ones ≡ None (M1); the concrete array makes the per-method
+            # `_importance` implementations mask-index without a null check
             mask = np.ones(self.data.shape[0], dtype=bool)
-        self._ensure_local_effects(feature)
+        self._ensure_local(feature)
         return float(self._importance(feature, mask))
 
     def _importance(self, feature: int, mask: np.ndarray) -> float:
@@ -617,7 +675,7 @@ class GlobalEffectBase(ABC):
         the μ-twin of `heter_score`, evaluated the same way it is. Continuous
         features use the uniform grid `heter_score` averages over; discrete
         features weight by level frequency. `centering=False` keeps it a pure
-        query — the std is invariant to centering and triggers no refit."""
+        query — the std is invariant to centering."""
         if self._is_cat(feature):
             levels, weights = self._level_weights(feature, mask)
             mu = self.eval(feature, levels, centering=False, mask=mask)
@@ -651,126 +709,30 @@ class GlobalEffectBase(ABC):
             )
         return out
 
-    def requires_refit(self, feature, centering):
-        """Check if refitting is needed."""
-        feature_key = f"feature_{feature}"
-
-        # if the state variable is not set, refit
-        if not self.is_fitted[feature]:
-            return True
-
-        # if the feature info does not exist, refit
-        if self.feature_effect.get(feature_key) is None:
-            return True
-
-        # if the above are ok and centering is False, no need to refit
-        if not centering:
-            return False
-
-        # if centering is not None and the norm_const is not set, refit
-        norm_const = self.feature_effect.get(feature_key, {}).get("norm_const")
-        if norm_const is None:
-            return True
-
-        # if centering is not None and is different from the centering when fitting, refit
-        if self.fit_args.get(feature_key, {}).get("centering") != centering:
-            return True
-
-        return False
-
-    def _mean_norm_const(self, norm_const):
-        """The scalar amount the centered mean effect subtracts. It is a scalar
-        for most methods (ALE/RHALE/ShapDP), so the stored value is returned as
-        is; PDP overrides this because its norm_const is a per-instance array."""
-        return norm_const
-
-    def _refit(self, feature: int, centering=None) -> None:
-        """Auto-refit for `feature`, replaying the kwargs of the user's last
-        explicit `fit` and overriding **only** `centering`. This keeps a
-        method-specific fit config (`order`, `binning_method`, …) intact when a
-        later `eval`/`plot` forces a refit because centering changed; without
-        it the refit would silently fall back to the method defaults.
-
-        Falls back to a plain default fit when the feature was never fitted
-        (nothing recorded to replay)."""
-        prev = self.fit_args.get("feature_" + str(feature))
-        if prev is None:
-            if centering is None:
-                self.fit(features=feature)
-            else:
-                self.fit(features=feature, centering=centering)
-            return
-        replay = {k: v for k, v in prev.items() if k != "centering"}
-        eff_centering = prev["centering"] if centering is None else centering
-        self._fit_loop(feature, eff_centering, **replay)
-
-    def eval(
+    @abstractmethod
+    def plot(
         self,
         feature: int,
-        xs: np.ndarray,
-        centering: Union[None, bool, str] = None,
-        mask: Optional[np.ndarray] = None,
-    ) -> np.ndarray:
-        """Evaluate the mean effect of the `feature`-th feature at positions `xs`.
-
-        Notes:
-            This is the one evaluation method of every effect class (R1): it
-            always returns the mean effect as a single `(T,)` array.
-            Heterogeneity lives on its own surface — `eval_heter(feature, xs)`
-            for the curve, `heter_score(feature)` for the scalar, and
-            `payload(feature)` for the method's raw object.
-
-        Args:
-            feature: index of feature of interest
-            xs: the points along the s-th axis to evaluate the effect at
-
-              - `np.ndarray` of shape `(T, )`
-
-            centering: whether to center the effect
-
-                - `None` (default) uses the class default (`DEFAULT_CENTERING`)
-                - `False`: no centering
-                - `True` or `"zero_integral"`: center around the `y` axis
-                - `"zero_start"`: the effect starts from `y=0`
-
-            mask: optional boolean `(N,)` selecting a subregion. `None`
-                (default) evaluates the fitted state; a mask summarizes that
-                subset of the cached local effects on the fly — the effect
-                *within* the subregion, on the global frame, without model
-                calls. Centering is then computed over the subregion's own
-                interval. Nothing is stored.
-
-        Returns:
-            the mean effect `y` at the given `xs`, `(T,)`
+        heterogeneity: Union[bool, str] = False,
+        centering: Union[bool, str] = False,
+        **kwargs,
+    ) -> None:
         """
-        centering = self.DEFAULT_CENTERING if centering is None else centering
-        centering = helpers.prep_centering(centering)
-        mask = self._prep_mask(mask)
 
-        if mask is not None:
-            if not self._is_cat(feature):
-                self._effective_limits(feature, mask)  # degeneracy guard
-            self._ensure_local_effects(feature)
-            params = self._masked_params(feature, mask)
-            y = self._eval_masked_mean(feature, xs, params, mask)
-            if centering is not False:
-                norm_const = self._compute_norm_const(
-                    feature, method=centering, params=params, mask=mask
-                )
-                y = y - self._mean_norm_const(norm_const)
-            return y
+        Parameters
+        ----------
+        feature: index of the feature to plot
+        heterogeneity: whether to plot the heterogeneity measures
 
-        if self.requires_refit(feature, centering):
-            self._refit(feature, centering)
+            - If `heterogeneity=False`, the plot shows only the mean effect
+            - If `heterogeneity=True`, the plot additionally shows the heterogeneity with the default visualization, e.g., ICE plots for PDPs
+            - If `heterogeneity=<str>`, the plot shows the heterogeneity using the specified method
 
-        if not self.axis_limits[0, feature] < self.axis_limits[1, feature]:
-            raise ValueError(
-                f"Feature {feature} has a degenerate axis interval "
-                f"[{self.axis_limits[0, feature]}, {self.axis_limits[1, feature]}]"
-            )
+        centering: whether to center the PDP
 
-        y = self._eval_unnorm(feature, xs)
-        if centering is not False:
-            norm_const = self.feature_effect["feature_" + str(feature)]["norm_const"]
-            y = y - self._mean_norm_const(norm_const)
-        return y
+                - If `centering` is `False`, the PDP not centered
+                - If `centering` is `True` or `zero_integral`, the PDP is centered around the `y` axis.
+                - If `centering` is `zero_start`, the PDP starts from `y=0`.
+        **kwargs: all other plot-specific arguments
+        """
+        raise NotImplementedError

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -1,5 +1,4 @@
 import typing
-from abc import abstractmethod
 from typing import List, Optional, Union
 
 import numpy as np
@@ -40,17 +39,21 @@ class ALEBase(GlobalEffectBase):
             random_state=random_state,
         )
 
-    @abstractmethod
-    def fit(self, features: typing.Union[int, str, list] = "all", **kwargs) -> None:
-        raise NotImplementedError
+    def _cat_frame(self, feature: int) -> tuple:
+        """The categorical frame (R14): the *declared* level order — the
+        resolution ("similarity" seriation, ascending default) is deterministic
+        given data + random_state, so comparing declarations equals comparing
+        resolutions without paying the resolution on every access."""
+        order = self._config(feature).get("order")
+        if order is None:
+            return ("order", "asc")
+        if isinstance(order, str):
+            return ("order", order)
+        return ("order", tuple(float(v) for v in np.asarray(order, dtype=float)))
 
-    def _eval_unnorm(
-        self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
+    def _eval_payload(
+        self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
     ):
-        # `params` (from `_summarize`) lets the masked heterogeneity path evaluate
-        # a transient subregion payload without disturbing the stored fitted one
-        if params is None:
-            params = self.feature_effect["feature_" + str(feature)]
         if params.get("is_cat"):
             # discrete kernel (method_semantics.md): accumulate in code space —
             # exact at levels, and h(v_j) is the variance of the step *into*
@@ -81,8 +84,7 @@ class ALEBase(GlobalEffectBase):
                 x=x, bin_limits=params["limits"], bin_value=params["bin_variance"]
             )
             return y, var
-        else:
-            return y
+        return y
 
     def _validate_order_arg(self, features, order):
         if order is None or isinstance(order, str):
@@ -95,39 +97,40 @@ class ALEBase(GlobalEffectBase):
                 "feature — call fit per feature"
             )
 
-    def _compute_local_effects_cat(self, feature: int, order=None) -> dict:
-        """Step 2 (categorical): two-sided adjacent-level differences in code
-        space — the discrete derivative (method_semantics.md). The levels (and
-        their order) are frozen from the full data, so a subregion re-bins the
-        same per-instance differences without re-querying the model."""
+    def _compute_local_cat(self, feature: int, frame: tuple) -> dict:
+        """Cache-(a) kernel (categorical): two-sided adjacent-level differences
+        in code space — the discrete derivative (method_semantics.md). The
+        levels (and their order) are frozen from the full data, so a subregion
+        re-bins the same per-instance differences without re-querying the
+        model."""
         levels = self._levels(feature)
         if len(levels) < 2:
             raise ValueError(
                 f"feature {feature} {self.feature_names[feature]!r} has a "
                 f"single level — no effect to compute"
             )
+        order = self._config(feature).get("order")
         if order is not None:
             levels = self._resolve_level_order(feature, levels, order)
         positions, effects, instance_idx = utils.compute_local_effects_categorical(
             self.data, self.model, levels, feature
         )
-        prim = {
+        return {
+            "frame": frame,
             "positions": positions,
             "effects": effects,
             "instance_idx": instance_idx,
             "levels": levels,
         }
-        self.local_effects["feature_" + str(feature)] = prim
-        return prim
 
     def _summarize_cat(
         self, feature: int, mask=None, binning_method=None
     ) -> typing.Dict:
-        """Step 3 (categorical): bin the cached adjacent-level differences over
-        the subregion `mask` (None = all). ALE keeps one bin per transition;
-        RHALE merges adjacent transitions with Greedy/DP (adaptive grouping)."""
-        self._ensure_local_effects(feature)
-        prim = self.local_effects["feature_" + str(feature)]
+        """Summary kernel (categorical): bin the cached adjacent-level
+        differences over the subregion `mask` (None = all). ALE keeps one bin
+        per transition; RHALE merges adjacent transitions with Greedy/DP
+        (adaptive grouping)."""
+        prim = self._local[feature]
         positions = prim["positions"]
         effects = prim["effects"]
         levels = prim["levels"]
@@ -152,14 +155,6 @@ class ALEBase(GlobalEffectBase):
         params["levels"] = levels
         params["is_cat"] = True
         return params
-
-    def _fit_feature_cat(
-        self, feature: int, binning_method=None, order=None
-    ) -> typing.Dict:
-        """The discrete (RH)ALE kernel (compute + summarize), used by the global
-        fit; `_summarize_cat` alone powers the masked split search."""
-        self._compute_local_effects_cat(feature, order)
-        return self._summarize_cat(feature, None, binning_method)
 
     def plot(
         self,
@@ -234,30 +229,18 @@ class ALEBase(GlobalEffectBase):
         if feature_label is not None:
             feature_names[feature] = feature_label
 
-        if mask is None:
-            # fit the feature if needed (the eval below reuses the stored state)
-            self.eval(
-                feature, np.array([self.axis_limits[0, feature]]), centering=centering
-            )
-            params = self.feature_effect["feature_" + str(feature)]
-            x_window = None
-        else:
-            # transient subregion payload from the cached local effects —
-            # pure numpy, nothing stored (the masked-plot path)
-            self._ensure_local_effects(feature)
-            params = self._masked_params(feature, mask)
-            x_window = (
-                None if params.get("is_cat") else self._effective_limits(feature, mask)
-            )
+        # one path for global and masked alike (R14): pick the payload, read it
+        params = self._summary(feature, mask)
+        x_window = (
+            self._effective_limits(feature, mask)
+            if mask is not None and not params.get("is_cat")
+            else None
+        )
 
         def centered_eval(xs):
-            if mask is None:
-                return self.eval(feature, xs, centering=centering)
-            y = self._eval_unnorm(feature, xs, params=params)
+            y = self._eval_payload(feature, params, xs)
             if centering is not False:
-                y = y - self._compute_norm_const(
-                    feature, method=centering, params=params, mask=mask
-                )
+                y = y - self._centering_const(feature, mask, centering)
             return y
 
         # the accumulated curve is piecewise linear between bin limits, so
@@ -269,11 +252,7 @@ class ALEBase(GlobalEffectBase):
             x = np.asarray(params["limits"], dtype=float)
             y = centered_eval(x)
 
-        if show_avg_output:
-            data = self.data if mask is None else self.data[mask]
-            avg_output = helpers.prep_avg_output(data, self.model, None, scale_y)
-        else:
-            avg_output = None
+        avg_output = self._avg_output(mask, scale_y) if show_avg_output else None
 
         title = (
             "Accumulated Local Effects (ALE)"
@@ -286,7 +265,7 @@ class ALEBase(GlobalEffectBase):
             levels, labels = self._level_display(feature, params["levels"])
             y_levels = centered_eval(levels)
             variances = (
-                self._eval_unnorm(feature, levels, heterogeneity=True, params=params)[1]
+                self._eval_payload(feature, params, levels, heterogeneity=True)[1]
                 if heterogeneity is not False
                 else None
             )
@@ -432,40 +411,52 @@ class ALE(ALEBase):
             method_name="ALE",
         )
 
-    def _compute_local_effects(self, feature: int) -> None:
-        """Step 2: ALE's local effect is the secant of the model across each
-        fixed bin — *edge-bound* (it depends on the bin limits), so the bins are
-        frozen at the global Fixed grid and a subregion re-bins these same
-        secants rather than re-querying the model."""
+    @staticmethod
+    def _check_binning_is_fixed(binning_method) -> None:
+        if not (binning_method == "fixed" or isinstance(binning_method, ap.Fixed)):
+            raise ValueError(
+                f"Invalid binning_method: {binning_method!r}; ALE works only with "
+                "the fixed binning method ('fixed' or an ap.Fixed instance)"
+            )
+
+    def _frame_from_config(self, feature: int) -> tuple:
+        """ALE's local effect is *edge-bound* (the secant depends on the bin
+        limits), so the fixed grid IS the frame: changing it invalidates the
+        cached secants."""
         if self._is_cat(feature):
-            order = self.fit_args.get("feature_" + str(feature), {}).get("order")
-            self._compute_local_effects_cat(feature, order)
-            return
-        binning_method = self.fit_args.get("feature_" + str(feature), {}).get(
-            "binning_method", "fixed"
+            return self._cat_frame(feature)
+        binning_method = self._config(feature).get("binning_method", "fixed")
+        binning = ap.Fixed() if isinstance(binning_method, str) else binning_method
+        return (
+            "fixed",
+            binning.params["nof_bins"],
+            binning.constraints.min_points_per_bin,
         )
-        if isinstance(binning_method, str):
-            binning_method = ap.Fixed()
-        limits = binning_method.find_limits(
+
+    def _compute_local(self, feature: int, frame: tuple) -> dict:
+        """Cache-(a) kernel: the secant of the model across each fixed bin —
+        computed on the frame's grid, one model query pair for all instances."""
+        if self._is_cat(feature):
+            return self._compute_local_cat(feature, frame)
+        binning_method = self._config(feature).get("binning_method", "fixed")
+        binning = ap.Fixed() if isinstance(binning_method, str) else binning_method
+        limits = binning.find_limits(
             self.data[:, feature], None, self.axis_limits[:, feature]
         )
-        utils.raise_if_no_binning(limits, feature, binning_method)
+        utils.raise_if_no_binning(limits, feature, binning)
         secants = utils.compute_local_effects(self.data, self.model, limits, feature)
-        self.local_effects["feature_" + str(feature)] = {
-            "effects": secants,
-            "limits": limits,
-        }
+        return {"frame": frame, "effects": secants, "limits": limits}
 
     def _summarize(
         self, feature: int, mask=None, binning_method="fixed", order=None
     ) -> typing.Dict:
-        """Step 3 (pure numpy): re-bin the cached secants over the subregion
-        `mask` (None = all) on the frozen global bins → bin effects/variances."""
+        """Summary kernel (pure numpy): re-bin the cached secants over the
+        subregion `mask` (None = all) on the frozen frame bins → bin
+        effects/variances."""
         if self._is_cat(feature):
             # ALE keeps one bin per transition (binning_method=None)
             return self._summarize_cat(feature, mask, None)
-        self._ensure_local_effects(feature)
-        prim = self.local_effects["feature_" + str(feature)]
+        prim = self._local[feature]
         secants, limits = prim["effects"], prim["limits"]
         col = self.data[:, feature]
         if mask is not None:
@@ -475,26 +466,11 @@ class ALE(ALEBase):
         dale_params["alg_params"] = "fixed"
         return dale_params
 
-    def _fit_feature(
-        self, feature: int, binning_method="fixed", order=None
-    ) -> typing.Dict:
-        if self._is_cat(feature):
-            return self._fit_feature_cat(feature, order=order)
-        if not (binning_method == "fixed" or isinstance(binning_method, ap.Fixed)):
-            raise ValueError(
-                f"Invalid binning_method: {binning_method!r}; ALE works only with "
-                "the fixed binning method ('fixed' or an ap.Fixed instance)"
-            )
-        return self._summarize(
-            feature, None, binning_method=binning_method, order=order
-        )
-
     def fit(
         self,
         features: typing.Union[int, str, list] = "all",
         *,
         centering: typing.Union[bool, str] = True,
-        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         binning_method: typing.Union[str, ap.Fixed] = "fixed",
         order: typing.Union[None, str, list] = None,
     ) -> None:
@@ -512,13 +488,11 @@ class ALE(ALEBase):
                 class `effector.axis_partitioning.Fixed` with the desired parameters.
                 For example: `Fixed(nof_bins=20, min_points_per_bin=0)`
 
-            centering: whether to compute the normalization constant for centering the plot:
+            centering: the default centering mode for this feature's queries:
 
                 - `False` means no centering
                 - `True` or `zero_integral` centers around the `y` axis.
                 - `zero_start` starts the plot from `y=0`.
-
-            points_for_centering: the number of points to use for centering the plot. Default is 30.
 
             order: level order for a *categorical* feature of interest
 
@@ -532,20 +506,16 @@ class ALE(ALEBase):
                 - a list of the levels: declare it explicitly (applies to
                   exactly one categorical feature)
 
-                Changing `order` requires calling `fit` again; `eval`/`plot`
-                reuse the fitted order.
+                Changing `order` changes the frame (R14): the next query
+                recomputes the local effects; the same `order` re-fitted is
+                a cache hit.
         """
-        if not (binning_method == "fixed" or isinstance(binning_method, ap.Fixed)):
-            raise ValueError(
-                f"Invalid binning_method: {binning_method!r}; ALE works only with "
-                "the fixed binning method ('fixed' or an ap.Fixed instance)"
-            )
+        self._check_binning_is_fixed(binning_method)
         self._validate_order_arg(features, order)
 
         self._fit_loop(
             features,
             centering,
-            points_for_centering,
             binning_method=binning_method,
             order=order,
         )
@@ -661,25 +631,29 @@ class RHALE(ALEBase):
         )
 
     def _fill_jacobian(self):
-        """Compute the model Jacobian on the data (step 2 raw material): exact
-        via `model_jac`, else numerically. Runs at most once."""
+        """Compute the model Jacobian on the data (shared cache-(a) raw
+        material): exact via `model_jac`, else numerically. Runs at most once
+        per object — every feature's local effect is a column view of it."""
         if self.data_effect is None and self.model_jac is not None:
             self.data_effect = self.model_jac(self.data)
         elif self.data_effect is None and self.model_jac is None:
             self.data_effect = utils.compute_jacobian_numerically(self.model, self.data)
 
-    def _compute_local_effects(self, feature: int) -> None:
-        """Step 2: RHALE's local effect is the pointwise derivative — a column
-        of the model Jacobian, independent of the binning (so re-binning a
-        subregion needs no model calls)."""
+    def _frame_from_config(self, feature: int) -> tuple:
+        """RHALE's continuous local effect is the pointwise derivative —
+        instance-anchored, no frame (binning is a summary-stage parameter).
+        Categorical features share the (RH)ALE order frame."""
+        if self._is_cat(feature):
+            return self._cat_frame(feature)
+        return ()
+
+    def _compute_local(self, feature: int, frame: tuple) -> dict:
         if self._is_cat(feature):
             # ordinal kernel: adjacent-level differences are the discrete
             # derivative; the jacobian (if any) is ignored for this feature
-            order = self.fit_args.get("feature_" + str(feature), {}).get("order")
-            self._compute_local_effects_cat(feature, order)
-            return
+            return self._compute_local_cat(feature, frame)
         self._fill_jacobian()
-        self.local_effects["feature_" + str(feature)] = self.data_effect[:, feature]
+        return {"frame": frame, "effects": self.data_effect[:, feature]}
 
     def _summarize(
         self,
@@ -691,8 +665,9 @@ class RHALE(ALEBase):
         order=None,
         binning_scope: str = "global",
     ) -> typing.Dict:
-        """Step 3 (pure numpy): bin the cached per-instance jacobian over the
-        subregion `mask` (None = all) and derive the bin effects/variances.
+        """Summary kernel (pure numpy): bin the cached per-instance jacobian
+        over the subregion `mask` (None = all) and derive the bin
+        effects/variances.
 
         `binning_scope` (masked only): the x-range handed to the binner —
         `"global"` keeps the frozen global frame (one frame for the split
@@ -702,8 +677,7 @@ class RHALE(ALEBase):
             # ordinal: merge adjacent transitions with the chosen binning
             # (code-space bins — binning_scope does not apply)
             return self._summarize_cat(feature, mask, binning_method)
-        self._ensure_local_effects(feature)
-        eff = self.local_effects["feature_" + str(feature)]
+        eff = self._local[feature]["effects"]
         col = self.data[:, feature]
         if mask is not None:
             eff = eff[mask]
@@ -725,33 +699,11 @@ class RHALE(ALEBase):
         dale_params["alg_params"] = binning
         return dale_params
 
-    def _fit_feature(
-        self,
-        feature: int,
-        binning_method: Union[
-            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
-        ] = "dp",
-        order=None,
-        binning_scope: str = "global",
-    ) -> typing.Dict:
-        if self._is_cat(feature):
-            # ordinal kernel: adjacent-level differences are the discrete
-            # derivative; the jacobian (if any) is ignored for this feature
-            return self._fit_feature_cat(feature, binning_method, order=order)
-        return self._summarize(
-            feature,
-            None,
-            binning_method=binning_method,
-            order=order,
-            binning_scope=binning_scope,
-        )
-
     def fit(
         self,
         features: typing.Union[int, str, list] = "all",
         *,
         centering: typing.Union[bool, str] = True,
-        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         binning_method: typing.Union[
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
@@ -774,13 +726,11 @@ class RHALE(ALEBase):
                 - Use `"fixed"` for using a Fixed binning solution with the default parameters.
                   For custom parameters initialize a `axis_partitioning.Fixed` object
 
-            centering: whether to compute the normalization constant for centering the plot:
+            centering: the default centering mode for this feature's queries:
 
                 - `False` means no centering
                 - `True` or `zero_integral` centers around the `y` axis
                 - `zero_start` starts the plot from `y=0`
-
-            points_for_centering: the number of points to use for centering the plot. Default is 30.
 
             order: level order for a *categorical* feature of interest
 
@@ -794,8 +744,9 @@ class RHALE(ALEBase):
                 - a list of the levels: declare it explicitly (applies to
                   exactly one categorical feature)
 
-                Changing `order` requires calling `fit` again; `eval`/`plot`
-                reuse the fitted order.
+                Changing `order` changes the frame (R14): the next query
+                recomputes the local effects; the same `order` re-fitted is
+                a cache hit.
 
             binning_scope: the x-range the binner covers when a *masked*
                 summary re-bins a subregion (`eval`/`eval_heter`/`plot`/
@@ -818,7 +769,6 @@ class RHALE(ALEBase):
         self._fit_loop(
             features,
             centering,
-            points_for_centering,
             binning_method=binning_method,
             order=order,
             binning_scope=binning_scope,

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -147,9 +147,7 @@ class PDPBase(GlobalEffectBase):
             return (y, params["heter"][codes]) if heterogeneity else y
         y = np.interp(x, params["grid"], params["mean"])
         return (
-            (y, np.interp(x, params["grid"], params["heter"]))
-            if heterogeneity
-            else y
+            (y, np.interp(x, params["grid"], params["heter"])) if heterogeneity else y
         )
 
     def _eval_mean(
@@ -171,7 +169,9 @@ class PDPBase(GlobalEffectBase):
         idx = np.clip(np.searchsorted(pos, x), 0, len(pos) - 1)
         if np.all(pos[idx] == x):
             return entry["ice"][idx][:, mask].mean(axis=1)
-        y_ice = self._predict(self.data[mask], x, feature, self._use_vectorized(feature))
+        y_ice = self._predict(
+            self.data[mask], x, feature, self._use_vectorized(feature)
+        )
         return np.mean(y_ice, axis=1)
 
     def _compute_norm_const(
@@ -331,9 +331,9 @@ class PDPBase(GlobalEffectBase):
                 )
             if heterogeneity is not False:
                 params = self._summary(feature, mask)
-                variances = self._eval_payload(
-                    feature, params, x, heterogeneity=True
-                )[1]
+                variances = self._eval_payload(feature, params, x, heterogeneity=True)[
+                    1
+                ]
             else:
                 variances = None
             return vis.plot_categorical_effect(

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -47,41 +47,71 @@ class PDPBase(GlobalEffectBase):
             y = method(self.model, self.model_jac, data, xx, feature, True)
         return y
 
-    def _fit_feature(self, feature: int, use_vectorized: bool = True) -> dict:
-        # the (d-)PDP stores no per-feature payload beyond the normalization
-        # constant (which the base fit loop appends); ICE curves are computed
-        # by the evaluation kernel
-        if self._is_cat(feature):
-            return {"levels": self._levels(feature), "is_cat": True}
-        return {}
+    def _use_vectorized(self, feature: int) -> bool:
+        return self._config(feature).get("use_vectorized", True)
 
-    def _compute_local_effects(self, feature: int) -> None:
-        """Step 2 (model-touching): the (d-)ICE table on the heterogeneity grid
-        — one row per grid point, one column per instance `(T, N)`. This is the
-        (d-)PDP's per-instance local effect; the split search re-scores column
-        subsets of it without re-querying the model."""
-        use_vectorized = self.fit_args.get("feature_" + str(feature), {}).get(
-            "use_vectorized", True
+    def _canonical_grid(self, feature: int) -> np.ndarray:
+        """The frozen summary frame: the observed levels for a discrete
+        feature, else the uniform `NOF_INTERNAL_POINTS` grid on the global
+        interval. Every (b)-stage quantity (payload, heterogeneity, centering
+        constants) is a function of these rows only, so position-store growth
+        never changes a summary."""
+        if self._is_cat(feature):
+            return self._levels(feature)
+        return np.linspace(
+            self.axis_limits[0, feature],
+            self.axis_limits[1, feature],
+            helpers.NOF_INTERNAL_POINTS,
         )
-        if self._is_cat(feature):
-            grid = self._levels(feature)
-        else:
-            grid = np.linspace(
-                self.axis_limits[0, feature],
-                self.axis_limits[1, feature],
-                helpers.NOF_INTERNAL_POINTS,
-            )
-        ice = self._predict(self.data, grid, feature, use_vectorized)  # (T, N)
-        self.local_effects["feature_" + str(feature)] = {"grid": grid, "ice": ice}
 
+    # ------------------------------------------------------------------
+    # cache (a): the growing position store
+    # ------------------------------------------------------------------
+    def _compute_local(self, feature: int, frame: tuple) -> dict:
+        """Cache-(a) kernel: the (d-)ICE table on the canonical grid — one row
+        per position, one column per instance `(T, N)`. The store then grows
+        as `eval` asks for never-before-seen positions (missing-only)."""
+        grid = self._canonical_grid(feature)
+        ice = self._predict(self.data, grid, feature, self._use_vectorized(feature))
+        return {"frame": frame, "pos": grid, "ice": ice}
+
+    def _ensure_positions(self, feature: int, xs: np.ndarray) -> dict:
+        """Grow the position store to cover `xs`: compute ICE columns for the
+        missing positions only (the one model touch of the global eval path)
+        and append them. Growth is additive — no epoch bump, no summary is
+        invalidated (they read the canonical rows only)."""
+        entry = self._ensure_local(feature)
+        xs = np.unique(np.asarray(xs, dtype=float))
+        pos = entry["pos"]
+        idx = np.clip(np.searchsorted(pos, xs), 0, len(pos) - 1)
+        missing = xs[pos[idx] != xs]
+        if missing.size:
+            new_ice = self._predict(
+                self.data, missing, feature, self._use_vectorized(feature)
+            )
+            pos = np.concatenate([pos, missing])
+            order = np.argsort(pos, kind="mergesort")
+            entry["pos"] = pos[order]
+            entry["ice"] = np.concatenate([entry["ice"], new_ice], axis=0)[order]
+        return entry
+
+    def _grid_rows(self, feature: int, entry: dict):
+        """(grid, ice-rows) restricted to the canonical grid — the frame every
+        summary is computed on, regardless of how far the store has grown."""
+        grid = self._canonical_grid(feature)
+        rows = np.searchsorted(entry["pos"], grid)
+        return grid, entry["ice"][rows]
+
+    # ------------------------------------------------------------------
+    # the pure kernels
+    # ------------------------------------------------------------------
     def _summarize(self, feature: int, mask=None, use_vectorized: bool = True) -> dict:
-        """Step 3 (pure numpy): from the cached (d-)ICE table restricted to the
-        subregion `mask` (None = all), the mean curve and the heterogeneity curve
-        on the grid — cross-instance variance of the per-instance-centered ICE
-        curves (PDP) or of the raw d-ICE curves (DerPDP)."""
-        self._ensure_local_effects(feature)
-        prim = self.local_effects["feature_" + str(feature)]
-        grid, ice = prim["grid"], prim["ice"]  # ice (T, N)
+        """Summary kernel (pure numpy): from the canonical-grid rows of the
+        cached (d-)ICE table restricted to the subregion `mask` (None = all),
+        the mean curve and the heterogeneity curve — cross-instance variance of
+        the per-instance-centered ICE curves (PDP) or of the raw d-ICE curves
+        (DerPDP)."""
+        grid, ice = self._grid_rows(feature, self._local[feature])
         if mask is not None:
             ice = ice[:, mask]
 
@@ -103,175 +133,111 @@ class PDPBase(GlobalEffectBase):
             out["levels"] = grid
         return out
 
+    def _eval_payload(
+        self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
+    ):
+        """Reader kernel: mean/heterogeneity off the canonical grid — exact at
+        grid positions (levels are always on it), linear interpolation between
+        them."""
+        if params.get("is_cat"):
+            codes = utils.codes_from_levels(
+                x, params["levels"], feature, self.feature_names[feature]
+            )
+            y = params["mean"][codes]
+            return (y, params["heter"][codes]) if heterogeneity else y
+        y = np.interp(x, params["grid"], params["mean"])
+        return (
+            (y, np.interp(x, params["grid"], params["heter"]))
+            if heterogeneity
+            else y
+        )
+
+    def _eval_mean(
+        self, feature: int, x: np.ndarray, params: dict, mask: Optional[np.ndarray]
+    ) -> np.ndarray:
+        """The (d-)PDP mean effect is *exact*, not interpolated: global calls
+        read (and grow) the position store; masked calls read cached columns
+        when every position is present, else recompute ICE on `data[mask]`
+        transiently — the one documented model-touching exception (R14)."""
+        if self._is_cat(feature):
+            return self._eval_payload(feature, params, x)  # levels validated inside
+        x = np.asarray(x, dtype=float)
+        if mask is None:
+            entry = self._ensure_positions(feature, x)
+            rows = np.searchsorted(entry["pos"], x)
+            return entry["ice"][rows].mean(axis=1)
+        entry = self._local[feature]
+        pos = entry["pos"]
+        idx = np.clip(np.searchsorted(pos, x), 0, len(pos) - 1)
+        if np.all(pos[idx] == x):
+            return entry["ice"][idx][:, mask].mean(axis=1)
+        y_ice = self._predict(self.data[mask], x, feature, self._use_vectorized(feature))
+        return np.mean(y_ice, axis=1)
+
     def _compute_norm_const(
         self,
         feature: int,
-        method: str = "zero_integral",
-        nof_points: int = helpers.NOF_INTERNAL_POINTS,
-        params: Optional[dict] = None,
+        method: str,
+        params: dict,
         mask: Optional[np.ndarray] = None,
     ):
-        """(d-)PDP overrides the base: its normalization constant is
-        *per-instance* — each ICE curve is centered on its own — so an
-        `(N,)` array is stored instead of a scalar.
-
-        The masked path is model-free: the constants come from the cached ICE
-        table's masked columns, integrated over the subregion's effective
-        interval (linear interpolation between grid rows)."""
+        """(d-)PDP overrides the base: its centering constant is *per-instance*
+        — each ICE curve is centered on its own — so an array is returned
+        instead of a scalar, derived from the canonical-grid columns (masked
+        columns for a masked call), zero model calls (R14)."""
         assert method in ["zero_integral", "zero_start"]
+        grid, ice = self._grid_rows(feature, self._local[feature])
         if mask is not None:
-            prim = self.local_effects["feature_" + str(feature)]
-            grid, ice = prim["grid"], prim["ice"][:, mask]
-            if self._is_cat(feature):
-                # weights of the levels *within* the mask, aligned to the grid
-                # (= the globally observed levels); absent levels weigh zero
-                levels, weights = self._level_weights(feature, mask)
-                if method == "zero_integral":
-                    w = np.zeros(len(grid))
-                    w[np.searchsorted(grid, levels)] = weights
-                    return np.average(ice, axis=0, weights=w)
-                return ice[np.searchsorted(grid, levels[0])]
-            lo, hi = self._effective_limits(feature, mask)
-            if method == "zero_integral":
-                xs = np.linspace(lo, hi, nof_points)
-                return np.mean(_interp_columns(grid, ice, xs), axis=0)
-            return _interp_columns(grid, ice, np.array([lo]))[0]
-        use_vectorized = self.fit_args.get("feature_" + str(feature), {}).get(
-            "use_vectorized", True
-        )
+            ice = ice[:, mask]
         if self._is_cat(feature):
-            levels, weights = self._level_weights(feature)
+            # weights of the levels *within* the mask, aligned to the grid
+            # (= the globally observed levels); absent levels weigh zero
+            levels, weights = self._level_weights(feature, mask)
             if method == "zero_integral":
-                y = self._predict(self.data, levels, feature, use_vectorized)
-                return np.average(y, axis=0, weights=weights)
-            y = self._predict(self.data, levels[:1], feature, use_vectorized)
-            return y[0]
+                w = np.zeros(len(grid))
+                w[np.searchsorted(grid, levels)] = weights
+                return np.average(ice, axis=0, weights=w)
+            return ice[np.searchsorted(grid, levels[0])]
+        lo, hi = self._effective_limits(feature, mask)
         if method == "zero_integral":
-            xx = np.linspace(
-                self.axis_limits[0, feature],
-                self.axis_limits[1, feature],
-                nof_points,
-            )
-            y = self._predict(self.data, xx, feature, use_vectorized)
-            return np.mean(y, axis=0)
-        xx = self.axis_limits[0, feature, np.newaxis]
-        y = self._predict(self.data, xx, feature, use_vectorized)
-        return y[0]
+            xs = np.linspace(lo, hi, helpers.NOF_INTERNAL_POINTS)
+            return np.mean(_interp_columns(grid, ice, xs), axis=0)
+        return _interp_columns(grid, ice, np.array([lo]))[0]
 
     def _mean_norm_const(self, norm_const):
-        # PDP's norm_const is per-instance (each ICE centers on its own); the
+        # PDP's constant is per-instance (each ICE centers on its own); the
         # mean-effect shift is their average
         return np.mean(norm_const)
-
-    def _eval_unnorm(
-        self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
-    ):
-        """Kernel: uncentered mean (d-)ICE at `x`; with `heterogeneity`, also
-        h(x) — the variance across the *per-instance centered* ICE curves for
-        the PDP (levels are only comparable after centering) and across the raw
-        d-ICE curves for the DerPDP (slopes are directly comparable).
-
-        When `params` (from `_summarize`) is given, read the mean/heterogeneity
-        off the cached grid — the model-free masked path used by the regional
-        split search — instead of re-querying the model at `x`."""
-        if params is not None:
-            if params.get("is_cat"):
-                codes = utils.codes_from_levels(
-                    x, params["levels"], feature, self.feature_names[feature]
-                )
-                y = params["mean"][codes]
-                return (y, params["heter"][codes]) if heterogeneity else y
-            y = np.interp(x, params["grid"], params["mean"])
-            return (
-                (y, np.interp(x, params["grid"], params["heter"]))
-                if heterogeneity
-                else y
-            )
-
-        if self._is_cat(feature):
-            # discrete features are evaluated only at levels (R10)
-            utils.codes_from_levels(
-                x, self._levels(feature), feature, self.feature_names[feature]
-            )
-        y_ice = self._predict(self.data, x, feature, use_vectorized=True)
-        y_mean = np.mean(y_ice, axis=1)
-        if not heterogeneity:
-            return y_mean
-
-        if self.method_name == "pdp":
-            if self._is_cat(feature):
-                levels, weights = self._level_weights(feature)
-                per_instance_norm = np.average(
-                    self._predict(self.data, levels, feature, use_vectorized=True),
-                    axis=0,
-                    weights=weights,
-                )
-            else:
-                xx = np.linspace(
-                    self.axis_limits[0, feature],
-                    self.axis_limits[1, feature],
-                    helpers.NOF_INTERNAL_POINTS,
-                )
-                per_instance_norm = np.mean(
-                    self._predict(self.data, xx, feature, use_vectorized=True), axis=0
-                )
-            y_var = np.var(y_ice - per_instance_norm[np.newaxis, :], axis=1)
-        else:
-            y_var = np.var(y_ice, axis=1)
-        return y_mean, y_var
-
-    def _eval_masked_mean(
-        self, feature: int, x: np.ndarray, params: dict, mask: np.ndarray
-    ) -> np.ndarray:
-        """Masked mean (d-)ICE: read the cached-grid payload when `x` lies on
-        it (levels are always on it), otherwise recompute ICE on `data[mask]`
-        at `x` — the exact-evaluation retouch, symmetric with the global
-        (d-)PDP `eval` (the one model-touching exception of the masked path)."""
-        if params.get("is_cat"):
-            return self._eval_unnorm(feature, x, params=params)
-        grid = params["grid"]
-        on_grid = np.isclose(x[:, None], grid[None, :]).any(axis=1).all()
-        if on_grid:
-            return self._eval_unnorm(feature, x, params=params)
-        use_vectorized = self.fit_args.get("feature_" + str(feature), {}).get(
-            "use_vectorized", True
-        )
-        y_ice = self._predict(self.data[mask], x, feature, use_vectorized)
-        return np.mean(y_ice, axis=1)
 
     def fit(
         self,
         features: Union[int, str, list] = "all",
         *,
         centering: Union[bool, str] = False,
-        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         use_vectorized: bool = True,
     ):
         """
         Fit the Feature effect to the data.
 
         Notes:
-            You can use `.eval` or `.plot` without calling `.fit` explicitly.
-            The only thing that `.fit` does is to compute the normalization constant for centering the PDP and ICE plots.
-            This will be automatically done when calling `eval` or `plot`, so there is no need to call `fit` explicitly.
+            You can use `.eval` or `.plot` without calling `.fit` explicitly:
+            any query computes what it needs lazily with these defaults. `fit`
+            declares the config and warms the caches (R14).
 
         Args:
             features: the features to fit.
                 - If set to "all", all the features will be fitted.
 
-            centering: whether to center the plot:
+            centering: the default centering mode for this feature's queries:
 
                 - `False` means no centering
                 - `True` or `zero_integral` centers around the `y` axis.
                 - `zero_start` starts the plot from `y=0`.
 
-            points_for_centering: number of linspaced points along the feature axis used for centering.
             use_vectorized: whether to use vectorized operations for the PDP and ICE curves
 
         """
-        self._fit_loop(
-            features, centering, points_for_centering, use_vectorized=use_vectorized
-        )
+        self._fit_loop(features, centering, use_vectorized=use_vectorized)
 
     def _plot(
         self,
@@ -302,34 +268,28 @@ class PDPBase(GlobalEffectBase):
 
         is_cat = self._is_cat(feature)
         if mask is None:
-            x = (
-                self._levels(feature)
-                if is_cat
-                else np.linspace(
+            # the display grid joins the position store (grown missing-only),
+            # so a repeated plot costs zero model calls
+            if is_cat:
+                entry = self._ensure_local(feature)
+                x = entry["pos"]
+                yy = entry["ice"]
+            else:
+                x = np.linspace(
                     self.axis_limits[0, feature],
                     self.axis_limits[1, feature],
                     nof_points,
                 )
-            )
-
-            # the ICE table is the method's own object: computed by the kernel
-            # and centered with the stored per-instance norms (payload state)
-            if self.requires_refit(feature, centering):
-                self._refit(feature, centering)
-            yy = self._predict(self.data, x, feature, use_vectorized)
-            if centering is not False:
-                norm_consts = self.feature_effect["feature_" + str(feature)][
-                    "norm_const"
-                ]
-                yy = yy - norm_consts[np.newaxis, :]
+                entry = self._ensure_positions(feature, x)
+                rows = np.searchsorted(entry["pos"], x)
+                yy = entry["ice"][rows]
         else:
-            # masked branch: the cached ICE table's masked columns at grid
-            # resolution — no model calls; `nof_points` does not apply. The x
-            # arrays are cropped to the subregion's effective interval, so the
-            # figure windows itself to the region.
-            self._ensure_local_effects(feature)
-            prim = self.local_effects["feature_" + str(feature)]
-            grid, ice_m = prim["grid"], prim["ice"][:, mask]
+            # masked branch: the canonical-grid rows' masked columns — no model
+            # calls; `nof_points` does not apply. The x array is cropped to the
+            # subregion's effective interval, so the figure windows itself.
+            entry = self._ensure_local(feature)
+            grid, ice = self._grid_rows(feature, entry)
+            ice_m = ice[:, mask]
             if is_cat:
                 x = grid
                 yy = ice_m
@@ -337,17 +297,11 @@ class PDPBase(GlobalEffectBase):
                 lo, hi = self._effective_limits(feature, mask)
                 x = np.concatenate([[lo], grid[(grid > lo) & (grid < hi)], [hi]])
                 yy = _interp_columns(grid, ice_m, x)
-            if centering is not False:
-                norm_consts = self._compute_norm_const(
-                    feature, method=centering, mask=mask
-                )
-                yy = yy - norm_consts[np.newaxis, :]
+        if centering is not False:
+            norm_consts = self._centering_const(feature, mask, centering)
+            yy = yy - norm_consts[np.newaxis, :]
 
-        if show_avg_output:
-            data = self.data if mask is None else self.data[mask]
-            avg_output = helpers.prep_avg_output(data, self.model, None, scale_y)
-        else:
-            avg_output = None
+        avg_output = self._avg_output(mask, scale_y) if show_avg_output else None
 
         title = (
             "Partial Dependence Plot (PDP)"
@@ -376,11 +330,9 @@ class PDPBase(GlobalEffectBase):
                     random_state=self.random_state,
                 )
             if heterogeneity is not False:
-                params = (
-                    self._masked_params(feature, mask) if mask is not None else None
-                )
-                variances = self._eval_unnorm(
-                    feature, x, heterogeneity=True, params=params
+                params = self._summary(feature, mask)
+                variances = self._eval_payload(
+                    feature, params, x, heterogeneity=True
                 )[1]
             else:
                 variances = None
@@ -401,9 +353,9 @@ class PDPBase(GlobalEffectBase):
                 show_plot=show_plot,
             )
         # R1: the method owns the compute. Derive the mean line and the
-        # std/std_err band here (from the ICE table we already have — one model
-        # pass, no re-eval); the plot layer only draws. The raw table is handed
-        # over only for the "ice" cloud, which genuinely needs every curve.
+        # std/std_err band here (from the ICE table we already have — cached
+        # columns, no re-eval); the plot layer only draws. The raw table is
+        # handed over only for the "ice" cloud, which genuinely needs every curve.
         y_mean = yy.mean(axis=1)
         band = None
         if heterogeneity == "std":
@@ -839,22 +791,6 @@ def ice_non_vectorized(
 
     Notes:
         The non-vectorized version is slower than the vectorized one, but it requires less memory.
-
-    Examples:
-        >>> # check the gradient of the PDP of a linear model
-        >>> import numpy as np
-        >>> model = lambda x: np.sum(x, axis=1)
-        >>> data = np.random.rand(100, 10)
-        >>> x = np.linspace(0.1, 1, 10)
-        >>> feature = 0
-        >>> y = ice_non_vectorized(model, data, x, feature, heterogeneity=False, model_returns_jac=False)
-        >>> (y[1:] - y[:-1]) / (x[1:] - x[:-1])
-        array([1., 1., 1., 1., 1., 1., 1., 1., 1.])
-        >>> # the derivative-ICE mean of a linear model
-        >>> d_ice = ice_non_vectorized(model, model_jac, data, x, feature, return_d_ice=True)
-        >>> d_ice.mean(axis=1)
-        array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])
-
 
     Args:
         model: The black-box function (N, D) -> (N) or the Jacobian wrt the input (N, D) -> (N, D)

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -220,10 +220,11 @@ class ShapDP(GlobalEffectBase):
             random_state=random_state,
         )
 
-    def _compute_local_effects(self, feature: int) -> None:
-        """Step 2: the SHAP values are the local effect — computed once by the
-        backend (or injected via `shap_values=`), feature-independent. Fill the
-        whole `(N,D)` table on first use and cache this feature's column."""
+    def _compute_local(self, feature: int, frame: tuple) -> dict:
+        """Cache-(a) kernel: the SHAP values are the local effect — computed
+        once per object by the backend (or injected via `shap_values=`),
+        feature-independent. Fill the whole `(N,D)` table on first use; each
+        feature's entry is a column view of it (no frame — instance-anchored)."""
         if self.shap_values is None:
             self.shap_values = _compute_shap_values(
                 self.model,
@@ -234,12 +235,12 @@ class ShapDP(GlobalEffectBase):
                 self.shap_explanation_kwargs,
                 self.random_state,
             )
-        self.local_effects["feature_" + str(feature)] = self.shap_values[:, feature]
+        return {"frame": frame, "phi": self.shap_values[:, feature]}
 
     def _importance(self, feature, mask):
         """R13 for SHAP: the canonical `mean(|phi_s|)` over the (masked)
         instances — `phi_s` is already the cached local effect."""
-        phi = self.local_effects["feature_" + str(feature)][mask]
+        phi = self._local[feature]["phi"][mask]
         return float(np.mean(np.abs(phi)))
 
     def _summarize(
@@ -258,8 +259,7 @@ class ShapDP(GlobalEffectBase):
         `binning_scope` (masked only): `"global"` bins over the frozen global
         frame, `"effective"` packs the bins into the masked column's own
         `[min, max]` (see `fit`)."""
-        self._ensure_local_effects(feature)
-        yy = self.local_effects["feature_" + str(feature)]
+        yy = self._local[feature]["phi"]
         xx = self.data[:, feature]
         if mask is not None:
             yy = yy[mask]
@@ -333,23 +333,9 @@ class ShapDP(GlobalEffectBase):
             "yy": yy,
         }
 
-    def _fit_feature(
-        self,
-        feature: int,
-        binning_method: Union[
-            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
-        ] = "dp",
-        binning_scope: str = "global",
-    ) -> typing.Dict:
-        return self._summarize(
-            feature, None, binning_method=binning_method, binning_scope=binning_scope
-        )
-
-    def _eval_unnorm(
-        self, feature: int, x: np.ndarray, heterogeneity: bool = False, params=None
+    def _eval_payload(
+        self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
     ):
-        if params is None:
-            params = self.feature_effect["feature_" + str(feature)]
         if params.get("is_cat"):
             codes = utils.codes_from_levels(
                 x, params["levels"], feature, self.feature_names[feature]
@@ -371,7 +357,6 @@ class ShapDP(GlobalEffectBase):
         features: Union[int, str, List] = "all",
         *,
         centering: Union[bool, str] = True,
-        points_for_centering: int = helpers.NOF_INTERNAL_POINTS,
         binning_method: Union[
             str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
         ] = "dp",
@@ -393,8 +378,6 @@ class ShapDP(GlobalEffectBase):
                 - If set to False, no centering will be applied.
                 - If set to "zero_integral" or True, the integral of the feature effect will be set to zero.
                 - If set to "zero_mean", the mean of the feature effect will be set to zero.
-
-            points_for_centering: number of linspaced points along the feature axis used for centering.
 
             binning_method: the binning method to be used for fitting a piecewise linear function to the SHAP values.
 
@@ -418,7 +401,6 @@ class ShapDP(GlobalEffectBase):
         self._fit_loop(
             features,
             centering,
-            points_for_centering,
             binning_method=binning_method,
             binning_scope=binning_scope,
         )
@@ -482,47 +464,25 @@ class ShapDP(GlobalEffectBase):
         if feature_label is not None:
             feature_names[feature] = feature_label
 
-        if mask is not None:
-            # transient subregion payload from the cached attributions —
-            # pure numpy, nothing stored (the masked-plot path)
-            if not self._is_cat(feature):
-                self._effective_limits(feature, mask)  # degeneracy guard
-            self._ensure_local_effects(feature)
-            m_params = self._masked_params(feature, mask)
-            m_norm = (
-                self._compute_norm_const(
-                    feature, method=centering, params=m_params, mask=mask
-                )
-                if centering is not False
-                else 0.0
-            )
+        if mask is not None and not self._is_cat(feature):
+            self._effective_limits(feature, mask)  # degeneracy guard
 
-        params_key = "feature_" + str(feature)
+        # one path for global and masked alike (R14): pick the payload, read it
+        params = self._summary(feature, mask)
+        norm = (
+            self._centering_const(feature, mask, centering)
+            if centering is not False
+            else 0.0
+        )
+        avg_output = self._avg_output(mask, scale_y) if show_avg_output else None
+
         if self._is_cat(feature):
-            if mask is not None:
-                # the masked payload's frame: the levels observed *within* the
-                # subregion (its φ were re-binned per level by _summarize)
-                params = m_params
-                levels, labels = self._level_display(feature, params["levels"])
-                y_levels = self._eval_unnorm(feature, levels, params=params) - m_norm
-                data = self.data[mask]
-            else:
-                # fit if needed, then draw per-level bars (+ the shap cloud)
-                self.eval(feature, self._levels(feature)[:1], centering=centering)
-                params = self.feature_effect[params_key]
-                levels, labels = self._level_display(feature)
-                y_levels = self.eval(feature, levels, centering=centering)
-                data = self.data
-            avg_output = (
-                helpers.prep_avg_output(data, self.model, None, scale_y)
-                if show_avg_output
-                else None
-            )
+            # the payload's frame: the levels observed within the (masked) data
+            levels, labels = self._level_display(feature, params["levels"])
+            y_levels = self._eval_payload(feature, params, levels) - norm
             title = "SHAP Dependence Plot (SHAP-DP)"
             if heterogeneity == "shap_values":
-                yy = params["yy"]
-                if centering is not False:
-                    yy = yy - (m_norm if mask is not None else params["norm_const"])
+                yy = params["yy"] - norm
                 return vis.plot_shap_categorical(
                     levels,
                     y_levels,
@@ -542,7 +502,7 @@ class ShapDP(GlobalEffectBase):
                     random_state=self.random_state,
                 )
             variances = (
-                self._eval_unnorm(feature, levels, heterogeneity=True, params=params)[1]
+                self._eval_payload(feature, params, levels, heterogeneity=True)[1]
                 if heterogeneity is not False
                 else None
             )
@@ -563,63 +523,21 @@ class ShapDP(GlobalEffectBase):
                 show_plot=show_plot,
             )
 
-        if mask is not None:
-            # the masked payload's frame: x spans the subregion's effective
-            # interval, the cloud is the masked φ (already filtered by
-            # _summarize) — model-free
-            lo, hi = self._effective_limits(feature, mask)
-            x = np.linspace(lo, hi, nof_points)
-            y = self._eval_unnorm(feature, x, params=m_params)
-            if centering is not False:
-                y = y - m_norm
-            y_std = (
-                np.sqrt(np.maximum(m_params["spline_var"](x), 0.0))
-                if heterogeneity == "std"
-                else None
-            )
-            _, ind = helpers.prep_nof_instances(
-                nof_shap_values, len(m_params["yy"]), self.random_state
-            )
-            yy = m_params["yy"][ind] if heterogeneity == "shap_values" else None
-            if yy is not None and centering is not False:
-                yy = yy - m_norm
-            xx = m_params["xx"][ind] if heterogeneity == "shap_values" else None
-            data = self.data[mask]
-        else:
-            x = np.linspace(
-                self.axis_limits[0, feature], self.axis_limits[1, feature], nof_points
-            )
-
-            # get the SHAP curve
-            y = self.eval(feature, x, centering=centering)
-            y_std = (
-                np.sqrt(self.feature_effect["feature_" + str(feature)]["spline_var"](x))
-                if heterogeneity == "std"
-                else None
-            )
-
-            # get some SHAP values
-            _, ind = helpers.prep_nof_instances(
-                nof_shap_values, self.data.shape[0], self.random_state
-            )
-            yy = (
-                self.feature_effect["feature_" + str(feature)]["yy"][ind]
-                if heterogeneity == "shap_values"
-                else None
-            )
-            if yy is not None and centering is not False:
-                yy = yy - self.feature_effect["feature_" + str(feature)]["norm_const"]
-            xx = (
-                self.feature_effect["feature_" + str(feature)]["xx"][ind]
-                if heterogeneity == "shap_values"
-                else None
-            )
-            data = self.data
-
-        if show_avg_output:
-            avg_output = helpers.prep_avg_output(data, self.model, None, scale_y)
-        else:
-            avg_output = None
+        # continuous: the x-axis spans the (effective) interval; the cloud is
+        # the (masked) φ, already filtered by _summarize — model-free
+        lo, hi = self._effective_limits(feature, mask)
+        x = np.linspace(lo, hi, nof_points)
+        y = self._eval_payload(feature, params, x) - norm
+        y_std = (
+            np.sqrt(np.maximum(params["spline_var"](x), 0.0))
+            if heterogeneity == "std"
+            else None
+        )
+        _, ind = helpers.prep_nof_instances(
+            nof_shap_values, len(params["yy"]), self.random_state
+        )
+        yy = params["yy"][ind] - norm if heterogeneity == "shap_values" else None
+        xx = params["xx"][ind] if heterogeneity == "shap_values" else None
 
         ret = vis.plot_shap(
             x,

--- a/effector/partition.py
+++ b/effector/partition.py
@@ -163,9 +163,7 @@ class Partition:
 
         # A future flat finder may produce non-root regions with parent_idx=None;
         # tree rendering does not apply there.
-        is_flat = any(
-            r.level > 0 and r.parent_idx is None for r in self.regions
-        )
+        is_flat = any(r.level > 0 and r.parent_idx is None for r in self.regions)
 
         print("\n")
         print("Feature {} - Full partition tree:".format(feature))
@@ -207,16 +205,16 @@ class Partition:
         max_level = max(r.level for r in self.regions)
         prev_heter = 0.0
         for lev in range(max_level + 1):
-            hk = sum(
-                r.heterogeneity * r.weight for r in self.regions if r.level == lev
-            )
+            hk = sum(r.heterogeneity * r.weight for r in self.regions if r.level == lev)
             if lev == 0:
                 print(f"Level {lev}🔹heter: {hk:.2f}")
             else:
                 indent = "    " * lev
                 drop = prev_heter - hk
                 perc = 100 * drop / prev_heter if prev_heter else 0
-                print(f"{indent}Level {lev}🔹heter: {hk:.2f} | 🔻{drop:.2f} ({perc:.2f}%)")
+                print(
+                    f"{indent}Level {lev}🔹heter: {hk:.2f} | 🔻{drop:.2f} ({perc:.2f}%)"
+                )
             prev_heter = hk
 
     # -- effect-backed sugar ---------------------------------------------------

--- a/effector/report.py
+++ b/effector/report.py
@@ -196,7 +196,11 @@ class Report:
         band = np.sqrt(np.clip(fr.h, 0, None))
         ax.plot(fr.xs, fr.y, color="#4C78A8", label="mean effect")
         ax.fill_between(
-            fr.xs, fr.y - band, fr.y + band, alpha=0.2, color="#4C78A8",
+            fr.xs,
+            fr.y - band,
+            fr.y + band,
+            alpha=0.2,
+            color="#4C78A8",
             label="± std",
         )
         ax.set_xlabel(fr.name)

--- a/notebooks/synthetic-examples/05_conditional_interaction_independent_uniform_heter.ipynb
+++ b/notebooks/synthetic-examples/05_conditional_interaction_independent_uniform_heter.ipynb
@@ -635,7 +635,7 @@
     "K = 31\n",
     "bin_centers = np.linspace(-1 + 1/K, 1 - 1/K, K)\n",
     "for feature in [0, 1, 2]:\n",
-    "    bin_var = ale.feature_effect[f\"feature_{feature}\"][\"bin_variance\"]\n",
+    "    bin_var = ale.payload(feature)[\"bin_variance\"]\n",
     "    gt_var = ale_ground_truth(feature)\n",
     "    mask = ~np.isnan(gt_var)\n",
     "    np.testing.assert_allclose(bin_var[mask], gt_var[mask], atol=1e-1)"
@@ -807,7 +807,7 @@
    "source": [
     "# make a test\n",
     "for feature in [0, 1, 2]:\n",
-    "    bin_var = rhale.feature_effect[f\"feature_{feature}\"][\"bin_variance\"]\n",
+    "    bin_var = rhale.payload(feature)[\"bin_variance\"]\n",
     "    gt_var = bench.rhale_bin_variance_gt(feature)\n",
     "    np.testing.assert_allclose(bin_var, gt_var, atol=1e-1)"
    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ Regional methods run on the gated-linear model from the functional anchor
 which runs on N=50 / budget=128 to keep the gate fast.
 """
 
+from contextlib import contextmanager
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -169,6 +171,18 @@ class CountingModel:
     def __call__(self, x):
         self.n_calls += 1
         return self.fn(x)
+
+
+@contextmanager
+def budget(*counters, expected):
+    """Assert the exact number of model calls a block issues (R14 budgets):
+    the sum of the given `CountingModel` counters must grow by `expected`."""
+    before = sum(c.n_calls for c in counters)
+    yield
+    got = sum(c.n_calls for c in counters) - before
+    assert got == expected, (
+        f"model-call budget violated: expected exactly {expected} calls, got {got}"
+    )
 
 
 def gated_model(x):

--- a/tests/test_contract_find_regions.py
+++ b/tests/test_contract_find_regions.py
@@ -169,9 +169,7 @@ def _find_counted(name, data, grid):
         fx = effector.RHALE(data, model, model_jac=jac, nof_instances="all")
     elif name == "shapdp":
         shap_values = np.random.RandomState(0).normal(size=data.shape)
-        fx = effector.ShapDP(
-            data, model, shap_values=shap_values, nof_instances="all"
-        )
+        fx = effector.ShapDP(data, model, shap_values=shap_values, nof_instances="all")
     else:
         raise ValueError(name)
     fx.find_regions(0, finder=finder)  # triggers the one lazy fit + model-free search
@@ -299,13 +297,16 @@ def test_rc10_high_cardinality_categorical_conditioning_feature():
     def model(x):
         return np.where(x[:, 1] < 12, 2 * x[:, 0], -2 * x[:, 0])
 
-    schema = {"feature_names": ["x0", "hour"],
-              "feature_types": ["continuous", "nominal"]}
+    schema = {
+        "feature_names": ["x0", "hour"],
+        "feature_types": ["continuous", "nominal"],
+    }
     fx = effector.PDP(X, model, schema=schema, nof_instances="all")
     fx.fit(0)
     part = fx.find_regions(0, finder="best")  # must not raise IndexError
     assert isinstance(part, Partition)
     # end-to-end explain path (candidate_conditioning_features="all") must also survive
-    rep = effector.explain(X, model, method="pdp", schema=schema,
-                           nof_instances="all", top_k=2)
+    rep = effector.explain(
+        X, model, method="pdp", schema=schema, nof_instances="all", top_k=2
+    )
     assert len(rep.features) == 2

--- a/tests/test_contract_importance.py
+++ b/tests/test_contract_importance.py
@@ -40,6 +40,7 @@ def _grid_std(m, feature):
     )
     return np.std(grid)
 
+
 CONT_NAMES = ["pdp", "ale", "rhale"]  # recover the exact linear effect
 
 

--- a/tests/test_contract_lifecycle.py
+++ b/tests/test_contract_lifecycle.py
@@ -1,0 +1,309 @@
+"""R14 — the two-block lifecycle as arithmetic.
+
+Every test here replays one of the agreed lifecycle traces and pins the EXACT
+model-call count of every step (the `budget` context manager), plus the state
+transitions the constitution promises (`_local[f]["frame"]`, `_epoch[f]`,
+position-store growth). Any future edit that sneaks in an extra model touch,
+loses a cache hit, or forgets a frame comparison flips one of these integers
+and fails loudly.
+
+The traces:
+- cache (a) fills once per frame; same frame re-fitted = 0 calls
+- a frame change (ALE grid, categorical order) recomputes and bumps the epoch
+- the (d-)PDP position store grows missing-only and never bumps the epoch
+- repeated evals/plots, centering switches, scores, masked surfaces: 0 calls
+- `ToyEffect` (tests/toy_method.py): a brand-new method written with zero
+  cache logic gets the whole constitution for free
+- lazy ≡ eager: never-fit queries equal fit-then-query, byte for byte
+"""
+
+import numpy as np
+import pytest
+
+import effector
+import effector.axis_partitioning as ap
+from effector import helpers
+
+from .conftest import (
+    COEF,
+    GLOBAL_NAMES,
+    CountingModel,
+    analytic_shap_values,
+    budget,
+    linear_model,
+    linear_model_jac,
+    make_global,
+    make_global_data,
+)
+from .toy_method import ToyEffect
+
+XS = np.linspace(-0.8, 0.8, 7)
+
+
+def make_counting(name, data):
+    """A fresh effect on counting model + counting jacobian. Returns
+    (effect, [counters]) — sum the counters for the budget."""
+    model = CountingModel(linear_model)
+    jac = CountingModel(linear_model_jac)
+    if name == "pdp":
+        return effector.PDP(data, model), [model]
+    if name == "derpdp":
+        return effector.DerPDP(data, model, model_jac=jac), [model, jac]
+    if name == "ale":
+        return effector.ALE(data, model), [model]
+    if name == "rhale":
+        return effector.RHALE(data, model, model_jac=jac), [model, jac]
+    if name == "shapdp":
+        return effector.ShapDP(data, model, shap_values=analytic_shap_values(data)), [
+            model
+        ]
+    raise ValueError(name)
+
+
+# ---------------------------------------------------------------------------
+# L1 — the five lifecycle traces, exact budgets
+# ---------------------------------------------------------------------------
+
+
+def test_l1_pdp_trace(global_data):
+    m, counters = make_counting("pdp", global_data)
+
+    with budget(*counters, expected=1):  # ICE on the 30-pt canonical grid
+        m.fit(features=0, centering=True)  # payload + const DERIVED: 0 extra
+    with budget(*counters, expected=1):  # only the missing display positions
+        m.plot(0, show_plot=False)
+    with budget(*counters, expected=0):  # every position cached
+        m.plot(0, show_plot=False)
+    grid = m._local[0]["pos"]
+    with budget(*counters, expected=0):  # on-cached-positions eval
+        m.eval(0, grid[3:8])
+    with budget(*counters, expected=0):  # centering switch = derive a constant
+        m.eval(0, grid[3:8], centering="zero_start")
+    with budget(*counters, expected=0):
+        m.heter_score(0)
+        m.importance(0)
+
+
+def test_l1_derpdp_trace(global_data):
+    m, counters = make_counting("derpdp", global_data)
+
+    with budget(*counters, expected=1):  # d-ICE on the canonical grid (jac)
+        m.fit(features=0)
+    with budget(*counters, expected=0):  # on-grid positions -> cache read
+        m.eval(0, m._local[0]["pos"][:5])
+    with budget(*counters, expected=1):  # missing display positions
+        m.plot(0, show_plot=False)
+    with budget(*counters, expected=0):
+        m.plot(0, show_plot=False)
+
+
+def test_l1_ale_trace(global_data):
+    m, counters = make_counting("ale", global_data)
+
+    with budget(*counters, expected=2):  # secants: model(right), model(left)
+        m.fit(features=0)  # centering const derived: 0 extra
+    with budget(*counters, expected=0):  # payload read
+        m.plot(0, show_plot=False)
+    with budget(*counters, expected=0):  # different centering = new constant
+        m.eval(0, XS, centering="zero_start")
+    with budget(*counters, expected=2):  # frame change -> recompute secants
+        m.fit(features=0, binning_method=ap.Fixed(nof_bins=5, min_points_per_bin=0))
+    assert len(m.payload(0)["limits"]) == 6  # the stale-grid bug fix, pinned
+    with budget(*counters, expected=0):  # same frame re-fitted = cache hit
+        m.fit(features=0, binning_method=ap.Fixed(nof_bins=5, min_points_per_bin=0))
+
+
+def test_l1_rhale_trace(global_data):
+    m, counters = make_counting("rhale", global_data)
+
+    with budget(*counters, expected=1):  # the whole (N, D) jacobian, shared
+        m.fit(features=0, binning_method="dp")
+    with budget(*counters, expected=0):
+        m.plot(0, show_plot=False)
+    with budget(*counters, expected=0):  # binning is a summary-stage param
+        m.fit(features=0, binning_method="greedy")
+    with budget(*counters, expected=0):  # the shared table covers feature 1
+        m.fit(features=1)
+        m.eval(1, XS)
+
+
+def test_l1_shapdp_trace(global_data, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_shap(model, data, *args, **kwargs):
+        calls["n"] += 1
+        return analytic_shap_values(data)
+
+    monkeypatch.setattr(
+        effector.global_effect_shap, "_compute_shap_values", fake_shap
+    )
+    model = CountingModel(linear_model)
+    m = effector.ShapDP(global_data, model)
+
+    m.fit(features=0)
+    assert calls["n"] == 1  # the explainer ran exactly once
+    with budget(model, expected=0):
+        m.plot(0, heterogeneity="shap_values", show_plot=False)
+        m.eval(0, XS, centering=False)
+        m.fit(features=1)  # the (N, D) phi table is shared
+        m.eval(1, XS)
+    assert calls["n"] == 1  # ... and never again
+
+
+# ---------------------------------------------------------------------------
+# L2 — the categorical order frame (ALE): 2(L-1) per frame, 0 on re-fit
+# ---------------------------------------------------------------------------
+
+CAT_SCHEMA = {"feature_types": ["continuous", "continuous", "nominal"]}
+
+
+def make_cat_data(n=90, seed=3):
+    rng = np.random.default_rng(seed)
+    return np.stack(
+        [
+            rng.uniform(-1, 1, n),
+            rng.uniform(-1, 1, n),
+            rng.integers(0, 3, n).astype(float),
+        ],
+        axis=1,
+    )
+
+
+def test_l2_categorical_order_frame():
+    data = make_cat_data()
+    model = CountingModel(linear_model)
+    m = effector.ALE(data, model, schema=CAT_SCHEMA)
+    L = 3
+
+    with budget(model, expected=2 * (L - 1)):  # 2 calls per transition
+        m.fit(features=2)
+    with budget(model, expected=0):  # same order = same frame (was: recompute)
+        m.fit(features=2)
+    with budget(model, expected=2 * (L - 1)):  # new order = new frame
+        m.fit(features=2, order=[2.0, 0.0, 1.0])
+    np.testing.assert_array_equal(m.payload(2)["levels"], [2.0, 0.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# L3 — state pokes: the decisions themselves, not just their cost
+# ---------------------------------------------------------------------------
+
+
+def test_l3_ale_frame_and_epoch(global_data):
+    m = make_global("ale", global_data)
+    m.fit(features=0)
+    assert m._local[0]["frame"][0] == "fixed"
+    e0 = m._epoch[0]
+    m.eval(0, XS)  # queries never bump the epoch
+    assert m._epoch[0] == e0
+    m.fit(features=0, binning_method=ap.Fixed(nof_bins=5, min_points_per_bin=0))
+    assert m._epoch[0] > e0  # frame replace bumped it
+    assert m._local[0]["frame"] == ("fixed", 5, 0)
+
+
+def test_l3_rhale_config_change_bumps_epoch_without_recompute(global_data):
+    m = make_global("rhale", global_data)
+    m.fit(features=0, binning_method="dp")
+    entry0 = m._local[0]
+    e0 = m._epoch[0]
+    m.fit(features=0, binning_method="greedy")
+    assert m._local[0] is entry0  # cache (a) untouched (no frame)
+    assert m._epoch[0] > e0  # but dp-binned summaries are unreachable
+
+
+def test_l3_pdp_store_grows_without_epoch_bump(global_data):
+    m = make_global("pdp", global_data)
+    m.fit(features=0)
+    n0 = len(m._local[0]["pos"])
+    e0 = m._epoch[0]
+    h0 = m.eval_heter(0, XS)
+    m.eval(0, np.array([0.123456, 0.654321]), centering=False)
+    assert len(m._local[0]["pos"]) == n0 + 2  # grew by the missing positions
+    assert m._epoch[0] == e0  # growth is additive: no invalidation
+    np.testing.assert_array_equal(m.eval_heter(0, XS), h0)  # summaries stable
+
+
+def test_l3_summaries_memoized_per_mask(global_data):
+    m = make_global("ale", global_data)
+    m.fit(features=0)
+    mask = global_data[:, 0] > 0
+    p1 = m._summary(0, mask)
+    p2 = m._summary(0, mask)
+    assert p1 is p2  # same key -> same object (memo hit)
+    assert m._summary(0, None) is m._summary(0, np.ones(len(global_data), bool))
+
+
+# ---------------------------------------------------------------------------
+# L4 — avg-output: one y_pred per object, ever
+# ---------------------------------------------------------------------------
+
+
+def test_l4_avg_output_costs_one_call_total(global_data):
+    m, counters = make_counting("ale", global_data)
+    m.fit(features=0)
+    with budget(*counters, expected=1):  # y_pred, once
+        m.plot(0, show_avg_output=True, show_plot=False)
+    with budget(*counters, expected=0):  # cached — masked variant included
+        m.plot(0, show_avg_output=True, show_plot=False)
+        m.plot(0, show_avg_output=True, show_plot=False, mask=global_data[:, 0] > 0)
+
+
+# ---------------------------------------------------------------------------
+# L5 — lazy ≡ eager, byte for byte, every method
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", GLOBAL_NAMES)
+def test_l5_lazy_equals_eager(name, global_data):
+    eager = make_global(name, global_data)
+    eager.fit(features=0)
+    lazy = make_global(name, global_data)
+
+    np.testing.assert_array_equal(eager.eval(0, XS), lazy.eval(0, XS))
+    np.testing.assert_array_equal(eager.eval_heter(0, XS), lazy.eval_heter(0, XS))
+    assert eager.heter_score(0) == lazy.heter_score(0)
+    assert eager.importance(0) == lazy.importance(0)
+
+
+# ---------------------------------------------------------------------------
+# L6 — ToyEffect: a zero-cache-logic method gets the constitution for free
+# ---------------------------------------------------------------------------
+
+
+def test_l6_toy_method_full_constitution(global_data):
+    model = CountingModel(linear_model)
+    m = ToyEffect(global_data, model)
+
+    with budget(model, expected=1):  # one prediction pass, ever
+        m.fit(features=0, nof_bins=8)
+    with budget(model, expected=0):  # plots, scores, masks, regions: free
+        m.plot(0, heterogeneity=True, show_plot=False)
+        m.eval(0, XS, centering="zero_integral")
+        m.heter_score(0)
+        m.importances()
+        part = m.find_regions(0)
+        for r in part.leaves:
+            part.plot(r.idx, show_plot=False)
+    with budget(model, expected=0):  # nof_bins is a summary knob, not a frame
+        m.fit(features=0, nof_bins=4)
+    assert len(m.payload(0)["limits"]) == 5
+
+    # lazy ≡ eager holds for the toy too
+    lazy = ToyEffect(make_global_data(), linear_model)
+    eager = ToyEffect(make_global_data(), linear_model)
+    eager.fit(features=0)
+    np.testing.assert_array_equal(eager.eval(0, XS), lazy.eval(0, XS))
+
+
+# ---------------------------------------------------------------------------
+# L7 — repeated plots cost nothing, every method
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", GLOBAL_NAMES)
+def test_l7_repeat_plot_costs_nothing(name, global_data):
+    m, counters = make_counting(name, global_data)
+    m.plot(0, show_plot=False)  # warm (lazy — no fit needed)
+    with budget(*counters, expected=0):
+        m.plot(0, show_plot=False)
+        m.plot(0, show_plot=False)

--- a/tests/test_contract_lifecycle.py
+++ b/tests/test_contract_lifecycle.py
@@ -22,10 +22,8 @@ import pytest
 
 import effector
 import effector.axis_partitioning as ap
-from effector import helpers
 
 from .conftest import (
-    COEF,
     GLOBAL_NAMES,
     CountingModel,
     analytic_shap_values,
@@ -134,9 +132,7 @@ def test_l1_shapdp_trace(global_data, monkeypatch):
         calls["n"] += 1
         return analytic_shap_values(data)
 
-    monkeypatch.setattr(
-        effector.global_effect_shap, "_compute_shap_values", fake_shap
-    )
+    monkeypatch.setattr(effector.global_effect_shap, "_compute_shap_values", fake_shap)
     model = CountingModel(linear_model)
     m = effector.ShapDP(global_data, model)
 

--- a/tests/test_contract_masked.py
+++ b/tests/test_contract_masked.py
@@ -300,11 +300,11 @@ def test_m5_binning_scope_controls_masked_bins(name, global_data):
 
     m_eff = make_global(name, global_data)
     m_eff.fit(features=0, binning_scope="effective")
-    p_eff = m_eff._summarize(0, mask, **m_eff._replay_fit_kwargs(0))
+    p_eff = m_eff._summary(0, mask)
 
     m_glob = make_global(name, global_data)
     m_glob.fit(features=0)  # default: "global"
-    p_glob = m_glob._summarize(0, mask, **m_glob._replay_fit_kwargs(0))
+    p_glob = m_glob._summary(0, mask)
 
     def limits_of(p):
         if "limits" in p:

--- a/tests/test_functional_categorical.py
+++ b/tests/test_functional_categorical.py
@@ -195,7 +195,7 @@ def test_rhale_greedy_groups_levels_and_stays_exact(data, model):
         data, model.predict, model.jacobian, nof_instances="all", schema=SCHEMA
     )
     rhale.fit(0, binning_method="greedy", centering="zero_start")
-    limits = rhale.feature_effect["feature_0"]["limits"]
+    limits = rhale.payload(0)["limits"]
     # candidate edges are exactly the integer level codes
     np.testing.assert_allclose(limits, np.round(limits), atol=1e-12)
     # accumulated values at the levels stay exact whatever the grouping,
@@ -309,7 +309,7 @@ def test_ale_refit_on_centering_change_preserves_order(data, model):
     y = ale.eval(0, np.array(order), centering="zero_integral")
 
     # the custom order must survive the centering-triggered refit
-    np.testing.assert_array_equal(ale.feature_effect["feature_0"]["levels"], order)
+    np.testing.assert_array_equal(ale.payload(0)["levels"], order)
 
     # and the centered answer must equal fitting centered with that order upfront
     ref = effector.ALE(data, model.predict, nof_instances="all", schema=SCHEMA)
@@ -337,8 +337,8 @@ def test_ale_similarity_order_runs_and_is_deterministic(data, model):
     a2 = effector.ALE(data, model.predict, schema={"feature_types": types})
     a2.fit(0, order="similarity")
     np.testing.assert_array_equal(
-        a1.feature_effect["feature_0"]["levels"],
-        a2.feature_effect["feature_0"]["levels"],
+        a1.payload(0)["levels"],
+        a2.payload(0)["levels"],
     )
 
 

--- a/tests/test_functional_conditional_interaction.py
+++ b/tests/test_functional_conditional_interaction.py
@@ -112,7 +112,7 @@ class TestHeterogeneity:
             features=feature,
             binning_method=effector.axis_partitioning.Fixed(nof_bins=NOF_BINS),
         )
-        bin_var = ale.feature_effect[f"feature_{feature}"]["bin_variance"]
+        bin_var = ale.payload(feature)["bin_variance"]
         gt_var = bench.ale_bin_variance_gt(feature, nof_bins=NOF_BINS)
         mask = ~np.isnan(gt_var)  # the jump bin's variance is an artifact
         np.testing.assert_allclose(bin_var[mask], gt_var[mask], atol=ATOL)
@@ -129,7 +129,7 @@ class TestHeterogeneity:
             features=feature,
             binning_method=effector.axis_partitioning.Fixed(nof_bins=NOF_BINS),
         )
-        bin_var = rhale.feature_effect[f"feature_{feature}"]["bin_variance"]
+        bin_var = rhale.payload(feature)["bin_variance"]
         gt_var = bench.rhale_bin_variance_gt(feature, nof_bins=NOF_BINS)
         np.testing.assert_allclose(bin_var, gt_var, atol=ATOL)
 

--- a/tests/test_functional_conditional_interaction.py
+++ b/tests/test_functional_conditional_interaction.py
@@ -145,13 +145,9 @@ class TestRegionalEffects:
     @pytest.fixture(scope="class", params=["pdp", "ale", "rhale"])
     def partition(self, request, bench, data):
         if request.param == "pdp":
-            fx = effector.PDP(
-                data, bench.model.predict, axis_limits=bench.axis_limits
-            )
+            fx = effector.PDP(data, bench.model.predict, axis_limits=bench.axis_limits)
         elif request.param == "ale":
-            fx = effector.ALE(
-                data, bench.model.predict, axis_limits=bench.axis_limits
-            )
+            fx = effector.ALE(data, bench.model.predict, axis_limits=bench.axis_limits)
         else:
             fx = effector.RHALE(
                 data,
@@ -168,8 +164,7 @@ class TestRegionalEffects:
         for region in children:
             assert region.foc_index == bench.regional_split_feature
             assert (
-                abs(region.foc_split_position - bench.regional_split_position)
-                <= 0.15
+                abs(region.foc_split_position - bench.regional_split_position) <= 0.15
             )
 
     def test_region_effects_are_plus_minus_x_squared(self, partition, bench):

--- a/tests/test_functional_four_regions.py
+++ b/tests/test_functional_four_regions.py
@@ -118,9 +118,7 @@ class TestRegionalEffects:
     @pytest.fixture(scope="class", params=["pdp", "rhale"])
     def fitted(self, request, bench, data):
         if request.param == "pdp":
-            fx = effector.PDP(
-                data, bench.model.predict, axis_limits=bench.axis_limits
-            )
+            fx = effector.PDP(data, bench.model.predict, axis_limits=bench.axis_limits)
         else:
             fx = effector.RHALE(
                 data,
@@ -129,9 +127,7 @@ class TestRegionalEffects:
                 axis_limits=bench.axis_limits,
             )
         fx.fit(0, centering=True)
-        return fx.find_regions(
-            0, finder=effector.space_partitioning.Best(max_depth=2)
-        )
+        return fx.find_regions(0, finder=effector.space_partitioning.Best(max_depth=2))
 
     def test_two_levels_sign_gate_then_power_gate(self, fitted, bench):
         part = fitted

--- a/tests/test_regional_categorical.py
+++ b/tests/test_regional_categorical.py
@@ -81,7 +81,11 @@ def test_regional_ale_on_categorical_foi_finds_the_gate(data):
 
 def test_regional_rhale_on_ordinal_foi(data):
     fx = effector.RHALE(
-        data, gated_cat_model, model_jac=gated_cat_jac, nof_instances="all", schema=SCHEMA
+        data,
+        gated_cat_model,
+        model_jac=gated_cat_jac,
+        nof_instances="all",
+        schema=SCHEMA,
     )
     _assert_gate_found(_find(fx))
 

--- a/tests/test_unit_partition.py
+++ b/tests/test_unit_partition.py
@@ -76,8 +76,14 @@ def test_container_protocol():
 def test_constructor_validates_root():
     n = 4
     bad_root = Region(
-        idx=0, name="x0", mask=np.ones(n, dtype=bool), heterogeneity=0.1,
-        nof_instances=n, weight=0.5, level=0, parent_idx=None,
+        idx=0,
+        name="x0",
+        mask=np.ones(n, dtype=bool),
+        heterogeneity=0.1,
+        nof_instances=n,
+        weight=0.5,
+        level=0,
+        parent_idx=None,
     )
     with pytest.raises(ValueError):
         Partition([bad_root], feature=0, feature_name="x0", finder_name="best")
@@ -102,10 +108,19 @@ def test_label_glyphs():
     n = 4
     for comparison, glyph in [(">=", "≥"), ("<=", "≤"), ("!=", "≠"), ("==", "=")]:
         child = Region(
-            idx=1, name="c", mask=np.array([1, 1, 0, 0], dtype=bool),
-            heterogeneity=0.1, nof_instances=2, weight=0.5, level=1, parent_idx=0,
-            foc_index=1, foc_name="x1", foc_type="numerical",
-            foc_split_position=2.0, comparison=comparison,
+            idx=1,
+            name="c",
+            mask=np.array([1, 1, 0, 0], dtype=bool),
+            heterogeneity=0.1,
+            nof_instances=2,
+            weight=0.5,
+            level=1,
+            parent_idx=0,
+            foc_index=1,
+            foc_name="x1",
+            foc_type="numerical",
+            foc_split_position=2.0,
+            comparison=comparison,
         )
         part = Partition(
             [_root(n), child], feature=0, feature_name="x0", finder_name="best"

--- a/tests/toy_method.py
+++ b/tests/toy_method.py
@@ -70,9 +70,7 @@ class ToyEffect(GlobalEffectBase):
 
     # -- 4. the pure reader kernel ------------------------------------------
     def _eval_payload(self, feature, params, x, heterogeneity=False):
-        idx = np.clip(
-            np.digitize(x, params["limits"]) - 1, 0, len(params["mean"]) - 1
-        )
+        idx = np.clip(np.digitize(x, params["limits"]) - 1, 0, len(params["mean"]) - 1)
         y = params["mean"][idx]
         return (y, params["var"][idx]) if heterogeneity else y
 

--- a/tests/toy_method.py
+++ b/tests/toy_method.py
@@ -1,0 +1,108 @@
+"""ToyEffect — the reference implementation of the R14 subclass contract.
+
+A deliberately minimal effect method: the *local effect* of every instance is
+just its model prediction f(x^i); the summary is the per-bin mean/variance of
+those predictions along the feature axis; eval reads the step function.
+Scientific value: none. Pedagogical value: the whole two-block lifecycle
+(docs/design.md R14) in ~60 lines of method code —
+
+1. answer the frame question: which config params invalidate the local
+   effects? (here: none — predictions are instance-anchored; `nof_bins` is a
+   summary-stage knob, like RHALE's binning)
+2. implement the three pure kernels: `_compute_local` (the only one that may
+   touch the model), `_summarize` (numpy in, payload out), `_eval_payload`
+   (payload + xs in, numbers out)
+3. write ZERO cache/retrigger/mask logic — the base owns all of it: masking,
+   memoization, centering, heter_score, importance, find_regions and the
+   Partition sugar all work on this class for free.
+
+Copy this file as the starting point of a real new method.
+"""
+
+import numpy as np
+
+from effector import ingestion, utils
+from effector.global_effect import GlobalEffectBase
+
+
+class ToyEffect(GlobalEffectBase):
+    DEFAULT_CENTERING = False
+    SUPPORTED_FEATURE_TYPES = frozenset({ingestion.CONTINUOUS})
+    CAT_STRATEGY = None
+
+    def __init__(self, data, model, **kwargs):
+        super().__init__("toy", data, model, None, **kwargs)
+
+    # -- 1. the frame declaration ------------------------------------------
+    def _frame_from_config(self, feature):
+        return ()  # instance-anchored: the cached predictions never go stale
+
+    # -- 2. the model-touching kernel (the ONLY one) ------------------------
+    def _compute_local(self, feature, frame):
+        # feature-independent raw material is computed once per OBJECT and
+        # shared across features (the RHALE-jacobian / ShapDP-table pattern);
+        # here it coincides with the base's `_y_pred` slot
+        if self._y_pred is None:
+            self._y_pred = np.asarray(self.model(self.data))
+        return {"frame": frame, "pred": self._y_pred}
+
+    # -- 3. the pure summary kernel -----------------------------------------
+    def _summarize(self, feature, mask=None, nof_bins=10):
+        pred = self._local[feature]["pred"]
+        col = self.data[:, feature]
+        if mask is not None:
+            pred, col = pred[mask], col[mask]
+        limits = np.linspace(
+            self.axis_limits[0, feature], self.axis_limits[1, feature], nof_bins + 1
+        )
+        idx = np.clip(np.digitize(col, limits) - 1, 0, nof_bins - 1)
+        counts = np.bincount(idx, minlength=nof_bins)
+        mean = np.bincount(idx, weights=pred, minlength=nof_bins)
+        sq = np.bincount(idx, weights=pred**2, minlength=nof_bins)
+        with np.errstate(invalid="ignore"):
+            mean = np.where(counts > 0, mean / np.maximum(counts, 1), np.nan)
+            var = np.where(counts > 0, sq / np.maximum(counts, 1) - mean**2, np.nan)
+        return {
+            "limits": limits,
+            "mean": utils.fill_nans(mean),
+            "var": np.maximum(utils.fill_nans(var), 0.0),
+        }
+
+    # -- 4. the pure reader kernel ------------------------------------------
+    def _eval_payload(self, feature, params, x, heterogeneity=False):
+        idx = np.clip(
+            np.digitize(x, params["limits"]) - 1, 0, len(params["mean"]) - 1
+        )
+        y = params["mean"][idx]
+        return (y, params["var"][idx]) if heterogeneity else y
+
+    # -- public surface: declare config, delegate everything to the base ----
+    def fit(self, features="all", *, centering=False, nof_bins=10):
+        self._fit_loop(features, centering, nof_bins=nof_bins)
+
+    def plot(
+        self,
+        feature,
+        heterogeneity=False,
+        centering=False,
+        show_plot=True,
+        mask=None,
+        **kwargs,
+    ):
+        import matplotlib.pyplot as plt
+
+        mask = self._prep_mask(mask)
+        params = self._summary(feature, mask)
+        centers = (params["limits"][:-1] + params["limits"][1:]) / 2
+        y = self.eval(feature, centers, centering=centering, mask=mask)
+        fig, ax = plt.subplots()
+        ax.step(centers, y, where="mid")
+        if heterogeneity is not False:
+            band = np.sqrt(self._eval_payload(feature, params, centers, True)[1])
+            ax.fill_between(centers, y - band, y + band, alpha=0.2, step="mid")
+        ax.set_xlabel(self.feature_names[feature])
+        ax.set_ylabel(self.target_name)
+        if show_plot:
+            plt.show(block=False)
+            return None
+        return fig, ax


### PR DESCRIPTION
## Two-block lifecycle constitution (R14)

The engine's three retrigger mechanisms (`requires_refit`, presence-only local-effects check, `_fit_epoch` memo) never talked to each other and produced real bugs: ALE silently ignored a refit with a different `Fixed` grid, categorical (RH)ALE re-touched the model on every fit even with an unchanged `order`, `heter_score(mask=None)` cost 2 PDP model calls where the all-ones path cost 0, `show_avg_output` called the model at plot time, and every repeated PDP plot re-predicted the full ICE table.

This PR replaces all of it with **one constitution, owned entirely by `GlobalEffectBase`** (new `docs/design.md` R14):

- **Cache (a) — local effects** (model-touching): one frame-carrying entry per feature. *Recompute iff absent or the stored frame ≠ the frame derived from the current config.* PDP/DerPDP get a **growing position store** (missing-columns-only; repeated plots/evals are 0 model calls); ALE's frame is its fixed grid; categorical's is the level order; RHALE/ShapDP are instance-anchored views of shared tables. `y_pred` computed once for avg-output.
- **Cache (b) — summaries** (pure numpy): one LRU memo for payloads **and centering constants**, keyed `(feature, epoch, mask_key[, mode])`; `None` ≡ all-ones normalized in one place. Epoch bumps on frame/config change → stale entries become unreachable, never served.
- **Centering is a summary**: constants always derive from cache (a). `requires_refit`, `_refit`, and the `points_for_centering` kwarg are **deleted** (constants use the same 30-pt grid as before, so default values are unchanged).
- **Subclass contract**: a method = frame declaration + 3 pure kernels (`_compute_local` / `_summarize` / `_eval_payload`); zero cache/mask logic in subclasses. The masked/global dual branches in every `plot` collapse to one payload path.

### Enforcement

- `tests/test_contract_lifecycle.py` — the constitution as arithmetic: exact model-call budgets for every lifecycle step of all 5 methods (L1), the categorical order frame (L2), state pokes on frame/epoch/store-growth (L3), one-`y_pred`-ever (L4), lazy ≡ eager byte-equality (L5), and repeat-plot-is-free (L7).
- `tests/toy_method.py` — **ToyEffect**, a ~60-line reference method with zero cache logic that gets masking, memoization, centering, `heter_score`, `importance`, `find_regions` and the `Partition` sugar for free (L6). It doubles as the copy-me template.
- `CONTRIBUTING.md` — new "Writing a new effect method" checklist (the frame question, the 3 kernels, the legal override points).

### Perf

No path issues more model calls than before (pinned by the budget tests); several drop to zero: repeated plots/evals, centering-mode switches, categorical refits, `heter_score`, avg-output. The only cost is memory in the PDP position store (~80 KB per position at 10k instances).

### Follow-up (separate PR)

Re-executed notebooks + regenerated doc pages (default outputs are expected to be unchanged; only custom-`points_for_centering` call sites are removed).
