### PR TITLE
Kernel dispatch: cont/cat variants + pure-numpy ShapDP payloads

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -27,7 +27,8 @@ aggregation ladder with one consumer per level:
 - **`eval_heter(feature, xs)` → `(T,)`** — the heterogeneity curve h(xs).
   h is the *variance* of the method's own per-instance effect object
   (PDP: centered ICE levels; DerPDP: d-ICE slopes; (RH)ALE: per-bin slope
-  variance as a step function; ShapDP: the residual spline). Variance
+  variance as a step function; ShapDP: the interpolated per-bin φ variance).
+  Variance
   internally, std only at the plot layer. **No centering kwarg** — h is
   invariant to centering, and the signature enforces it. Every plotted
   band/error-bar equals `eval_heter` (R1 extended to heterogeneity).
@@ -308,7 +309,12 @@ additive). Frame change → replace the entry and bump the feature's **epoch**.
 
 **Cache (b) — summaries** (pure numpy, LRU-bounded). Entries are payloads,
 keyed `(feature, epoch, mask_key)`, and centering constants, keyed
-`(feature, epoch, mask_key, mode)`. `mask_key` normalizes `None` and all-ones
+`(feature, epoch, mask_key, mode)`. Payloads come in two archetypes, both
+plain-numpy dicts (serializable, no callables): *binned* —
+`limits`/`bin_effect`/`bin_variance` (+ `levels` on a discrete axis) for
+ALE/RHALE/ShapDP, whose readers accumulate or interpolate between bins — and
+*gridded* — `grid`/`mean`/`heter` for (d-)PDP, read by exact lookup at grid
+positions. `mask_key` normalizes `None` and all-ones
 to a single key (rule M1) — that equivalence lives in exactly one function.
 The epoch bumps on frame replacement **or** config change (a refit with new
 binning/scope), so stale summaries become *unreachable*: staleness is handled
@@ -324,10 +330,18 @@ caches nothing — partial-N columns cannot enter an instance-aligned cache);
 is zero model calls, pinned by counting-model contract tests.
 
 **Subclass contract.** A method implements a frame declaration
-(`_frame_from_config`) and three pure kernels — `_compute_local` (the only
-kernel that may touch the model), `_summarize` (numpy in, payload dict out),
-`_eval_payload` (payload + xs in, numbers out) — and contains **no cache,
-retrigger, or mask logic, ever**. Methods that don't fit the mold override a
-named hook (`_eval_mean`, `_importance`, the norm-const shape) — they
+(`_frame_from_config`) and three pure kernels, each split into a continuous
+and a categorical variant — `_compute_local_cont|_cat` (the only kernels that
+may touch the model), `_summarize_cont|_cat` (numpy in, payload dict out),
+`_eval_payload_cont|_cat` (payload + xs in, numbers out) — and contains **no
+cache, retrigger, or mask logic, ever**. The base owns the dispatch: each
+gate-facing name (`_compute_local`, `_summarize`, `_eval_payload`,
+`_compute_norm_const`) forks on `_is_cat(feature)` exactly once, so a kernel
+body never inspects the feature type. A type-agnostic kernel is declared with
+a class-level alias (`_compute_local_cat = _compute_local_cont`), never a fork
+in the body. The `_cat` defaults raise — unreachable when
+`SUPPORTED_FEATURE_TYPES` excludes ordinal/nominal, so continuous-only
+methods (DerPDP) skip them entirely. Methods that don't fit the mold override
+a named hook (`_eval_mean`, `_importance`, the norm-const shape) — they
 never bypass the gates. `tests/toy_method.py` is the reference implementation
 and the contract suite's guinea pig.

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -691,9 +691,9 @@ class GlobalEffectBase(ABC):
         Notes:
             The values are *method-specific* (R2): the variance of the centered
             ICE curves (PDP), of the d-ICE curves (DerPDP), the per-bin variance
-            of the local effects as a step function (ALE/RHALE), or the residual
-            spline around the SHAP curve (ShapDP). They are variances — take a
-            square root for a std-like band.
+            of the local effects as a step function (ALE/RHALE), or the
+            interpolated per-bin variance of the SHAP values (ShapDP). They are
+            variances — take a square root for a std-like band.
 
             There is deliberately no `centering` argument: heterogeneity is
             invariant to centering.

--- a/effector/global_effect.py
+++ b/effector/global_effect.py
@@ -15,9 +15,15 @@ Every effect object holds exactly two caches and one config, all owned here:
   not accept.
 
 Subclasses implement a frame declaration (`_frame_from_config`) and three pure
-kernels — `_compute_local` (the only kernel that may touch the model),
-`_summarize` (numpy in, payload dict out), `_eval_payload` (payload + xs in,
-numbers out) — and contain no cache, retrigger, or mask logic.
+kernels, each split into a continuous and a categorical variant —
+`_compute_local_cont|_cat` (the only kernels that may touch the model),
+`_summarize_cont|_cat` (numpy in, payload dict out), `_eval_payload_cont|_cat`
+(payload + xs in, numbers out) — and contain no cache, retrigger, or mask
+logic. The base owns the dispatch (`_is_cat(feature)`, once per kernel); a
+type-agnostic kernel is declared with a class-level alias
+(`_compute_local_cat = _compute_local_cont`), never a fork in the body.
+Methods whose `SUPPORTED_FEATURE_TYPES` exclude ordinal/nominal skip the
+`_cat` variants entirely — the capability matrix makes them unreachable.
 """
 
 import warnings
@@ -27,6 +33,7 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 
+import effector.axis_partitioning as ap
 from effector import helpers, ingestion, utils
 from effector.rules import Rule
 
@@ -155,7 +162,11 @@ class GlobalEffectBase(ABC):
         self._y_pred: Optional[np.ndarray] = None
 
     # ------------------------------------------------------------------
-    # the three subclass kernels + the frame declaration (R14)
+    # the three kernel dispatchers + the frame declaration (R14). Each kernel
+    # comes in a continuous and a categorical variant; the dispatch below is
+    # the ONLY place a kernel forks on the feature type. The `_cat` defaults
+    # raise: they are unreachable when `SUPPORTED_FEATURE_TYPES` excludes
+    # ordinal/nominal (`_ensure_local` enforces the capability matrix first).
     # ------------------------------------------------------------------
     def _frame_from_config(self, feature: int) -> tuple:
         """The frame tuple this feature's local effects depend on, derived from
