### PR TITLE
fix: display surfaces honor the schema's scale_y (triage plane, report, CALM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Display units honor the schema's `scale_y`**: every surface labeled "(target units)" — `effector.plot_triage`, `CALM.plot_triage`, and the report's importance/heterogeneity bars, triage plane, ranked tables, ledger heter columns, and `heter_threshold` chip — now bridges the model-unit scalars by `scale_y["std"]`, so a model trained on a standardized target reads in the target's own scale (matching the curve plots, which already rescaled). Unbound reports render the same as bound ones: `Report` stamps `scale_y`/`scale_x_list`, and the unbound curve fallback applies them. The engine verbs (`importance`, `heter_score`) and all stamped/serialized payloads stay in model-output units, so `find_regions` thresholds and old dicts are unaffected.
+
 # [0.5.0] - 2026-07-14
 
 ### Breaking

--- a/effector/calm.py
+++ b/effector/calm.py
@@ -68,6 +68,7 @@ class CALM:
         importances,
         heter_scores,
         baseline,
+        scale_y=None,
     ):
         self.index = int(index)
         self.r2 = float(r2)
@@ -75,6 +76,9 @@ class CALM:
         self.stage = stage
         self.feature_names = list(feature_names)
         self.target_name = target_name
+        # the schema's y scaling ({"mean", "std"} or None): the stamped
+        # scalars speak model-output units; display surfaces bridge by its std
+        self.scale_y = scale_y
         self._importances = {int(k): float(v) for k, v in importances.items()}
         self._heter_scores = {int(k): float(v) for k, v in heter_scores.items()}
         # global (imp, het) start points of the split features' triage arrows
@@ -128,6 +132,8 @@ class CALM:
             else:
                 imps[f] = float(effect.importance(f))
                 hets[f] = float(effect.heter_score(f))
+        from effector.report import _scale_payload
+
         calm = cls(
             index=index,
             r2=r2,
@@ -138,6 +144,7 @@ class CALM:
             importances=imps,
             heter_scores=hets,
             baseline=base,
+            scale_y=_scale_payload(effect.scale_y),
         )
         calm._effect = effect
         return calm
@@ -240,26 +247,36 @@ class CALM:
         weighted-mean point — the movement the accepted split bought.
 
         Args:
-            threshold: heterogeneity line — a float draws it, `False`
-                (default) nothing.
+            threshold: heterogeneity line — a float draws it (given in
+                `heter_score` units; rescaled with the points when the schema
+                declared a `scale_y`), `False` (default) nothing.
             title: figure title.
             show_plot: if `True`, show and return `None`; else `(fig, ax)`.
         """
         from effector.visualization import triage_scatter
 
+        # stamped scalars speak model-output units; the axes claim the
+        # target's units, so bridge by the schema's y-std (spreads: std only)
+        sy = self.scale_y["std"] if self.scale_y else 1.0
         pts = [
-            (self.feature_names[f], self._importances[f], self._heter_scores[f])
+            (
+                self.feature_names[f],
+                self._importances[f] * sy,
+                self._heter_scores[f] * sy,
+            )
             for f in range(len(self.feature_names))
             if np.isfinite(self._importances[f])
         ]
         arrows = {
             self.feature_names[f]: (
-                self._baseline[f],
-                (self._importances[f], self._heter_scores[f]),
+                tuple(v * sy for v in self._baseline[f]),
+                (self._importances[f] * sy, self._heter_scores[f] * sy),
             )
             for f in self.features
             if f in self._baseline
         }
+        if threshold is not None and threshold is not False:
+            threshold = float(threshold) * sy
         default = (
             "Feature triage" if self.is_gam else f"Feature triage — CALM {self.index}"
         )
@@ -305,6 +322,7 @@ class CALM:
             "importances": {str(f): v for f, v in self._importances.items()},
             "heter_scores": {str(f): v for f, v in self._heter_scores.items()},
             "baseline": {str(f): list(v) for f, v in self._baseline.items()},
+            "scale_y": self.scale_y,
         }
 
     @classmethod
@@ -329,6 +347,7 @@ class CALM:
             importances=d["importances"],
             heter_scores=d["heter_scores"],
             baseline=d["baseline"],
+            scale_y=d.get("scale_y"),
         )
 
 
@@ -398,6 +417,7 @@ class CalmSequence:
         """
         from effector.report import _print_explained_variance
 
+        sy = self.final.scale_y["std"] if self.final.scale_y else 1.0
         _print_explained_variance(
             {
                 "gam_r2": self.gam_r2,
@@ -407,6 +427,7 @@ class CalmSequence:
                 "skipped": self.skipped,
             },
             ascii=ascii,
+            sy=sy,
         )
 
     def __repr__(self):

--- a/effector/report.py
+++ b/effector/report.py
@@ -70,7 +70,7 @@ def _clip(text, width, ell="…"):
     return text if len(text) <= width else text[: width - len(ell)] + ell
 
 
-def _print_explained_variance(ev, *, ascii=False):
+def _print_explained_variance(ev, *, ascii=False, sy=1.0):
     """Print the EXPLAINED VARIANCE and REJECTED SPLITS tables from an
     explained-variance payload (`Report.explained_variance`, or a
     `CalmSequence`'s decision-sequence keys). Shared by `Report.show` and
@@ -79,6 +79,9 @@ def _print_explained_variance(ev, *, ascii=False):
     Args:
         ev: dict with `gam_r2`, `regional_r2`, `min_gain`, `stages`, `skipped`.
         ascii: draw with plain ASCII instead of box-drawing characters.
+        sy: display scale for the heter columns (the schema's y-std) — the
+            stamped values speak model-output units; R² columns are ratios
+            and never scale.
     """
     g = _ASCII_GLYPHS if ascii else _UNICODE_GLYPHS
     dash, arrow, cross, em = g["dash"], g["arrow"], g["cross"], g["em"]
@@ -123,7 +126,7 @@ def _print_explained_variance(ev, *, ascii=False):
     def heter_cell(st):
         if st.get("heter_before") is None:
             return em
-        return f"{hnum(st['heter_before'])} {arrow} {hnum(st['heter_after'])}"
+        return f"{hnum(st['heter_before'] * sy)} {arrow} {hnum(st['heter_after'] * sy)}"
 
     # 13 + on + 8 + 8 + 8 + het = 70. `solo`/`dR2` are 8 wide because a
     # signed percent runs to 7 glyphs ("+100.0%") and needs a space.
@@ -289,6 +292,12 @@ class Report:
     overview: List[dict] = field(default_factory=list)
     explained_variance: Optional[dict] = None
     summary: Optional[dict] = None
+    # the schema's y scaling ({"mean", "std"} or None), stamped so unbound
+    # reports render in the same display units as bound ones
+    scale_y: Optional[dict] = None
+    # per-feature x scaling (list of {"mean", "std"}/None, or None), for the
+    # unbound curve fallback
+    scale_x_list: Optional[list] = None
 
     def __post_init__(self):
         self._effect = None
@@ -308,6 +317,15 @@ class Report:
     def _bind(self, effect):
         self._effect = effect
         return self
+
+    @property
+    def _sy(self):
+        """Display scale for the spread-type scalars (importance/heter_score):
+        the stamped scalars speak model-output units, every labeled surface
+        speaks the target's units, and the schema's y-std is the bridge (std
+        only, no mean shift — they are spreads). 1.0 when no scaling is
+        declared: model units already are display units."""
+        return float(self.scale_y["std"]) if self.scale_y else 1.0
 
     def _require_effect(self):
         if self._effect is None:
@@ -422,7 +440,7 @@ class Report:
         ev = self.explained_variance
         accepted = {st["feature"] for st in ev["stages"]} if ev else None
         if ev and self._ev_headline():
-            _print_explained_variance(ev, ascii=ascii)
+            _print_explained_variance(ev, ascii=ascii, sy=self._sy)
 
         # -- the ranked features -----------------------------------------------
         # 14 + 11 + 2 + 18 + 11 + 14 = 70
@@ -433,11 +451,12 @@ class Report:
         )
         rule()
         imax = max((fr.importance for fr in self.features), default=0.0)