@@ -163,23 +174,64 @@ class GlobalEffectBase(ABC):
         (never invalidated; PDP's position store only grows)."""
         return ()
 
-    @abstractmethod
     def _compute_local(self, feature: int, frame: tuple) -> dict:
+        if self._is_cat(feature):
+            return self._compute_local_cat(feature, frame)
+        return self._compute_local_cont(feature, frame)
+
+    @abstractmethod
+    def _compute_local_cont(self, feature: int, frame: tuple) -> dict:
         """The one model-touching kernel: compute the per-instance local
-        effects of `feature` under `frame` and return the cache-(a) entry —
-        a dict that includes `"frame": frame` plus instance-aligned arrays."""
+        effects of a continuous `feature` under `frame` and return the
+        cache-(a) entry — a dict that includes `"frame": frame` plus
+        instance-aligned arrays."""
         raise NotImplementedError
+
+    def _compute_local_cat(self, feature: int, frame: tuple) -> dict:
+        raise NotImplementedError(
+            f"{type(self).__name__} declares no categorical local-effect "
+            f"kernel — unreachable while SUPPORTED_FEATURE_TYPES excludes "
+            f"ordinal/nominal"
+        )
 
     def _summarize(
         self, feature: int, mask: Optional[np.ndarray] = None, **config
     ) -> dict:
-        """Pure-numpy kernel: derive the payload for `feature` from the cached
-        local effects restricted to `mask` (`None` = all instances), under the
-        declared `config`. Overridden per method; must not touch the model."""
-        raise NotImplementedError
+        if self._is_cat(feature):
+            return self._summarize_cat(feature, mask, **config)
+        return self._summarize_cont(feature, mask, **config)
 
     @abstractmethod
+    def _summarize_cont(
+        self, feature: int, mask: Optional[np.ndarray] = None, **config
+    ) -> dict:
+        """Pure-numpy kernel: derive the payload of a continuous `feature`
+        from the cached local effects restricted to `mask` (`None` = all
+        instances), under the declared `config`. Must not touch the model."""
+        raise NotImplementedError
+
+    def _summarize_cat(
+        self, feature: int, mask: Optional[np.ndarray] = None, **config
+    ) -> dict:
+        raise NotImplementedError(
+            f"{type(self).__name__} declares no categorical summary kernel — "
+            f"unreachable while SUPPORTED_FEATURE_TYPES excludes "
+            f"ordinal/nominal"
+        )
+
     def _eval_payload(
+        self,
+        feature: int,
+        params: dict,
+        x: np.ndarray,
+        heterogeneity: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        if self._is_cat(feature):
+            return self._eval_payload_cat(feature, params, x, heterogeneity)
+        return self._eval_payload_cont(feature, params, x, heterogeneity)
+
+    @abstractmethod
+    def _eval_payload_cont(
         self,
         feature: int,
         params: dict,
@@ -190,6 +242,19 @@ class GlobalEffectBase(ABC):
         payload `params`, and — if `heterogeneity` — also the heterogeneity
         curve h(x). Same payload + same x → same answer; no model, no state."""
         raise NotImplementedError
+
+    def _eval_payload_cat(
+        self,
+        feature: int,
+        params: dict,
+        x: np.ndarray,
+        heterogeneity: bool = False,
+    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+        raise NotImplementedError(
+            f"{type(self).__name__} declares no categorical reader kernel — "
+            f"unreachable while SUPPORTED_FEATURE_TYPES excludes "
+            f"ordinal/nominal"
+        )
 
     # ------------------------------------------------------------------
     # the two gates (all queries go through these; nothing else checks caches)
@@ -271,33 +336,80 @@ class GlobalEffectBase(ABC):
         method: str,
         params: dict,
         mask: Optional[np.ndarray] = None,
-    ) -> float:
+    ):
         """Derive the centering constant from the payload: `zero_integral` =
         the mean over the (effective) feature interval, `zero_start` = the
-        value at its left limit. Pure numpy; (d-)PDP overrides it with the
-        per-instance variant read off the cached ICE columns."""
+        value at its left limit. Pure numpy; (d-)PDP overrides the two
+        variants (not this dispatcher) with the per-instance form read off
+        the cached ICE columns."""
         assert method in ["zero_integral", "zero_start"]
-
-        def partial_eval(x):
-            return self._eval_payload(feature, params, x)
-
         if self._is_cat(feature):
-            # discrete centering (method_semantics.md): zero_integral is the
-            # frequency-weighted level mean (order-invariant); zero_start
-            # zeroes the first level *in fit order* (a custom `order` makes
-            # its first entry the reference level)
-            levels, weights = self._level_weights(feature, mask)
-            if method == "zero_integral":
-                return float(np.average(partial_eval(levels), weights=weights))
-            fit_levels = params.get("levels", levels)
-            return partial_eval(np.asarray(fit_levels[:1])).item()
+            return self._compute_norm_const_cat(feature, method, params, mask)
+        return self._compute_norm_const_cont(feature, method, params, mask)
 
+    def _compute_norm_const_cat(
+        self,
+        feature: int,
+        method: str,
+        params: dict,
+        mask: Optional[np.ndarray] = None,
+    ):
+        # discrete centering (method_semantics.md): zero_integral is the
+        # frequency-weighted level mean (order-invariant); zero_start
+        # zeroes the first level *in fit order* (a custom `order` makes
+        # its first entry the reference level)
+        levels, weights = self._level_weights(feature, mask)
+        if method == "zero_integral":
+            return float(
+                np.average(self._eval_payload(feature, params, levels), weights=weights)
+            )
+        fit_levels = params.get("levels", levels)
+        return self._eval_payload(feature, params, np.asarray(fit_levels[:1])).item()
+
+    def _compute_norm_const_cont(
+        self,
+        feature: int,
+        method: str,
+        params: dict,
+        mask: Optional[np.ndarray] = None,
+    ):
         start, stop = self._effective_limits(feature, mask)
         if method == "zero_integral":
             return utils.mean_1d_linspace(
-                partial_eval, start, stop, helpers.NOF_INTERNAL_POINTS
+                lambda x: self._eval_payload(feature, params, x),
+                start,
+                stop,
+                helpers.NOF_INTERNAL_POINTS,
             )
-        return partial_eval(np.array([start])).item()
+        return self._eval_payload(feature, params, np.array([start])).item()
+
+    def _bin_local_effects(
+        self,
+        feature: int,
+        col: np.ndarray,
+        eff: np.ndarray,
+        mask: Optional[np.ndarray],
+        binning_method,
+        binning_scope: str,
+    ) -> dict:
+        """The shared continuous-summary tail of the adaptive-binning methods
+        (RHALE/ShapDP): bin the (already mask-sliced) local effects `eff` at
+        positions `col` with the declared binner over the scope's x-range, and
+        return the `compute_ale_params` payload (+ `alg_params`)."""
+        binning = (
+            ap.return_default(binning_method)
+            if isinstance(binning_method, str)
+            else binning_method
+        )
+        if mask is not None and binning_scope == "effective":
+            limits_range = np.asarray(self._effective_limits(feature, mask))
+        else:
+            limits_range = self.axis_limits[:, feature]
+        limits = binning.find_limits(col, eff, limits_range)
+        utils.raise_if_no_binning(limits, feature, binning)
+        params = utils.compute_ale_params(col, eff, limits)
+        params["alg_params"] = binning
+        return params
 
     def _mean_norm_const(self, norm_const):
         """The scalar amount the centered mean effect subtracts. It is a scalar