+        sy = self._sy
         for fr in self.features:
             n = int(round(18 * fr.importance / imax)) if imax > 0 else 0
             p(
-                f"{' ' * INDENT}{fr.name:<14.14}{fr.importance:>11.4f}  "
-                f"{bar * n:<18}{fr.heter_score:>11.4f}"
+                f"{' ' * INDENT}{fr.name:<14.14}{fr.importance * sy:>11.4g}  "
+                f"{bar * n:<18}{fr.heter_score * sy:>11.4g}"
                 f"{self._regions_of(fr, accepted):>14d}"
             )
         cov = self.config.get("coverage_achieved")
@@ -508,7 +527,7 @@ class Report:
         rows = self._sorted_overview()
         split = self._split_features()
         fig, ax = plt.subplots(figsize=(7, 0.35 * len(rows) + 1.2))
-        vals = [o["_imp"] for o in rows]
+        vals = [o["_imp"] * self._sy for o in rows]
         ax.barh(range(len(rows)), vals, height=0.55, color=t.BAR_FACE)
         ax.set_yticks(range(len(rows)))
         ax.set_yticklabels([o["name"] for o in rows])
@@ -517,7 +536,7 @@ class Report:
             ax,
             vals,
             [
-                f"{v:.3f}" + ("  · split" if o["feature"] in split else "")
+                f"{v:.4g}" + ("  · split" if o["feature"] in split else "")
                 for v, o in zip(vals, rows)
             ],
             muted=theme.MUTED,
@@ -557,8 +576,9 @@ class Report:
             gridspec_kw={"wspace": 0.06},
         )
         y = range(len(rows))
-        imp = [o["_imp"] for o in rows]
-        het = [float(o["heter_score"]) for o in rows]
+        sy = self._sy
+        imp = [o["_imp"] * sy for o in rows]
+        het = [float(o["heter_score"]) * sy for o in rows]
         ax1.barh(y, imp, height=0.55, color=t.BAR_FACE)
         ax2.barh(y, het, height=0.55, color=t.BAND, alpha=0.75)
         ax1.set_yticks(list(y))
@@ -568,7 +588,7 @@ class Report:
             ax1,
             imp,
             [
-                f"{v:.3f}" + ("  · split" if o["feature"] in split else "")
+                f"{v:.4g}" + ("  · split" if o["feature"] in split else "")
                 for v, o in zip(imp, rows)
             ],
             muted=theme.MUTED,
@@ -578,13 +598,14 @@ class Report:
         self._value_labels(
             ax2,
             het,
-            [f"{v:.3f}" for v in het],
+            [f"{v:.4g}" for v in het],
             muted=theme.MUTED,
             emphasized=theme.INK2,
             emphasis=[False] * len(rows),
         )
         thr = self.config.get("heter_threshold")
         if thr is not None:
+            thr = thr * sy
             ax2.axvline(thr, color=t.REF, linewidth=1.0)
             ax2.text(
                 thr,
@@ -614,8 +635,12 @@ class Report:
         `effector.plot_triage`)."""
         from effector.visualization import triage_scatter
 
+        sy = self._sy
         thr = self.config.get("heter_threshold")
-        pts = [(o["name"], o["importance"], o["heter_score"]) for o in self.overview]
+        pts = [
+            (o["name"], o["importance"] * sy, o["heter_score"] * sy)
+            for o in self.overview
+        ]
         by_feature = {o["feature"]: o for o in self.overview}
         arrows = {}
         ev = self.explained_variance
@@ -626,16 +651,16 @@ class Report:
                 if o is None:
                     continue
                 arrows[o["name"]] = (
-                    (o["importance"], o["heter_score"]),
+                    (o["importance"] * sy, o["heter_score"] * sy),
                     (
-                        float(final["importances"][str(st["feature"])]),
-                        float(final["heter_scores"][str(st["feature"])]),
+                        float(final["importances"][str(st["feature"])]) * sy,
+                        float(final["heter_scores"][str(st["feature"])]) * sy,
                     ),
                 )
         return triage_scatter(
             pts,
             arrows=arrows,
-            threshold=thr if thr is not None else False,
+            threshold=thr * sy if thr is not None else False,
             unit=f" ({self.target_name} units)",
             title="Feature triage" if title is None else title,
             show_plot=False,
@@ -908,6 +933,10 @@ class Report:
         ):
             if key in self.config:
                 val = self.config[key]
+                if key == "heter_threshold" and val is not None:
+                    # display units, so the chip agrees with the threshold
+                    # line the overview figures draw
+                    val = val * self._sy
                 val = f"{val:.4f}" if isinstance(val, float) else str(val)
                 chips.append(f"<span class='chip'>{esc(key)} <b>{esc(val)}</b></span>")
         if chips:
@@ -952,13 +981,14 @@ class Report:
             "<th>heterogeneity</th><th>#regions</th><th>regional analysis</th></tr>"
         )
         reported = {fr.feature: fr for fr in self.features}
+        sy = self._sy
         for rank, o in enumerate(self.overview, 1):
             fr = reported.get(o["feature"])
             if fr is None:
                 imp_v = o.get("calm_importance", o["importance"])
                 out.append(
                     f"<tr class='dim'><td>{rank}</td><td>{esc(o['name'])}</td>"
-                    f"<td>{imp_v:.4f}</td><td>{o['heter_score']:.4f}</td>"
+                    f"<td>{imp_v * sy:.4g}</td><td>{o['heter_score'] * sy:.4g}</td>"
                     f"<td>·</td><td>not plotted (below the coverage cut)</td></tr>"
                 )
                 continue
@@ -974,8 +1004,8 @@ class Report:
                 note = "split found — rejected by the decision sequence"
             out.append(
                 f"<tr data-href='feat-{fr.feature}'><td>{rank}</td>"
-                f"<td>{esc(fr.name)}</td><td>{fr.importance:.4f}</td>"
-                f"<td>{fr.heter_score:.4f}</td><td>{nregions}</td>"
+                f"<td>{esc(fr.name)}</td><td>{fr.importance * sy:.4g}</td>"
+                f"<td>{fr.heter_score * sy:.4g}</td><td>{nregions}</td>"
                 f"<td>{note} →</td></tr>"
             )
         out.append("</table>")
@@ -1300,12 +1330,27 @@ class Report:
 
         t = theme.active()
         fig, ax = plt.subplots(figsize=(7, 4))
+        # stamped curves speak model units; rescale exactly like the live
+        # `effect.plot` (mean effect affine, band by std only, derivative
+        # curves by std only), so bound and unbound pages agree
+        xs, y = np.asarray(fr.xs, dtype=float), np.asarray(fr.y, dtype=float)
         band = np.sqrt(np.clip(fr.h, 0, None))
-        ax.plot(fr.xs, fr.y, color=t.MEAN, label="mean effect")
+        sx = (self.scale_x_list or [None] * len(self.feature_names))[fr.feature]
+        if sx is not None:
+            xs = xs * sx["std"] + sx["mean"]
+        if self.scale_y is not None:
+            is_der = getattr(
+                method_registry.resolve(self.method_name).cls, "IS_DERIVATIVE", False
+            )
+            band = band * self.scale_y["std"]
+            y = y * self.scale_y["std"]
+            if not is_der:
+                y = y + self.scale_y["mean"]
+        ax.plot(xs, y, color=t.MEAN, label="mean effect")
         ax.fill_between(
-            fr.xs,
-            fr.y - band,
-            fr.y + band,
+            xs,
+            y - band,
+            y + band,
             alpha=t.BAND_ALPHA,
             color=t.BAND,
             label="± std",
@@ -1360,6 +1405,8 @@ class Report:
             "features": [fr.to_dict() for fr in self.features],
             "explained_variance": self.explained_variance,
             "summary": self.summary,
+            "scale_y": self.scale_y,
+            "scale_x_list": self.scale_x_list,
         }
 
     @classmethod
@@ -1385,6 +1432,8 @@ class Report:
             overview=[dict(o) for o in d.get("overview", [])],
             explained_variance=d.get("explained_variance"),
             summary=d.get("summary"),
+            scale_y=d.get("scale_y"),
+            scale_x_list=d.get("scale_x_list"),
         )
 
 
@@ -1556,6 +1605,12 @@ def explain(
         finder=finder,
         candidate_conditioning_features=candidate_conditioning_features,
     )
+
+
+def _scale_payload(s):
+    """JSON-safe copy of a `{"mean", "std"}` scaling dict — plain floats, so
+    stamped reports/CALMs serialize even when the schema held numpy scalars."""
+    return None if s is None else {"mean": float(s["mean"]), "std": float(s["std"])}
 
 
 def _model_summary(effect, y=None):
@@ -1752,6 +1807,12 @@ def _explain_effect(
         ],
         explained_variance=ev,
         summary=summary,
+        scale_y=_scale_payload(effect.scale_y),
+        scale_x_list=(
+            [_scale_payload(s) for s in effect.scale_x_list]
+            if effect.scale_x_list
+            else None
+        ),
     )
     report._bind(effect)
     headline = report._ev_headline()

--- a/effector/visualization.py
+++ b/effector/visualization.py
@@ -1203,8 +1203,9 @@ def plot_triage(
         threshold: the heterogeneity threshold line. `None` (default) draws
             the median heterogeneity of the plotted features — the same
             convention `effector.explain` and `find_regions
-            (features="heterogeneous")` use; a float draws that value;
-            `False` draws nothing.
+            (features="heterogeneous")` use; a float draws that value, given
+            in `heter_score` units (it is rescaled together with the points
+            when the schema declares a `scale_y`); `False` draws nothing.
         features: which features to plot — `"all"` or a list of
             indices/names. Feature types the method does not support are
             skipped with one `UserWarning`.
@@ -1239,14 +1240,20 @@ def plot_triage(
     if not plotted:
         raise ValueError("plot_triage: no supported features to plot")
 
-    imp = {f: effect.importance(f) for f in plotted}
-    het = {f: effect.heter_score(f) for f in plotted}
+    # the verbs speak model-output units; the axes claim the target's units,
+    # so both scalars (spread-type quantities: std only, no mean shift) are
+    # bridged by the schema's y-std — the same convention the curve plots use
+    sy = effect.scale_y["std"] if effect.scale_y is not None else 1.0
+    imp = {f: effect.importance(f) * sy for f in plotted}
+    het = {f: effect.heter_score(f) * sy for f in plotted}
 
     if threshold is None:
         threshold = float(np.median([het[f] for f in plotted]))
         thr_label = "heterogeneity threshold (median)"
     else:
         thr_label = "heterogeneity threshold"
+        if threshold is not False:
+            threshold = float(threshold) * sy
 
     arrows = []
     if partitions:
@@ -1260,15 +1267,14 @@ def plot_triage(
                     (
                         start,
                         (
-                            effect.importance(f, rule=leaf.rule),
-                            effect.heter_score(f, rule=leaf.rule),
+                            effect.importance(f, rule=leaf.rule) * sy,
+                            effect.heter_score(f, rule=leaf.rule) * sy,
                         ),
                     )
                 )
 
     fig, ax = plt.subplots()
     points = [(effect.feature_names[f], imp[f], het[f]) for f in plotted]
-    # both axes are std-type quantities in the target's units (units contract)
     unit = f" ({effect.target_name} units)"
     _draw_triage(fig, ax, points, arrows, threshold, thr_label, unit, title)
     return _finalize(fig, ax, show_plot)

--- a/tests/test_calm.py
+++ b/tests/test_calm.py
@@ -185,3 +185,39 @@ def test_select_regions_costs_one_prediction_pass_after_fit():
     with budget(counting, expected=0):
         m.select_regions()
     assert counting.n_calls == fit_calls + 1
+
+
+# ---------------------------------------------------------------------------
+# display units
+# ---------------------------------------------------------------------------
+
+
+def test_calm_triage_scales_by_the_schema_y_std():
+    import matplotlib.pyplot as plt
+
+    data = make_uniform()
+    m = effector.PDP(
+        data,
+        switch_model,
+        nof_instances="all",
+        schema={"scale_y": {"mean": 1.0, "std": 4.0}},
+    )
+    m.fit(features="all")
+    chain = m.select_regions()
+    # the stamped scalars stay in model units (agree with the live verbs) ...
+    assert chain.final.scale_y == {"mean": 1.0, "std": 4.0}
+    d = chain.to_dict()
+    rebuilt = effector.CalmSequence.from_dict(d)
+    assert rebuilt.final.scale_y == {"mean": 1.0, "std": 4.0}
+    # ... old dicts (no scale_y key) default to 1:1
+    for c in d["calms"]:
+        c.pop("scale_y")
+    assert effector.CalmSequence.from_dict(d).final.scale_y is None
+    # ... and the triage plane bridges them by the schema's y-std, unbound too
+    fig, ax = rebuilt.final.plot_triage(show_plot=False)
+    offsets = np.asarray(ax.collections[0].get_offsets())
+    imp, het = chain.final.importances(), chain.final.heter_scores()
+    keep = np.isfinite(imp)
+    expected = 4.0 * np.stack([imp[keep], het[keep]], axis=1)
+    np.testing.assert_allclose(offsets, expected, atol=1e-12)
+    plt.close(fig)

--- a/tests/test_contract_triage.py
+++ b/tests/test_contract_triage.py
@@ -131,3 +131,65 @@ def test_unsupported_features_skipped_with_warning(monkeypatch):
 def test_junk_features_string_raises(pdp):
     with pytest.raises(ValueError, match="'all'"):
         effector.plot_triage(pdp, features="heterogeneous", show_plot=False)
+
+
+# -- display units: the axes claim the target's units, so a schema `scale_y`
+# bridges the model-unit verbs by its std (spreads: no mean shift) -----------
+
+SCALED_SCHEMA = {
+    "feature_names": ["g", "gate", "flag"],
+    "scale_y": {"mean": 5.0, "std": 3.0},
+}
+
+
+@pytest.fixture(scope="module")
+def pdp_scaled():
+    data = make_regional_data(n=300)
+    fx = effector.PDP(data, gated_model, nof_instances="all", schema=SCALED_SCHEMA)
+    fx.fit("all", centering=False)
+    return fx
+
+
+def test_offsets_scale_by_the_schema_y_std(pdp_scaled):
+    fig, ax = effector.plot_triage(pdp_scaled, show_plot=False)
+    offsets = np.asarray(ax.collections[0].get_offsets())
+    expected = 3.0 * np.array(
+        [[pdp_scaled.importance(f), pdp_scaled.heter_score(f)] for f in range(3)]
+    )
+    np.testing.assert_allclose(offsets, expected, atol=1e-12)
+    plt.close(fig)
+
+
+def test_threshold_scales_with_the_points(pdp_scaled):
+    # the median default is the median of the scaled points
+    fig, ax = effector.plot_triage(pdp_scaled, show_plot=False)
+    hs = [pdp_scaled.heter_score(f) * 3.0 for f in range(3)]
+    line = [ln for ln in ax.get_lines() if "threshold" in str(ln.get_label())][0]
+    assert line.get_ydata()[0] == pytest.approx(float(np.median(hs)))
+    plt.close(fig)
+    # a float is given in heter_score units and rescaled alongside the points
+    fig, ax = effector.plot_triage(pdp_scaled, threshold=0.5, show_plot=False)
+    line = [ln for ln in ax.get_lines() if "threshold" in str(ln.get_label())][0]
+    assert line.get_ydata()[0] == pytest.approx(1.5)
+    plt.close(fig)
+
+
+def test_leaf_points_scale_by_the_schema_y_std(pdp_scaled):
+    part = pdp_scaled.find_regions("g")
+    fig, ax = effector.plot_triage(pdp_scaled, partitions={"g": part}, show_plot=False)
+    leaf_offsets = np.concatenate(
+        [np.asarray(c.get_offsets()) for c in ax.collections[1:]]
+    )
+    expected = 3.0 * np.array(
+        [
+            [
+                pdp_scaled.importance("g", rule=leaf.rule),
+                pdp_scaled.heter_score("g", rule=leaf.rule),
+            ]
+            for leaf in part.leaves
+        ]
+    )
+    np.testing.assert_allclose(
+        np.sort(leaf_offsets, axis=0), np.sort(expected, axis=0), atol=1e-12
+    )
+    plt.close(fig)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -387,3 +387,36 @@ def test_explain_across_methods(method):
     assert isinstance(rep, Report)
     assert len(rep.features) == 2
     assert rep.features[0].importance >= rep.features[1].importance
+
+
+def test_report_display_units_scale_by_the_schema_y_std():
+    import matplotlib.pyplot as plt
+
+    data = make_global_data(n=800)
+    sy = {"mean": 5.0, "std": 3.0}
+    rep = effector.explain(
+        data, linear_model, method="pdp", nof_instances="all", schema={"scale_y": sy}
+    )
+    # the schema scaling is stamped, round-trips, and old dicts default to 1:1
+    assert rep.scale_y == sy
+    d = rep.to_dict()
+    assert Report.from_dict(d).scale_y == sy
+    d.pop("scale_y")
+    d.pop("scale_x_list")
+    assert Report.from_dict(d).scale_y is None
+    # the stamped scalars stay in model units; the bars stretch by the std
+    fig, ax = rep.plot_importance(show_plot=False)
+    widths = sorted(float(p.get_width()) for p in ax.patches)
+    expected = sorted(
+        3.0 * float(o.get("calm_importance", o["importance"])) for o in rep.overview
+    )
+    np.testing.assert_allclose(widths, expected, rtol=1e-9)
+    plt.close(fig)
+    # the triage points scale the same way
+    fig, ax = rep._triage_fig()
+    offsets = np.asarray(ax.collections[0].get_offsets())
+    expected = 3.0 * np.array(
+        [[o["importance"], o["heter_score"]] for o in rep.overview]
+    )
+    np.testing.assert_allclose(offsets, expected, rtol=1e-9)
+    plt.close(fig)


### PR DESCRIPTION
## The bug

`effector.plot_triage` labels its axes "(<target> units)" but plotted the raw `importance`/`heter_score` values, which speak **model-output** units. With a model trained on a standardized target (the bike-sharing setup: `scale_y std ~ 181`), the curve plots rescale to real counts through the schema's `scale_y`, while the triage plane showed 0.67/0.53 under a "bike-rentals units" label. The same mismatch existed in the report's importance/heterogeneity bars, triage figure, ranked tables, ledger heter columns, and `heter_threshold` chip, and in `CALM.plot_triage` — the report header (`_model_summary`) already rescaled, so one page actively contradicted itself.

## The fix

Display-layer only: every labeled surface bridges the spread-type scalars by `scale_y["std"]` (std only, no mean shift — the same convention the curve plots use for bands). The engine verbs (`importance`, `heter_score`) and every stamped/serialized payload stay in model-output units, so `find_regions` thresholds, `heter_small_enough` defaults, and existing dicts are untouched.

- `effector.plot_triage`: points, leaf arrows, and the threshold scale together (a float `threshold` is read in `heter_score` units and rescaled alongside — documented).
- `Report`: stamps `scale_y`/`scale_x_list` (JSON-safe floats) so **unbound** reports render identically; applies the bridge in `plot_importance`, the paired overview bars, the triage figure, `show()`'s FEATURES table, the ledger's heter cells, the HTML overview table, and the `heter_threshold` chip. The unbound curve fallback (`_effect_fig`) now applies the same x/y scaling as the live `effect.plot` (derivative curves: std only).
- `CALM`: stamps `scale_y` in `from_effect`, serializes it (optional key — old dicts load as unscaled), and applies it in `plot_triage`; `CalmSequence.show()` passes it to the shared ledger printer.
- Value-label/table formats moved `.3f`/`.4f` -> `.4g` so count-scale numbers stay readable.

Deliberately out of scope: `Partition.show()` tree text keeps model-unit heterogeneity — it is the engine layer (`find_regions` diagnostics, no unit label) and its stamped rules/stats serialize as-is.

## Tests

Merge gate green: 954 passed, 1 skipped. New pins: scaled triage offsets/threshold/leaf arrows equal verbs x std; `Report`/`CALM` round-trip `scale_y` through a real JSON boundary and old dicts (no key) default to 1:1; unbound triage equals bound.