@@ -605,9 +717,9 @@ class GlobalEffectBase(ABC):
 
     def payload(self, feature: int) -> dict:
         """The method's raw fitted object for the `feature`-th feature — the
-        honest method-specific state behind `eval`/`eval_heter` (bin effects
-        and variances for (RH)ALE, splines and shap values for ShapDP, the
-        grid summaries for (d-)PDP): the all-ones summary (R14)."""
+        honest method-specific state behind `eval`/`eval_heter` (per-bin
+        effects and variances for (RH)ALE and ShapDP, the grid summaries for
+        (d-)PDP): the all-ones summary (R14), pure numpy."""
         return dict(self._summary(feature, None))
 
     def heter_score(

--- a/effector/global_effect_ale.py
+++ b/effector/global_effect_ale.py
@@ -51,37 +51,40 @@ class ALEBase(GlobalEffectBase):
             return ("order", order)
         return ("order", tuple(float(v) for v in np.asarray(order, dtype=float)))
 
-    def _eval_payload(
+    def _eval_payload_cont(
         self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
     ):
-        if params.get("is_cat"):
-            # discrete kernel (method_semantics.md): accumulate in code space —
-            # exact at levels, and h(v_j) is the variance of the step *into*
-            # level j (h(v_1) = the first transition's variance)
-            codes = utils.codes_from_levels(
-                x, params["levels"], feature, self.feature_names[feature]
-            )
-            y = utils.compute_accumulated_effect(
-                codes.astype(float),
-                limits=params["limits"],
-                bin_effect=params["bin_effect"],
-                dx=params["dx"],
-            )
-            if heterogeneity:
-                transition_pos = np.maximum(codes, 1) - 0.5
-                var = utils.apply_bin_value(
-                    x=transition_pos,
-                    bin_limits=params["limits"],
-                    bin_value=params["bin_variance"],
-                )
-                return y, var
-            return y
         y = utils.compute_accumulated_effect(
             x, limits=params["limits"], bin_effect=params["bin_effect"], dx=params["dx"]
         )
         if heterogeneity:
             var = utils.apply_bin_value(
                 x=x, bin_limits=params["limits"], bin_value=params["bin_variance"]
+            )
+            return y, var
+        return y
+
+    def _eval_payload_cat(
+        self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
+    ):
+        # discrete kernel (method_semantics.md): accumulate in code space —
+        # exact at levels, and h(v_j) is the variance of the step *into*
+        # level j (h(v_1) = the first transition's variance)
+        codes = utils.codes_from_levels(
+            x, params["levels"], feature, self.feature_names[feature]
+        )
+        y = utils.compute_accumulated_effect(
+            codes.astype(float),
+            limits=params["limits"],
+            bin_effect=params["bin_effect"],
+            dx=params["dx"],
+        )
+        if heterogeneity:
+            transition_pos = np.maximum(codes, 1) - 0.5
+            var = utils.apply_bin_value(
+                x=transition_pos,
+                bin_limits=params["limits"],
+                bin_value=params["bin_variance"],
             )
             return y, var
         return y
@@ -123,13 +126,13 @@ class ALEBase(GlobalEffectBase):
             "levels": levels,
         }
 
-    def _summarize_cat(
+    def _summarize_levels(
         self, feature: int, mask=None, binning_method=None
     ) -> typing.Dict:
-        """Summary kernel (categorical): bin the cached adjacent-level
+        """The shared categorical summary body: bin the cached adjacent-level
         differences over the subregion `mask` (None = all). ALE keeps one bin
-        per transition; RHALE merges adjacent transitions with Greedy/DP
-        (adaptive grouping)."""
+        per transition (`binning_method=None`); RHALE merges adjacent
+        transitions with Greedy/DP (adaptive grouping)."""
         prim = self._local[feature]
         positions = prim["positions"]
         effects = prim["effects"]
@@ -153,7 +156,6 @@ class ALEBase(GlobalEffectBase):
         params = utils.compute_ale_params(positions, effects, limits)
         params["alg_params"] = "categorical"
         params["levels"] = levels
-        params["is_cat"] = True
         return params
 
     def plot(
@@ -233,10 +235,11 @@ class ALEBase(GlobalEffectBase):
             feature_names[feature] = feature_label
 
         # one path for global and masked alike (R14): pick the payload, read it
+        is_cat = self._is_cat(feature)
         params = self._summary(feature, mask)
         x_window = (
             self._effective_limits(feature, mask)
-            if mask is not None and not params.get("is_cat")
+            if mask is not None and not is_cat
             else None
         )
 
@@ -251,7 +254,7 @@ class ALEBase(GlobalEffectBase):
         # categoricals are drawn by the is_cat branch below (at their observed
         # level values); their limits are positional codes 0..K-1 that eval
         # would reject, so only build this grid for continuous features.
-        if not params.get("is_cat"):
+        if not is_cat:
             x = np.asarray(params["limits"], dtype=float)
             y = centered_eval(x)
 
@@ -262,7 +265,7 @@ class ALEBase(GlobalEffectBase):
             if self.method_name == "ale"
             else "Robust and Heterogeneity-Aware ALE (RHALE)"
         )
-        if params.get("is_cat"):
+        if is_cat:
             # bars = accumulated per-level values (in fit order); whiskers =
             # the variance of the step into each level (method_semantics.md)
             levels, labels = self._level_display(feature, params["levels"])
@@ -436,11 +439,9 @@ class ALE(ALEBase):
             binning.constraints.min_points_per_bin,
         )
 
-    def _compute_local(self, feature: int, frame: tuple) -> dict:
+    def _compute_local_cont(self, feature: int, frame: tuple) -> dict:
         """Cache-(a) kernel: the secant of the model across each fixed bin —
         computed on the frame's grid, one model query pair for all instances."""
-        if self._is_cat(feature):
-            return self._compute_local_cat(feature, frame)
         binning_method = self._config(feature).get("binning_method", "fixed")
         binning = ap.Fixed() if isinstance(binning_method, str) else binning_method
         limits = binning.find_limits(
@@ -450,15 +451,12 @@ class ALE(ALEBase):
         secants = utils.compute_local_effects(self.data, self.model, limits, feature)
         return {"frame": frame, "effects": secants, "limits": limits}
 
-    def _summarize(
+    def _summarize_cont(
         self, feature: int, mask=None, binning_method="fixed", order=None
     ) -> typing.Dict:
         """Summary kernel (pure numpy): re-bin the cached secants over the
         subregion `mask` (None = all) on the frozen frame bins → bin
         effects/variances."""
-        if self._is_cat(feature):
-            # ALE keeps one bin per transition (binning_method=None)
-            return self._summarize_cat(feature, mask, None)
         prim = self._local[feature]
         secants, limits = prim["effects"], prim["limits"]
         col = self.data[:, feature]
@@ -468,6 +466,13 @@ class ALE(ALEBase):
         dale_params = utils.compute_ale_params(col, secants, limits)
         dale_params["alg_params"] = "fixed"
         return dale_params
+
+    def _summarize_cat(
+        self, feature: int, mask=None, binning_method="fixed", order=None
+    ) -> typing.Dict:
+        # one bin per transition, hard-coded `None` — the config's "fixed"
+        # binning is a continuous-axis knob and must not group levels
+        return self._summarize_levels(feature, mask, None)
 
     def fit(
         self,
@@ -650,15 +655,15 @@ class RHALE(ALEBase):
             return self._cat_frame(feature)
         return ()
 
-    def _compute_local(self, feature: int, frame: tuple) -> dict:
-        if self._is_cat(feature):
-            # ordinal kernel: adjacent-level differences are the discrete
-            # derivative; the jacobian (if any) is ignored for this feature
-            return self._compute_local_cat(feature, frame)
+    def _compute_local_cont(self, feature: int, frame: tuple) -> dict:
+        """Cache-(a) kernel: the pointwise derivative — a column view of the
+        shared jacobian table, filled once per object. (The categorical kernel
+        is the inherited adjacent-level differences; the jacobian is ignored
+        for those features.)"""
         self._fill_jacobian()
         return {"frame": frame, "effects": self.data_effect[:, feature]}
 
-    def _summarize(
+    def _summarize_cont(
         self,
         feature: int,
         mask=None,
@@ -676,31 +681,28 @@ class RHALE(ALEBase):
         `"global"` keeps the frozen global frame (one frame for the split
         search and every node), `"effective"` packs the bins into the masked
         column's own `[min, max]` (finer subregion resolution)."""
-        if self._is_cat(feature):
-            # ordinal: merge adjacent transitions with the chosen binning
-            # (code-space bins — binning_scope does not apply)
-            return self._summarize_cat(feature, mask, binning_method)
         eff = self._local[feature]["effects"]
         col = self.data[:, feature]
         if mask is not None:
             eff = eff[mask]
             col = col[mask]
-
-        binning = (
-            ap.return_default(binning_method)
-            if isinstance(binning_method, str)
-            else binning_method
+        return self._bin_local_effects(
+            feature, col, eff, mask, binning_method, binning_scope
         )
-        if mask is not None and binning_scope == "effective":
-            limits_range = np.asarray(self._effective_limits(feature, mask))
-        else:
-            limits_range = self.axis_limits[:, feature]
-        limits = binning.find_limits(col, eff, limits_range)
-        utils.raise_if_no_binning(limits, feature, binning)
 
-        dale_params = utils.compute_ale_params(col, eff, limits)
-        dale_params["alg_params"] = binning
-        return dale_params
+    def _summarize_cat(
+        self,
+        feature: int,
+        mask=None,
+        binning_method: Union[
+            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
+        ] = "dp",
+        order=None,
+        binning_scope: str = "global",
+    ) -> typing.Dict:
+        # ordinal: merge adjacent transitions with the chosen binning
+        # (code-space bins — binning_scope does not apply)
+        return self._summarize_levels(feature, mask, binning_method)
 
     def fit(
         self,

--- a/effector/global_effect_pdp.py
+++ b/effector/global_effect_pdp.py
@@ -41,10 +41,10 @@ class PDPBase(GlobalEffectBase):
 
     def _predict(self, data, xx, feature, use_vectorized=True):
         method = ice_vectorized if use_vectorized else ice_non_vectorized
-        if self.method_name == "pdp":
-            y = method(self.model, None, data, xx, feature, False)
-        else:
+        if self.IS_DERIVATIVE:
             y = method(self.model, self.model_jac, data, xx, feature, True)
+        else:
+            y = method(self.model, None, data, xx, feature, False)
         return y
 
     def _use_vectorized(self, feature: int) -> bool:
@@ -67,13 +67,17 @@ class PDPBase(GlobalEffectBase):
     # ------------------------------------------------------------------
     # cache (a): the growing position store
     # ------------------------------------------------------------------
-    def _compute_local(self, feature: int, frame: tuple) -> dict:
+    def _compute_local_cont(self, feature: int, frame: tuple) -> dict:
         """Cache-(a) kernel: the (d-)ICE table on the canonical grid — one row
         per position, one column per instance `(T, N)`. The store then grows
-        as `eval` asks for never-before-seen positions (missing-only)."""
+        as `eval` asks for never-before-seen positions (missing-only).
+        Type-agnostic (the canonical grid is the levels for a discrete axis),
+        hence the class-level cat alias below."""
         grid = self._canonical_grid(feature)
         ice = self._predict(self.data, grid, feature, self._use_vectorized(feature))
         return {"frame": frame, "pos": grid, "ice": ice}
+
+    _compute_local_cat = _compute_local_cont
 
     def _ensure_positions(self, feature: int, xs: np.ndarray) -> dict:
         """Grow the position store to cover `xs`: compute ICE columns for the
@@ -105,50 +109,71 @@ class PDPBase(GlobalEffectBase):
     # ------------------------------------------------------------------
     # the pure kernels
     # ------------------------------------------------------------------
-    def _summarize(self, feature: int, mask=None, use_vectorized: bool = True) -> dict:
+    def _grid_ice(self, feature: int, mask):
+        """The shared summary prelude: the canonical-grid rows of the cached
+        (d-)ICE table, columns restricted to the subregion `mask` (None = all)."""
+        grid, ice = self._grid_rows(feature, self._local[feature])
+        if mask is not None:
+            ice = ice[:, mask]
+        return grid, ice
+
+    def _summarize_cont(
+        self, feature: int, mask=None, use_vectorized: bool = True
+    ) -> dict:
         """Summary kernel (pure numpy): from the canonical-grid rows of the
         cached (d-)ICE table restricted to the subregion `mask` (None = all),
         the mean curve and the heterogeneity curve — cross-instance variance of
         the per-instance-centered ICE curves (PDP) or of the raw d-ICE curves
         (DerPDP)."""
-        grid, ice = self._grid_rows(feature, self._local[feature])
-        if mask is not None:
-            ice = ice[:, mask]
-
-        is_cat = self._is_cat(feature)
-        if self.method_name == "pdp":
-            # each ICE curve is centered on its own (frequency-weighted for a
-            # discrete axis) mean — a per-instance shift, so mask-invariant
-            if is_cat:
-                _, weights = self._level_weights(feature)
-                per_instance_norm = np.average(ice, axis=0, weights=weights)
-            else:
-                per_instance_norm = np.mean(ice, axis=0)
-            heter = np.var(ice - per_instance_norm[np.newaxis, :], axis=1)
-        else:
+        grid, ice = self._grid_ice(feature, mask)
+        if self.IS_DERIVATIVE:
             heter = np.var(ice, axis=1)
-        out = {"grid": grid, "heter": heter, "mean": np.mean(ice, axis=1)}
-        if is_cat:
-            out["is_cat"] = True
-            out["levels"] = grid
-        return out
+        else:
+            # each ICE curve is centered on its own mean — a per-instance
+            # shift, so mask-invariant
+            per_instance_norm = np.mean(ice, axis=0)
+            heter = np.var(ice - per_instance_norm[np.newaxis, :], axis=1)
+        return {"grid": grid, "heter": heter, "mean": np.mean(ice, axis=1)}
 
-    def _eval_payload(
+    def _summarize_cat(
+        self, feature: int, mask=None, use_vectorized: bool = True
+    ) -> dict:
+        """The categorical summary: the grid is the observed levels; ICE
+        centering weights each level by its *global* frequency — deliberately
+        unmasked, the per-instance shift is mask-invariant."""
+        grid, ice = self._grid_ice(feature, mask)
+        if self.IS_DERIVATIVE:
+            heter = np.var(ice, axis=1)
+        else:
+            _, weights = self._level_weights(feature)
+            per_instance_norm = np.average(ice, axis=0, weights=weights)
+            heter = np.var(ice - per_instance_norm[np.newaxis, :], axis=1)
+        return {
+            "grid": grid,
+            "heter": heter,
+            "mean": np.mean(ice, axis=1),
+            "levels": grid,
+        }
+
+    def _eval_payload_cont(
         self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
     ):
         """Reader kernel: mean/heterogeneity off the canonical grid — exact at
-        grid positions (levels are always on it), linear interpolation between
-        them."""
-        if params.get("is_cat"):
-            codes = utils.codes_from_levels(
-                x, params["levels"], feature, self.feature_names[feature]
-            )
-            y = params["mean"][codes]
-            return (y, params["heter"][codes]) if heterogeneity else y
+        grid positions, linear interpolation between them."""
         y = np.interp(x, params["grid"], params["mean"])
         return (
             (y, np.interp(x, params["grid"], params["heter"])) if heterogeneity else y
         )
+
+    def _eval_payload_cat(
+        self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
+    ):
+        # levels are always on the canonical grid — exact lookup, no interp
+        codes = utils.codes_from_levels(
+            x, params["levels"], feature, self.feature_names[feature]
+        )
+        y = params["mean"][codes]
+        return (y, params["heter"][codes]) if heterogeneity else y
 
     def _eval_mean(
         self, feature: int, x: np.ndarray, params: dict, mask: Optional[np.ndarray]
@@ -158,7 +183,8 @@ class PDPBase(GlobalEffectBase):
         when every position is present, else recompute ICE on `data[mask]`
         transiently — the one documented model-touching exception (R14)."""
         if self._is_cat(feature):
-            return self._eval_payload(feature, params, x)  # levels validated inside
+            # the base default (read the payload) is exact at levels
+            return super()._eval_mean(feature, x, params, mask)
         x = np.asarray(x, dtype=float)
         if mask is None:
             entry = self._ensure_positions(feature, x)
@@ -174,30 +200,35 @@ class PDPBase(GlobalEffectBase):
         )
         return np.mean(y_ice, axis=1)
 
-    def _compute_norm_const(
+    def _compute_norm_const_cat(
         self,
         feature: int,
         method: str,
         params: dict,
         mask: Optional[np.ndarray] = None,
     ):
-        """(d-)PDP overrides the base: its centering constant is *per-instance*
-        — each ICE curve is centered on its own — so an array is returned
-        instead of a scalar, derived from the canonical-grid columns (masked
-        columns for a masked call), zero model calls (R14)."""
-        assert method in ["zero_integral", "zero_start"]
-        grid, ice = self._grid_rows(feature, self._local[feature])
-        if mask is not None:
-            ice = ice[:, mask]
-        if self._is_cat(feature):
-            # weights of the levels *within* the mask, aligned to the grid
-            # (= the globally observed levels); absent levels weigh zero
-            levels, weights = self._level_weights(feature, mask)
-            if method == "zero_integral":
-                w = np.zeros(len(grid))
-                w[np.searchsorted(grid, levels)] = weights
-                return np.average(ice, axis=0, weights=w)
-            return ice[np.searchsorted(grid, levels[0])]
+        """(d-)PDP overrides the base variants: its centering constant is
+        *per-instance* — each ICE curve is centered on its own — so an array
+        is returned instead of a scalar, derived from the canonical-grid
+        columns (masked columns for a masked call), zero model calls (R14)."""
+        grid, ice = self._grid_ice(feature, mask)
+        # weights of the levels *within* the mask, aligned to the grid
+        # (= the globally observed levels); absent levels weigh zero
+        levels, weights = self._level_weights(feature, mask)
+        if method == "zero_integral":
+            w = np.zeros(len(grid))
+            w[np.searchsorted(grid, levels)] = weights
+            return np.average(ice, axis=0, weights=w)
+        return ice[np.searchsorted(grid, levels[0])]
+
+    def _compute_norm_const_cont(
+        self,
+        feature: int,
+        method: str,
+        params: dict,
+        mask: Optional[np.ndarray] = None,
+    ):
+        grid, ice = self._grid_ice(feature, mask)
         lo, hi = self._effective_limits(feature, mask)
         if method == "zero_integral":
             xs = np.linspace(lo, hi, helpers.NOF_INTERNAL_POINTS)

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -220,11 +220,12 @@ class ShapDP(GlobalEffectBase):
             random_state=random_state,
         )
 
-    def _compute_local(self, feature: int, frame: tuple) -> dict:
+    def _compute_local_cont(self, feature: int, frame: tuple) -> dict:
         """Cache-(a) kernel: the SHAP values are the local effect — computed
         once per object by the backend (or injected via `shap_values=`),
-        feature-independent. Fill the whole `(N,D)` table on first use; each
-        feature's entry is a column view of it (no frame — instance-anchored)."""
+        feature-independent (hence the class-level cat alias below). Fill the
+        whole `(N,D)` table on first use; each feature's entry is a column
+        view of it (no frame — instance-anchored)."""
         if self.shap_values is None:
             self.shap_values = _compute_shap_values(
                 self.model,
@@ -237,13 +238,24 @@ class ShapDP(GlobalEffectBase):
             )
         return {"frame": frame, "phi": self.shap_values[:, feature]}
 
+    _compute_local_cat = _compute_local_cont
+
     def _importance(self, feature, mask):
         """R13 for SHAP: the canonical `mean(|phi_s|)` over the (masked)
         instances — `phi_s` is already the cached local effect."""
         phi = self._local[feature]["phi"][mask]
         return float(np.mean(np.abs(phi)))
 
-    def _summarize(
+    def _masked_phi(self, feature: int, mask):
+        """(positions, φ) of the SHAP cloud restricted to `mask` (None = all)."""
+        yy = self._local[feature]["phi"]
+        xx = self.data[:, feature]
+        if mask is not None:
+            yy = yy[mask]
+            xx = xx[mask]
+        return xx, yy
+
+    def _summarize_cont(
         self,
         feature: int,
         mask=None,
@@ -252,54 +264,20 @@ class ShapDP(GlobalEffectBase):
         ] = "dp",
         binning_scope: str = "global",
     ) -> typing.Dict:
-        """Step 3 (pure numpy): bin/aggregate the cached SHAP column over the
-        subregion `mask` (None = all) — a spline of per-bin mean/variance for
-        continuous features, per-level mean/variance for discrete ones.
+        """Summary kernel (pure numpy): bin the cached SHAP column over the
+        subregion `mask` (None = all) — per-bin mean/variance of φ, read back
+        by piecewise-linear interpolation between the bin centers.
 
         `binning_scope` (masked only): `"global"` bins over the frozen global
         frame, `"effective"` packs the bins into the masked column's own
         `[min, max]` (see `fit`)."""
-        yy = self._local[feature]["phi"]
-        xx = self.data[:, feature]
-        if mask is not None:
-            yy = yy[mask]
-            xx = xx[mask]
-
-        if self._is_cat(feature):
-            # per-level mean/variance of the shap values with a step lookup —
-            # no spline, no order enters the math (method_semantics.md)
-            levels = np.unique(xx)
-            codes = utils.codes_from_levels(
-                xx, levels, feature, self.feature_names[feature]
-            )
-            limits = np.arange(len(levels) + 1, dtype=float) - 0.5
-            feature_effect_dict = utils.compute_ale_params(
-                codes.astype(float), yy, limits
-            )
-            return {
-                "bin_effect": feature_effect_dict["bin_effect"],
-                "bin_variance": feature_effect_dict["bin_variance"],
-                "levels": levels,
-                "is_cat": True,
-                "xx": xx,
-                "yy": yy,
-            }
-
-        binning = (
-            ap.return_default(binning_method)
-            if isinstance(binning_method, str)
-            else binning_method
+        xx, yy = self._masked_phi(feature, mask)
+        feature_effect_dict = self._bin_local_effects(
+            feature, xx, yy, mask, binning_method, binning_scope
         )
-        if mask is not None and binning_scope == "effective":
-            limits_range = np.asarray(self._effective_limits(feature, mask))
-        else:
-            limits_range = self.axis_limits[:, feature]
-        limits = binning.find_limits(xx, yy, limits_range)
-        utils.raise_if_no_binning(limits, feature, binning)
-        feature_effect_dict = utils.compute_ale_params(xx, yy, limits)
-        feature_effect_dict["alg_params"] = binning
 
         # Compute bin edges and bin centers, then piecewise-linear interpolation
+        limits = feature_effect_dict["limits"]
         bin_centers = (limits[:-1] + limits[1:]) / 2
         if len(bin_centers) == 1:
             # a single bin (e.g. an unstructured φ that the adaptive binning
@@ -333,23 +311,52 @@ class ShapDP(GlobalEffectBase):
             "yy": yy,
         }
 
-    def _eval_payload(
+    def _summarize_cat(
+        self,
+        feature: int,
+        mask=None,
+        binning_method: Union[
+            str, ap.DynamicProgramming, ap.Agglomerative, ap.Quantile, ap.Fixed
+        ] = "dp",
+        binning_scope: str = "global",
+    ) -> typing.Dict:
+        # per-level mean/variance of the shap values with a step lookup —
+        # no interpolation, no order enters the math (method_semantics.md)
+        xx, yy = self._masked_phi(feature, mask)
+        levels = np.unique(xx)
+        codes = utils.codes_from_levels(
+            xx, levels, feature, self.feature_names[feature]
+        )
+        limits = np.arange(len(levels) + 1, dtype=float) - 0.5
+        feature_effect_dict = utils.compute_ale_params(codes.astype(float), yy, limits)
+        return {
+            "bin_effect": feature_effect_dict["bin_effect"],
+            "bin_variance": feature_effect_dict["bin_variance"],
+            "levels": levels,
+            "xx": xx,
+            "yy": yy,
+        }
+
+    def _eval_payload_cont(
         self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
     ):
-        if params.get("is_cat"):
-            codes = utils.codes_from_levels(
-                x, params["levels"], feature, self.feature_names[feature]
-            )
-            y = params["bin_effect"][codes]
-            if heterogeneity:
-                return y, params["bin_variance"][codes]
-            return y
         y = params["spline_mean"](x)
         if heterogeneity:
             # variance is non-negative by definition; linear extrapolation of the
             # per-bin variance beyond the outer bin centers (fill_value=
             # "extrapolate") can dip below 0, so clamp it.
             return y, np.maximum(params["spline_var"](x), 0.0)
+        return y
+
+    def _eval_payload_cat(
+        self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
+    ):
+        codes = utils.codes_from_levels(
+            x, params["levels"], feature, self.feature_names[feature]
+        )
+        y = params["bin_effect"][codes]
+        if heterogeneity:
+            return y, params["bin_variance"][codes]
         return y
 
     def fit(

--- a/effector/global_effect_shap.py
+++ b/effector/global_effect_shap.py
@@ -18,8 +18,6 @@ try:
 except ImportError:
     shapiq = None
 
-from scipy.interpolate import interp1d
-
 import effector.axis_partitioning as ap
 import effector.utils as utils
 
@@ -132,7 +130,7 @@ class ShapDP(GlobalEffectBase):
 
             where $w_{S, j}$ assures that the contribution of feature $j$ is the same for all coalitions of the same size. For example, there are $D-1$ ways for $x_j$ to enter a coalition of $|S| = 1$ feature, so $w_{S, j} = {1 \over D (D-1)}$ for each of them. In contrast, there is only one way for $x_j$ to enter a coaltion of $|S|=0$ (to be the first specified feature), so $w_{S, j} = {1 \over D}$.
 
-            The SHAP Dependence Plot (SHAP-DP) is a spline $\hat{f}^{SDP}_j(x_j)$ fit to the dataset $\{(x_j^i, \hat{\phi}_j(x_j^i))\}_{i=1}^N$ using the `UnivariateSpline` function from `scipy.interpolate`.
+            The SHAP Dependence Plot (SHAP-DP) is a curve $\hat{f}^{SDP}_j(x_j)$ fit to the dataset $\{(x_j^i, \hat{\phi}_j(x_j^i))\}_{i=1}^N$: the axis is split into bins, and the curve is the piecewise-linear interpolation of the per-bin SHAP means (linear extrapolation beyond the outer bin centers).
 
         ??? note "Notes"
 
@@ -272,44 +270,9 @@ class ShapDP(GlobalEffectBase):
         frame, `"effective"` packs the bins into the masked column's own
         `[min, max]` (see `fit`)."""
         xx, yy = self._masked_phi(feature, mask)
-        feature_effect_dict = self._bin_local_effects(
+        return self._bin_local_effects(
             feature, xx, yy, mask, binning_method, binning_scope
         )
-
-        # Compute bin edges and bin centers, then piecewise-linear interpolation
-        limits = feature_effect_dict["limits"]
-        bin_centers = (limits[:-1] + limits[1:]) / 2
-        if len(bin_centers) == 1:
-            # a single bin (e.g. an unstructured φ that the adaptive binning
-            # rightly refuses to split): interp1d on one knot divides by a
-            # zero span and returns nan everywhere — use the constant instead
-            mean_val = float(feature_effect_dict["bin_effect"][0])
-            var_val = float(feature_effect_dict["bin_variance"][0])
-
-            def mean_spline(x, _v=mean_val):
-                return np.full(np.shape(x), _v)
-
-            def var_spline(x, _v=var_val):
-                return np.full(np.shape(x), _v)
-        else:
-            mean_spline = interp1d(
-                bin_centers,
-                feature_effect_dict["bin_effect"],
-                kind="linear",
-                fill_value="extrapolate",
-            )
-            var_spline = interp1d(
-                bin_centers,
-                feature_effect_dict["bin_variance"],
-                kind="linear",
-                fill_value="extrapolate",
-            )
-        return {
-            "spline_mean": mean_spline,
-            "spline_var": var_spline,
-            "xx": xx,
-            "yy": yy,
-        }
 
     def _summarize_cat(
         self,
@@ -333,19 +296,22 @@ class ShapDP(GlobalEffectBase):
             "bin_effect": feature_effect_dict["bin_effect"],
             "bin_variance": feature_effect_dict["bin_variance"],
             "levels": levels,
-            "xx": xx,
-            "yy": yy,
         }
 
     def _eval_payload_cont(
         self, feature: int, params: dict, x: np.ndarray, heterogeneity: bool = False
     ):
-        y = params["spline_mean"](x)
+        # piecewise-linear between the bin centers, linear extrapolation
+        # beyond the outer ones (a single bin reads as a constant)
+        centers = (params["limits"][:-1] + params["limits"][1:]) / 2
+        y = utils.interp_linear_extrap(x, centers, params["bin_effect"])
         if heterogeneity:
-            # variance is non-negative by definition; linear extrapolation of the
-            # per-bin variance beyond the outer bin centers (fill_value=
-            # "extrapolate") can dip below 0, so clamp it.
-            return y, np.maximum(params["spline_var"](x), 0.0)
+            # variance is non-negative by definition; the linear extrapolation
+            # beyond the outer bin centers can dip below 0, so clamp it
+            var = np.maximum(
+                utils.interp_linear_extrap(x, centers, params["bin_variance"]), 0.0
+            )
+            return y, var
         return y
 
     def _eval_payload_cat(
@@ -372,11 +338,14 @@ class ShapDP(GlobalEffectBase):
         r"""Fit the SHAP Dependence Plot to the data.
 
         Notes:
-            The SHAP Dependence Plot (SDP) $\hat{f}^{SDP}_j(x_j)$ is a spline fit to
-            the dataset $\{(x_j^i, \hat{\phi}_j(x_j^i))\}_{i=1}^N$
-            using the `UnivariateSpline` function from `scipy.interpolate`.
+            The SHAP Dependence Plot (SDP) $\hat{f}^{SDP}_j(x_j)$ is fit to the
+            dataset $\{(x_j^i, \hat{\phi}_j(x_j^i))\}_{i=1}^N$: the axis is
+            split with `binning_method`, and the curve is the piecewise-linear
+            interpolation of the per-bin SHAP means, with linear extrapolation
+            beyond the outer bin centers.
 
-            The SHAP standard deviation, $\hat{\sigma}^{SDP}_j(x_j)$, is a spline fit            to the absolute value of the residuals, i.e., to the dataset $\{(x_j^i, |\hat{\phi}_j(x_j^i) - \hat{f}^{SDP}_j(x_j^i)|)\}_{i=1}^N$, using the `UnivariateSpline` function from `scipy.interpolate`.
+            The SHAP heterogeneity $\hat{\sigma}^{2,SDP}_j(x_j)$ is the same
+            interpolation of the per-bin SHAP *variances* (clamped at zero).
 
         Args:
             features: the features to fit.
@@ -455,7 +424,7 @@ class ShapDP(GlobalEffectBase):
             only_shap_values: whether to plot only the shap values
             show_plot: whether to show the plot
             mask: optional boolean `(N,)` selecting a subregion — plot the
-                SHAP-DP *within* it (the masked φ re-binned/re-splined from the
+                SHAP-DP *within* it (the masked φ re-binned from the
                 cached attributions, no model calls), with the x-axis windowed
                 to the subregion's own interval
             rule: sugar over `mask` — an `effector.Rule` or a rule string,
@@ -492,11 +461,14 @@ class ShapDP(GlobalEffectBase):
             y_levels = self._eval_payload(feature, params, levels) - norm
             title = "SHAP Dependence Plot (SHAP-DP)"
             if heterogeneity == "shap_values":
-                yy = params["yy"] - norm
+                # the scatter cloud comes from cache (a) — the same (masked)
+                # φ the payload was summarized from, by construction
+                xx, phi = self._masked_phi(feature, mask)
+                yy = phi - norm
                 return vis.plot_shap_categorical(
                     levels,
                     y_levels,
-                    params["xx"],
+                    xx,
                     yy,
                     feature,
                     title=title,
@@ -534,20 +506,22 @@ class ShapDP(GlobalEffectBase):
             )
 
         # continuous: the x-axis spans the (effective) interval; the cloud is
-        # the (masked) φ, already filtered by _summarize — model-free
+        # the (masked) φ from cache (a) — the same instances the payload was
+        # summarized from, model-free
         lo, hi = self._effective_limits(feature, mask)
         x = np.linspace(lo, hi, nof_points)
         y = self._eval_payload(feature, params, x) - norm
         y_std = (
-            np.sqrt(np.maximum(params["spline_var"](x), 0.0))
+            np.sqrt(self._eval_payload(feature, params, x, heterogeneity=True)[1])
             if heterogeneity == "std"
             else None
         )
+        col, phi = self._masked_phi(feature, mask)
         _, ind = helpers.prep_nof_instances(
-            nof_shap_values, len(params["yy"]), self.random_state
+            nof_shap_values, len(phi), self.random_state
         )
-        yy = params["yy"][ind] - norm if heterogeneity == "shap_values" else None
-        xx = params["xx"][ind] if heterogeneity == "shap_values" else None
+        yy = phi[ind] - norm if heterogeneity == "shap_values" else None
+        xx = col[ind] if heterogeneity == "shap_values" else None
 
         ret = vis.plot_shap(
             x,

--- a/effector/utils.py
+++ b/effector/utils.py
@@ -611,6 +611,46 @@ def compute_jacobian_numerically(
     return jacobian
 
 
+def interp_linear_extrap(
+    x: np.ndarray, xp: np.ndarray, fp: np.ndarray
+) -> np.ndarray:
+    """Piecewise-linear interpolation with linear extrapolation.
+
+    Inside `[xp[0], xp[-1]]` this is `np.interp`; outside, the first/last
+    segment's slope is extended — parity with
+    `scipy.interpolate.interp1d(kind="linear", fill_value="extrapolate")`.
+    A single knot yields a constant. `xp` must be strictly increasing; the
+    call sites (bin centers of `find_limits` limits that survived
+    `raise_if_no_binning`) guarantee it.
+
+    Examples:
+        >>> xp, fp = np.array([0.5, 1.5]), np.array([1.0, 3.0])
+        >>> interp_linear_extrap(np.array([0.0, 0.5, 1.0, 2.0]), xp, fp)
+        array([0., 1., 2., 4.])
+        >>> interp_linear_extrap(np.array([0.0, 5.0]), np.array([1.0]), np.array([2.0]))
+        array([2., 2.])
+
+    Args:
+        x: positions to evaluate at, (T)
+        xp: knot positions, strictly increasing, (K)
+        fp: knot values, (K)
+
+    Returns:
+        the interpolated/extrapolated values at `x`, (T)
+    """
+    x = np.asarray(x, dtype=float)
+    xp = np.asarray(xp, dtype=float)
+    fp = np.asarray(fp, dtype=float)
+    if len(xp) == 1:
+        return np.full(x.shape, fp[0])
+    y = np.interp(x, xp, fp)
+    slope_lo = (fp[1] - fp[0]) / (xp[1] - xp[0])
+    slope_hi = (fp[-1] - fp[-2]) / (xp[-1] - xp[-2])
+    y = np.where(x < xp[0], fp[0] + slope_lo * (x - xp[0]), y)
+    y = np.where(x > xp[-1], fp[-1] + slope_hi * (x - xp[-1]), y)
+    return y
+
+
 def mean_1d_linspace(
     func: typing.Callable, start: float, stop: float, nof_points: int = 100
 ) -> float:

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -308,7 +308,7 @@ def plot_shap(
     only_shap_values: bool = False,
     show_plot: bool = True,
 ):
-    """Draw the SHAP-DP spline `x`/`y` plus the requested heterogeneity: a std
+    """Draw the SHAP-DP curve `x`/`y` plus the requested heterogeneity: a std
     band (`y_std`) or the shap-value cloud `xx`/`yy`."""
     fig, ax = plt.subplots()
     t = theme.active()

--- a/tests/test_contract_masked.py
+++ b/tests/test_contract_masked.py
@@ -307,14 +307,11 @@ def test_m5_binning_scope_controls_masked_bins(name, global_data):
     p_glob = m_glob._summary(0, mask)
 
     def limits_of(p):
-        if "limits" in p:
-            return np.asarray(p["limits"], dtype=float)
-        # ShapDP keeps the spline, not the limits: read the spline knots' span
-        return np.asarray(p["spline_mean"].x, dtype=float)
+        return np.asarray(p["limits"], dtype=float)
 
     # the mask (x0 < 0.3) shares the global LEFT edge, so the scopes separate
     # on the right: effective bins stop at the masked max, global bins keep
-    # covering the full axis (ShapDP knots are bin centers — compare vs hi)
+    # covering the full axis
     eff = limits_of(p_eff)
     glob = limits_of(p_glob)
     assert eff[0] >= lo - 1e-12 and eff[-1] <= hi + 1e-12

--- a/tests/toy_method.py
+++ b/tests/toy_method.py
@@ -9,9 +9,11 @@ Scientific value: none. Pedagogical value: the whole two-block lifecycle
 1. answer the frame question: which config params invalidate the local
    effects? (here: none — predictions are instance-anchored; `nof_bins` is a
    summary-stage knob, like RHALE's binning)
-2. implement the three pure kernels: `_compute_local` (the only one that may
-   touch the model), `_summarize` (numpy in, payload out), `_eval_payload`
-   (payload + xs in, numbers out)
+2. implement the three pure kernels: `_compute_local_cont` (the only one that
+   may touch the model), `_summarize_cont` (numpy in, payload out),
+   `_eval_payload_cont` (payload + xs in, numbers out) — continuous-only here,
+   so the `_cat` variants are skipped (the base's capability matrix makes
+   them unreachable)
 3. write ZERO cache/retrigger/mask logic — the base owns all of it: masking,
    memoization, centering, heter_score, importance, find_regions and the
    Partition sugar all work on this class for free.
@@ -38,7 +40,7 @@ class ToyEffect(GlobalEffectBase):
         return ()  # instance-anchored: the cached predictions never go stale
 
     # -- 2. the model-touching kernel (the ONLY one) ------------------------
-    def _compute_local(self, feature, frame):
+    def _compute_local_cont(self, feature, frame):
         # feature-independent raw material is computed once per OBJECT and
         # shared across features (the RHALE-jacobian / ShapDP-table pattern);
         # here it coincides with the base's `_y_pred` slot
@@ -47,7 +49,7 @@ class ToyEffect(GlobalEffectBase):
         return {"frame": frame, "pred": self._y_pred}
 
     # -- 3. the pure summary kernel -----------------------------------------
-    def _summarize(self, feature, mask=None, nof_bins=10):
+    def _summarize_cont(self, feature, mask=None, nof_bins=10):
         pred = self._local[feature]["pred"]
         col = self.data[:, feature]
         if mask is not None:
@@ -69,7 +71,7 @@ class ToyEffect(GlobalEffectBase):
         }
 
     # -- 4. the pure reader kernel ------------------------------------------
-    def _eval_payload(self, feature, params, x, heterogeneity=False):
+    def _eval_payload_cont(self, feature, params, x, heterogeneity=False):
         idx = np.clip(np.digitize(x, params["limits"]) - 1, 0, len(params["mean"]) - 1)
         y = params["mean"][idx]
         return (y, params["var"][idx]) if heterogeneity else y


### PR DESCRIPTION
Executes the parked KERNEL_DISPATCH_PLAN.md (approved 2026-07-08). Behavior-preserving refactor of the global-effects core:

**Two-way kernel dispatch.** The gate-facing kernel names (`_compute_local`, `_summarize`, `_eval_payload`, `_compute_norm_const`) are now concrete dispatchers in `GlobalEffectBase` that fork on `_is_cat(feature)` exactly once; every method implements `_cont`/`_cat` variants. Type-agnostic kernels use a class-level alias (PDP, ShapDP `_compute_local`); the `_cat` base defaults raise and are unreachable for continuous-only methods (DerPDP, ToyEffect). The `"is_cat"` payload key is deleted.

**Pure-numpy ShapDP payloads.** ShapDP's summaries no longer store scipy `interp1d` callables or the raw `xx`/`yy` cloud — the payload is the same binned dict as RHALE's (`limits`/`bin_effect`/`bin_variance`), read back via the new `utils.interp_linear_extrap` (interp1d linear-extrapolate parity to ~1e-16, verified on grids beyond the outer bin centers, at knots, and single-bin). The plot's scatter cloud derives from cache (a). Cache (b) is now pure numpy unconditionally, per docs/design.md.

Also: shared `_bin_local_effects` helper deduplicates the RHALE/ShapDP binning tail; `_predict` dispatches on `IS_DERIVATIVE` instead of the method name string.

**Verification:** full suite 811 passed at every commit, identical to baseline; `test_contract_lifecycle.py` (model-call budgets) passes unmodified; `grep '"is_cat"|spline_mean|spline_var'` → zero hits.